### PR TITLE
Fix default namespace in PrettyPrinter.formatNodes

### DIFF
--- a/src/main/scala/scala/xml/PrettyPrinter.scala
+++ b/src/main/scala/scala/xml/PrettyPrinter.scala
@@ -203,7 +203,7 @@ class PrettyPrinter(width: Int, step: Int) {
    * @param sb   the stringbuffer to append to
    */
   def format(n: Node, sb: StringBuilder) { // entry point
-    format(n, null, sb)
+    format(n, TopScope, sb)
   }
 
   def format(n: Node, pscope: NamespaceBinding, sb: StringBuilder) { // entry point

--- a/src/main/scala/scala/xml/PrettyPrinter.scala
+++ b/src/main/scala/scala/xml/PrettyPrinter.scala
@@ -253,7 +253,7 @@ class PrettyPrinter(width: Int, step: Int) {
    *  @param nodes  the sequence of nodes to be serialized
    *  @param pscope the namespace to prefix mapping
    */
-  def formatNodes(nodes: Seq[Node], pscope: NamespaceBinding = null): String =
+  def formatNodes(nodes: Seq[Node], pscope: NamespaceBinding = TopScope): String =
     sbToString(formatNodes(nodes, pscope, _))
 
   /**

--- a/src/test/scala/scala/xml/XMLTest.scala
+++ b/src/test/scala/scala/xml/XMLTest.scala
@@ -836,4 +836,14 @@ expected closing tag of foo
     assertEquals("""<x:foo xmlns:x="gaga"/>""", pp.format(x))
   }
 
+  @UnitTest
+  def nodeSeqNs: Unit = {
+    val x = {
+      <x:foo xmlns:x="abc"/><y:bar xmlns:y="def"/>
+    }
+    val pp = new PrettyPrinter(80, 2)
+    val expected = """<x:foo xmlns:x="abc"/><y:bar xmlns:y="def"/>"""
+    assertEquals(expected, pp.formatNodes(x))
+  }
+
 }

--- a/src/test/scala/scala/xml/XMLTest.scala
+++ b/src/test/scala/scala/xml/XMLTest.scala
@@ -846,4 +846,15 @@ expected closing tag of foo
     assertEquals(expected, pp.formatNodes(x))
   }
 
+  @UnitTest
+  def nodeStringBuilder: Unit = {
+    val x = {
+        <x:foo xmlns:x="abc"/>
+    }
+    val pp = new PrettyPrinter(80, 2)
+    val expected = """<x:foo xmlns:x="abc"/>"""
+    val sb = new StringBuilder
+    pp.format(x, sb)
+    assertEquals(expected, sb.toString)
+  }
 }


### PR DESCRIPTION
This replicates the fix from #28 and applies it to the ```formatNodes``` method of ```PrettyPrinter``` as well. Existing behaviour is the same bug that @ashawley highlighted before - namely the addition of an erroneous empty ```xmlns=""``` at the top level of each node.