### PR TITLE
Fix PIs appearing before text nodes.

### DIFF
--- a/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
+++ b/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
@@ -189,6 +189,7 @@ abstract class FactoryAdapter extends DefaultHandler with factory.XMLLoader[Node
    * Processing instruction.
    */
   override def processingInstruction(target: String, data: String) {
+    captureText()
     hStack pushAll createProcInstr(target, data)
   }
 }

--- a/src/test/scala/scala/xml/parsing/PiParsingTest.scala
+++ b/src/test/scala/scala/xml/parsing/PiParsingTest.scala
@@ -1,0 +1,53 @@
+package scala.xml.parsing
+
+import org.junit.Test
+import org.junit.Ignore
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import scala.xml.JUnitAssertsForXML.assertEquals
+
+class PiParsingTest {
+
+
+  import scala.io.Source.fromString
+  import scala.xml.parsing.ConstructingParser.fromSource
+  import scala.xml.TopScope
+  private def parse(s:String) = fromSource(fromString(s), preserveWS = true).element(TopScope)
+  private def parseNoWS(s:String) = fromSource(fromString(s), preserveWS = false).element(TopScope)
+
+  @Test
+  def piNoWSparse: Unit = {
+    val expected = "<foo>a<?pi?>b</foo>"
+    assertEquals(expected, parseNoWS("<foo>a<?pi?>b</foo>"))
+  }
+
+  @Test
+  def piNoWSLiteral: Unit = {
+    val expected = "<foo>a<?pi?>b</foo>"
+    assertEquals(expected, <foo>a<?pi?>b</foo>)
+  }
+
+  @Test
+  def piNoWSloadString: Unit = {
+    val expected = "<foo>a<?pi?>b</foo>"
+    assertEquals(expected, xml.XML.loadString("<foo>a<?pi?>b</foo>"))
+  }
+
+  @Test
+  def piParse: Unit = {
+    val expected = "<foo> a <?pi?> b </foo>"
+    assertEquals(expected, parse("<foo> a <?pi?> b </foo>"))
+  }
+
+  @Test
+  def piLoadString: Unit = {
+    val expected = "<foo> a <?pi?> b </foo>"
+    assertEquals(expected, xml.XML.loadString("<foo> a <?pi?> b </foo>"))
+  }
+  @Test
+  def piLiteral: Unit = {
+    val expected = "<foo> a <?pi?> b </foo>"
+    assertEquals(expected, <foo> a <?pi?> b </foo>)
+  }
+
+}


### PR DESCRIPTION
The bug:

```
<foo>aaa<?pi?>bbb</foo>
```

is parsed as

```
<foo><?pi?>aaabbb</foo>
```

by loadXML.

Cause and fix:

The SAX handler that's used when you call loadXML didn't append
the text buffer to the current node list before pushing a
processing-instruction node.
