### PR TITLE
SI-4520 - reasonable exception instead of OOE in XML parser

### DIFF
--- a/src/main/scala/scala/xml/parsing/MarkupParser.scala
+++ b/src/main/scala/scala/xml/parsing/MarkupParser.scala
@@ -10,6 +10,8 @@ package scala
 package xml
 package parsing
 
+import java.io.{ByteArrayOutputStream, PrintStream}
+
 import scala.io.Source
 import scala.xml.dtd._
 import Utility.Escapes.{ pairs => unescape }
@@ -936,7 +938,12 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     handle.notationDecl(notat, extID)
   }
 
-  def reportSyntaxError(pos: Int, str: String) { curInput.reportError(pos, str) }
+  def reportSyntaxError(pos: Int, str: String) {
+    val msg = new ByteArrayOutputStream()
+    curInput.reportError(pos, str, new PrintStream(msg))
+    throw FatalError(msg.toString("UTF-8"))
+  }
+
   def reportSyntaxError(str: String) { reportSyntaxError(pos, str) }
   def reportValidationError(pos: Int, str: String) { reportSyntaxError(pos, str) }
 

--- a/src/test/scala/scala/xml/XMLTest.scala
+++ b/src/test/scala/scala/xml/XMLTest.scala
@@ -476,15 +476,16 @@ Ours is the portal of hope, come as you are."
         try {
           xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<foo>"), false).document()
         } catch {
-          case e: Exception => println(e.getMessage)
+          case e: Exception =>
+            e.printStackTrace()
+            println(e.getMessage)
         }
       }
     }
     out.flush()
     assertEquals(
       """:1:5: '/' expected instead of ' '    ^
-:1:5: name expected, but char ' ' cannot start a name    ^
-expected closing tag of foo
+
 """, out.toString)
   }
 
@@ -815,13 +816,57 @@ expected closing tag of foo
   import scala.xml.parsing._
   @UnitTest
   def dontLoop: Unit = {
-    val xml = "<!DOCTYPE xmeml SYSTEM> <xmeml> <sequence> </sequence> </xmeml> "
+    val xml = "<!DOCTYPE xmeml SYSTEM 'uri'> <xmeml> <sequence> </sequence> </xmeml> "
     val sink = new PrintStream(new ByteArrayOutputStream())
     (Console withOut sink) {
       (Console withErr sink) {
         ConstructingParser.fromSource((io.Source fromString xml), true).document.docElem
       }
     }
+  }
+
+  @UnitTest(expected = classOf[FatalError])
+  def shouldThrowFatalErrorWhenCantFindRequestedXToken {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+
+    x.xToken('b')
+  }
+
+  @UnitTest(expected = classOf[FatalError])
+  def shouldThrowFatalErrorWhenCantFindRequestedXCharData {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+
+    x.xCharData
+  }
+
+  @UnitTest(expected = classOf[FatalError])
+  def shouldThrowFatalErrorWhenCantFindRequestedXComment {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+
+    x.xComment
+  }
+
+  @UnitTest(expected = classOf[FatalError])
+  def shouldThrowFatalErrorWhenCantFindRequestedXmlProcInstr {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+
+    x.xmlProcInstr()
+  }
+
+  @Ignore("Ignored for future fix, currently throw OOE because of infinity MarkupParserCommon:66")
+  @UnitTest(expected = classOf[FatalError])
+  def shouldThrowFatalErrorWhenCantFindRequestedXAttributeValue {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+
+    x.xAttributeValue()
+  }
+
+  @Ignore("Ignored for future fix, currently return unexpected result")
+  @UnitTest(expected = classOf[FatalError])
+  def shouldThrowFatalErrorWhenCantFindRequestedXEntityValue {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+
+    assertEquals("a/>", x.xEntityValue())
   }
 
 }


### PR DESCRIPTION
That's fix `OutOfMemoryException` for case when we parse valid XML, however user code request not existent content or not correct content type. Now parser instead of consume all memory just raise exception that request info not present.

Jira: https://issues.scala-lang.org/browse/SI-4339 and https://issues.scala-lang.org/browse/SI-4520
