### PR TITLE
Avoid .format in serialization

### DIFF
--- a/src/main/scala/scala/xml/NamespaceBinding.scala
+++ b/src/main/scala/scala/xml/NamespaceBinding.scala
@@ -75,10 +75,7 @@ case class NamespaceBinding(prefix: String, uri: String, parent: NamespaceBindin
   private def doBuildString(sb: StringBuilder, stop: NamespaceBinding) {
     if ((this == null) || (this eq stop)) return // contains?
 
-    val s = " xmlns%s=\"%s\"".format(
-      (if (prefix != null) ":" + prefix else ""),
-      (if (uri != null) uri else "")
-    )
+    val s = " xmlns" + (if (prefix != null) ":" + prefix else "") + "=\"" + (if (uri != null) uri else "") + "\""
     parent.doBuildString(sb append s, stop) // copy(ignore)
   }
 }

--- a/src/main/scala/scala/xml/PCData.scala
+++ b/src/main/scala/scala/xml/PCData.scala
@@ -27,7 +27,7 @@ class PCData(data: String) extends Atom[String](data) {
    *  @return the input string buffer with the formatted CDATA section
    */
   override def buildString(sb: StringBuilder): StringBuilder =
-    sb append "<![CDATA[%s]]>".format(data)
+    sb.append("<![CDATA[" + data + "]]>")
 }
 
 /**

--- a/src/main/scala/scala/xml/ProcInstr.scala
+++ b/src/main/scala/scala/xml/ProcInstr.scala
@@ -35,5 +35,5 @@ case class ProcInstr(target: String, proctext: String) extends SpecialNode {
    *  to this stringbuffer.
    */
   override def buildString(sb: StringBuilder) =
-    sb append "<?%s%s?>".format(target, (if (proctext == "") "" else " " + proctext))
+    sb.append("<?" + target + (if (proctext == "") "" else " " + proctext) + "?>")
 }

--- a/src/main/scala/scala/xml/dtd/DTD.scala
+++ b/src/main/scala/scala/xml/dtd/DTD.scala
@@ -28,8 +28,5 @@ abstract class DTD {
   var ent: mutable.Map[String, EntityDecl] = new mutable.HashMap[String, EntityDecl]()
 
   override def toString() =
-    "DTD [\n%s%s]".format(
-      Option(externalID) getOrElse "",
-      decls.mkString("", "\n", "\n")
-    )
+    "DTD [\n" + Option(externalID).getOrElse("") + decls.mkString("", "\n", "\n") + "]"
 }

--- a/src/main/scala/scala/xml/dtd/DocType.scala
+++ b/src/main/scala/scala/xml/dtd/DocType.scala
@@ -29,7 +29,7 @@ case class DocType(name: String, extID: ExternalID, intSubset: Seq[dtd.Decl]) {
       if (intSubset.isEmpty) ""
       else intSubset.mkString("[", "", "]")
 
-    """<!DOCTYPE %s %s%s>""".format(name, extID.toString(), intString)
+    "<!DOCTYPE " + name + " " + extID.toString() + intString + ">"
   }
 }
 

--- a/src/main/scala/scala/xml/dtd/ValidationException.scala
+++ b/src/main/scala/scala/xml/dtd/ValidationException.scala
@@ -32,10 +32,10 @@ object MakeValidationException {
   def fromMissingAttribute(allKeys: Set[String]) = {
     val sb = new StringBuilder("missing value for REQUIRED attribute")
     if (allKeys.size > 1) sb.append('s')
-    allKeys foreach (k => sb append "'%s'".format(k))
+    allKeys foreach (k => sb.append("'" + k + "'"))
     new ValidationException(sb.toString())
   }
 
   def fromMissingAttribute(key: String, tpe: String) =
-    new ValidationException("missing value for REQUIRED attribute %s of type %s".format(key, tpe))
+    new ValidationException("missing value for REQUIRED attribute " + key + " of type " + tpe)
 }

--- a/src/main/scala/scala/xml/dtd/impl/DetWordAutom.scala
+++ b/src/main/scala/scala/xml/dtd/impl/DetWordAutom.scala
@@ -42,9 +42,9 @@ private[dtd] abstract class DetWordAutom[T <: AnyRef] {
     sb.append(" delta=\n")
 
     for (i <- 0 until nstates) {
-      sb append "%d->%s\n".format(i, delta(i))
+      sb.append(i + "->" + delta(i) + "\n")
       if (i < default.length)
-        sb append "_>%s\n".format(default(i))
+        sb.append("_>" + default(i) + "\n")
     }
     sb.toString
   }

--- a/src/main/scala/scala/xml/dtd/impl/NondetWordAutom.scala
+++ b/src/main/scala/scala/xml/dtd/impl/NondetWordAutom.scala
@@ -54,8 +54,8 @@ private[dtd] abstract class NondetWordAutom[T <: AnyRef] {
 
     val finalString = Map(finalStates map (j => j -> finals(j)): _*).toString
     val deltaString = (0 until nstates)
-      .map(i => "   %d->%s\n    _>%s\n".format(i, delta(i), default(i))).mkString
+      .map(i => "   " + i + "->" + delta(i) + "\n    _>" + default(i) + "\n").mkString
 
-    "[NondetWordAutom  nstates=%d  finals=%s  delta=\n%s".format(nstates, finalString, deltaString)
+    "[NondetWordAutom  nstates=" + nstates + "  finals=" + finalString + "  delta=\n" + deltaString
   }
 }

--- a/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
+++ b/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
@@ -24,8 +24,7 @@ trait ConsoleErrorHandler extends DefaultHandler {
 
   protected def printError(errtype: String, ex: SAXParseException): Unit =
     Console.withOut(Console.err) {
-      val s = "[%s]:%d:%d: %s".format(
-        errtype, ex.getLineNumber, ex.getColumnNumber, ex.getMessage)
+      val s = "[" + errtype + "]:" + ex.getLineNumber + ":" + ex.getColumnNumber + ": " + ex.getMessage
       Console.println(s)
       Console.flush()
     }

--- a/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
+++ b/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
@@ -86,7 +86,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
       case `end` => return buf.toString
       case ch    => buf append ch
     }
-    scala.sys.error("Expected '%s'".format(end))
+    scala.sys.error("Expected '" + end + "'")
   }
 
   /**
@@ -205,7 +205,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
 
   def xToken(that: Char) {
     if (ch == that) nextch()
-    else xHandleError(that, "'%s' expected instead of '%s'".format(that, ch))
+    else xHandleError(that, "'" + that + "' expected instead of '" + ch + "'")
   }
   def xToken(that: Seq[Char]) { that foreach xToken }
 


### PR DESCRIPTION
avoid .format since it calls java.util.Currency.getInstance and blocks thread

![capture d ecran 2015-05-06 a 15 01 35](https://cloud.githubusercontent.com/assets/2699647/7493421/fc9333de-f400-11e4-855c-8b5b19919742.png)
