### PR TITLE
Add OSGi headers and source bundle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "org.scala-lang.modules"
 
 name := "scala-xml"
 
-version := "1.0-RC4"
+version := "1.0.0-RC4"
 
 // standard stuff follows:
 scalaVersion := "2.11.0-M5"
@@ -104,6 +104,24 @@ definedTests in Test += (
       def annotationName = "partest"
     }, true, Array())
   )
+
+osgiSettings
+
+val osgiVersion = version(_.replace('-', '.'))
+
+OsgiKeys.bundleSymbolicName := s"${organization.value}.${name.value}"
+
+OsgiKeys.bundleVersion := osgiVersion.value
+
+OsgiKeys.exportPackage := Seq(s"scala.xml.*;version=${version.value}")
+
+// Sources should also have a nice MANIFEST file
+packageOptions in packageSrc := Seq(Package.ManifestAttributes(
+                      ("Bundle-SymbolicName", s"${organization.value}.${name.value}.source"),
+                      ("Bundle-Name", s"${name.value} sources"),
+                      ("Bundle-Version", osgiVersion.value),
+                      ("Eclipse-SourceBundle", s"""${organization.value}.${name.value};version="${osgiVersion.value}";roots:="."""")
+                  ))
 
 
 // TODO: mima

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.6.0")


### PR DESCRIPTION
A few changes needed for proper Eclipse consumption as OSGi:
- create OSGi headers
- make source jars OSGi bundles with the proper headers
- make the version number OSGi-friendly. In particular, 3 digits + qualifier

Fixed #1.
