### PR TITLE
SI-8523 Adjust test for namespace interpolation

### DIFF
--- a/src/test/scala/scala/xml/XMLTest.scala
+++ b/src/test/scala/scala/xml/XMLTest.scala
@@ -601,7 +601,7 @@ expected closing tag of foo
     </wsdl:definitions>;
 
   def wsdlTemplate3(serviceName: String): Node =
-    <wsdl:definitions name={ serviceName } xmlns:tns={ Text("target3") }>
+    <wsdl:definitions name={ serviceName } xmlns:tns={ new _root_.scala.xml.Text("target3") }>
     </wsdl:definitions>;
 
   def wsdlTemplate4(serviceName: String, targetNamespace: () => String): Node =


### PR DESCRIPTION
This test fails after we try to fix SI-8523 in the compiler.
But the test is actually at fault here, as it was relying on
the loose matching performed by the compiler's SymbolXMLBuilder.

The fix for SI-8523 that triggered the failure:

   https://github.com/scala/scala/commit/8d175b907

The original commit that introduced this test:

   https://github.com/scala/scala/commit/e1ffc05b10be6

Review by @som-snytt
