### PR TITLE
SI-9060: Accept fifth-edition names.

### DIFF
--- a/src/main/scala/scala/xml/Utility.scala
+++ b/src/main/scala/scala/xml/Utility.scala
@@ -273,6 +273,14 @@ object Utility extends AnyRef with parsing.TokenTests {
     case i  => Some(name.substring(0, i))
   }
 
+  object Qualified {
+    /** No ':' yields null namespace; leading or trailing yields empty string. */
+    def unapply(name: String): Option[(String, String)] = name indexOf ':' match {
+      case -1 => Some(null, name)
+      case i  => Some(name.substring(0, i), name.substring(i + 1)) // start out of range OK
+    }
+  }
+
   /**
    * Returns a hashcode for the given constituents of a node
    */

--- a/src/main/scala/scala/xml/parsing/MarkupParser.scala
+++ b/src/main/scala/scala/xml/parsing/MarkupParser.scala
@@ -264,8 +264,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
         theNode = m
     }
     if (1 != elemCount) {
-      reportSyntaxError("document must contain exactly one element")
-      Console.println(children.toList)
+      reportSyntaxError(s"document must contain exactly one element but has $elemCount")
     }
 
     doc.children = children

--- a/src/main/scala/scala/xml/parsing/MarkupParser.scala
+++ b/src/main/scala/scala/xml/parsing/MarkupParser.scala
@@ -573,10 +573,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
   def element1(pscope: NamespaceBinding): NodeSeq = {
     val pos = this.pos
     val (qname, (aMap, scope)) = xTag(pscope)
-    val (pre, local) = Utility.prefix(qname) match {
-      case Some(p) => (p, qname drop p.length + 1)
-      case _       => (null, qname)
-    }
+    val Utility.Qualified(pre, local) = qname
     val ts = {
       if (ch == '/') { // empty element
         xToken("/>")

--- a/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
+++ b/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
@@ -62,8 +62,9 @@ private[scala] trait MarkupParserCommon extends TokenTests {
    * @param endCh either `'` or `"`
    */
   def xAttributeValue(endCh: Char): String = {
+    require(endCh == '\'' || endCh == '"', s"Expected single or double quote, found $endCh")
     val buf = new StringBuilder
-    while (ch != endCh) {
+    while (ch != endCh && !eof) {
       // well-formedness constraint
       if (ch == '<') return errorAndResult("'<' not allowed in attrib value", "")
       else if (ch == SU) truncatedError("")

--- a/src/main/scala/scala/xml/parsing/TokenTests.scala
+++ b/src/main/scala/scala/xml/parsing/TokenTests.scala
@@ -35,7 +35,28 @@ trait TokenTests {
   def isAlpha(c: Char) = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
   def isAlphaDigit(c: Char) = isAlpha(c) || (c >= '0' && c <= '9')
 
-  /**
+  def isNameChar(c: Char): Boolean = (
+    isNameStart(c) ||
+    (c >= '0' && c <= '9') ||
+    c == '-' ||
+    c == '.' ||
+    c == 0xB7 ||
+    (c >= 0x300 && c <= 0x36F) ||
+    (c >= 0x203F && c <= 0x2040)
+  )
+  def isNameStart(c: Char): Boolean = (
+         if (c < 0x00C0)  isAlpha(c) || c == ':' || c == '_'
+    else if (c < 0x0300)  c != 0xD7 && c != 0xF7
+    else if (c < 0x2000)  c >= 0x370 && c != 0x37E
+    else if (c < 0x3001)  c == 0x200C || c == 0x200D || (0x2070 to 0x218F contains c) ||
+                          (0x2C00 to 0x2FEF contains c)
+    else if (c < 0xD800)  true
+    else if (c < 0x10000) (0xF900 to 0xFDCF contains c) || (0xFDF0 to 0xFFFD contains c)
+    else                  false // codepoint < 0xF0000
+  )
+
+  /* Documenting that Appendix B is obsolete. And nested comments rock.
+  /*
    * {{{
    *  NameChar ::= Letter | Digit | '.' | '-' | '_' | ':'
    *             | CombiningChar | Extender
@@ -54,7 +75,7 @@ trait TokenTests {
     })
   }
 
-  /**
+  /*
    * {{{
    *  NameStart ::= ( Letter | '_' )
    *  }}}
@@ -74,6 +95,7 @@ trait TokenTests {
       case _ => ch == '_'
     }
   }
+   */
 
   /**
    * {{{

--- a/src/test/scala/scala/xml/ShouldCompile.scala
+++ b/src/test/scala/scala/xml/ShouldCompile.scala
@@ -64,7 +64,9 @@ class B {
 
 // SI-5858
 object SI_5858 {
-  new Elem(null, null, Null, TopScope, Nil: _*) // was ambiguous
+  @deprecated("ignore me", since="")
+  def e =
+    new Elem(null, null, Null, TopScope, Nil: _*) // was ambiguous
 }
 
 class Floozy {

--- a/src/test/scala/scala/xml/UtilityTest.scala
+++ b/src/test/scala/scala/xml/UtilityTest.scala
@@ -13,7 +13,9 @@ class UtilityTest {
   @Test
   def isNameStart: Unit = {
     assertTrue(Utility.isNameStart('b'))
-    assertFalse(Utility.isNameStart(':'))
+    // No indication of who relied on this behavior.
+    //assertFalse(Utility.isNameStart(':'))
+    assertTrue(Utility.isNameStart(':'))
   }
 
   @Test

--- a/src/test/scala/scala/xml/parsing/ConstructingParserTest.scala
+++ b/src/test/scala/scala/xml/parsing/ConstructingParserTest.scala
@@ -1,0 +1,55 @@
+package scala.xml
+package parsing
+
+import org.junit.Test
+import org.junit.Ignore
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Assert
+import Assert._
+import scala.xml.JUnitAssertsForXML.assertEquals
+
+class ConstructingParserTest {
+
+  import scala.io.Source.fromString
+  import ConstructingParser.fromSource
+  //import scala.xml.{ NodeSeq, TopScope }
+  import XML.loadString
+
+  private def parse(s:String) = fromSource(fromString(s), false).element(TopScope)
+
+  // fifth edition
+  // ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] |
+  // [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] |
+  // [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
+  // and
+  // "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
+  //
+  @Test def `SI-9060: valid chars in names`(): Unit = {
+    // promote chars to ints
+    def c(a: Int) = a to a
+    def cs(a: Int, b: Int) = a to b
+    val ranges = List(
+      c(':'), cs('A','Z'), cs('a','z'), cs('_','_'),
+      0xC0 to 0x2FF filter { case 0xD7 | 0xF7 => false case _ => true },
+      0x370 to 0x37D, 0x37F to 0x1FFF, 0x200C to 0x200D, 0x2070 to 0x218F,
+      0x2C00 to 0x2FEF, 0x3001 to 0xD7FF, 0xF900 to 0xFDCF, 0xFDF0 to 0xFFFD
+      // , 0x10000 to 0xEFFFF  // TODO, code points
+    )
+    val others = List[Range](
+      c('-'), c('.'), '0'.toInt to '9', 0xB7 to 0xB7, 0x300 to 0x36F, 0x203F to 0x2040
+    )
+
+    val tester = new TokenTests { }
+    for (r <- ranges ; i <- r) assertTrue(f"NameStart: $i%#x (${i.toChar})", tester.isNameStart(i.toChar))
+    for (r <- others ; i <- r) assertTrue(f"NameChar: $i%#x (${i.toChar})", tester.isNameChar(i.toChar))
+  }
+
+  // notice the middle dot
+  @Test def `SI-9060: problematic char in name`(): Unit = {
+    val problematic = """<a xmlns:b·="http://example.com"/>"""
+    val expected = problematic
+    assertEquals(expected, parse(problematic))
+    assertEquals(expected, loadString(problematic))
+  }
+}


### PR DESCRIPTION
Accept fifth-edition names.

Fix infinite loopiness in attribute parsing.

Improve tests a bit.
