### PR TITLE
Upgrade to Scala 2.11.0-M6.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,12 +5,12 @@ name := "scala-xml"
 version := "1.0.0-SNAPSHOT"
 
 // standard stuff follows:
-scalaVersion := "2.11.0-M5"
+scalaVersion := "2.11.0-M6"
 
 // NOTE: not necessarily equal to scalaVersion
 // (e.g., during PR validation, we override scalaVersion to validate,
 // but don't rebuild scalacheck, so we don't want to rewire that dependency)
-scalaBinaryVersion := "2.11.0-M5"
+scalaBinaryVersion := "2.11.0-M6"
 
 
 // don't use for doc scope, scaladoc warnings are not to be reckoned with
@@ -108,11 +108,15 @@ libraryDependencies ++= (
      *
      */
     def excludeScalaXml(dep: ModuleID): ModuleID =
-      dep.exclude("org.scala-lang.modules", "scala-xml_2.11.0-M5").
-      exclude("org.scala-lang.modules", "scala-xml_2.11.0-M4").
+      dep.exclude("org.scala-lang.modules", "scala-xml_2.11.0-M4").
+      exclude("org.scala-lang.modules", "scala-xml_2.11.0-M5").
+      exclude("org.scala-lang.modules", "scala-xml_2.11.0-M6").
       exclude("org.scalacheck", "scalacheck_2.11.0-M5")
-    Seq("org.scala-lang.modules" % "scala-partest-interface_2.11.0-M5" % "0.2"                         % "test",
-        "org.scala-lang.modules" % "scala-partest_2.11.0-M5"           % TestKeys.partestVersion.value % "test").
+    Seq("org.scala-lang.modules" % "scala-partest-interface_2.11.0-M5" % "0.2"                         % "test" intransitive,
+        "org.scala-lang.modules" % "scala-partest_2.11.0-M5"           % TestKeys.partestVersion.value % "test" intransitive,
+        // diffutils is needed by partest
+        "com.googlecode.java-diff-utils" % "diffutils"      % "1.3.0" % "test",
+        "org.scala-lang" % "scala-compiler" % scalaVersion.value % "test").
       map(excludeScalaXml)
   }
   else Seq.empty

--- a/test/files/neg/t1011.check
+++ b/test/files/neg/t1011.check
@@ -1,4 +1,208 @@
 t1011.scala:8: error: not found: value entity
        <dl><code>{Text(entity)}</code>
                        ^
-one error found
+t1011.scala:9: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:10: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:11: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:12: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:13: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:14: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:15: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:16: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:17: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:18: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:19: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:20: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:21: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:22: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:23: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:24: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:25: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:26: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:27: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:28: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:29: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:30: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:31: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:32: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:33: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:34: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:35: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:36: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:37: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:38: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:39: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:40: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:41: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:42: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:43: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:44: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:45: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:46: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:47: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:48: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:49: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:50: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:51: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:52: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:53: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:54: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:55: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:56: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:57: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:58: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:59: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:60: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:61: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:62: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:63: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:64: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:65: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:66: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:67: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:68: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:69: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:70: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:71: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:72: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:73: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:74: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:75: error: not found: value entity
+           <code>{Text(entity)}</code>
+                       ^
+t1011.scala:76: error: not found: value entity
+           <code>{Text(entity)}</code></dl>
+                       ^
+69 errors found


### PR DESCRIPTION
That entails tweaking dependencies once again. Hold your breath:
- we can't upgrade to new version of partest because it's not been
  released yet; we can't release it first because scalacheck is needed
- therefore we are using the M5 version and then we have to exclude
  all transitive dependencies that were built against M5; one such
  dependency would be scala-compiler itself
- since we excluded all transitive dependencies we need to bring some
  back: we add diffutils and scala-compiler but M6 version

All newly added dependencies are in "test" scope. I verified that nothing
leaks to a pom.xml.

Also, updated check file for one of the tests because there were some
improvements to error handling that changed errors being emitted. See
SI-7895 for details.
