### PR TITLE
Fix #51 Test compat for -Xxml:coalescing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,10 @@ version                    := "1.0.5-SNAPSHOT"
 
 scalaVersion               := crossScalaVersions.value.head
 
-crossScalaVersions         := Seq("2.11.6", "2.12.0-M1")
+crossScalaVersions         := Seq("2.11.7", "2.12.0-M1")
+
+//scalacOptions             ++= "-deprecation:false -feature -Xlint:-stars-align,-nullary-unit,_ -Xfatal-warnings -Xxml:coalescing".split("\\s+").to[Seq]
+scalacOptions             ++= "-deprecation:false -feature -Xlint:-stars-align,-nullary-unit,_ -Xxml:coalescing".split("\\s+").to[Seq]
 
 // important!! must come here (why?)
 scalaModuleOsgiSettings

--- a/src/main/scala/scala/xml/dtd/ContentModel.scala
+++ b/src/main/scala/scala/xml/dtd/ContentModel.scala
@@ -14,11 +14,21 @@ import scala.xml.dtd.impl._
 import scala.xml.Utility.sbToString
 import PartialFunction._
 
+/*
+@deprecated("Avoidance", since="2.10")
+trait ContentModelLaundry extends WordExp
+object ContentModelLaundry extends ContentModelLaundry {
+}
+*/
+
 object ContentModel extends WordExp {
+
   type _labelT = ElemName
   type _regexpT = RegExp
 
-  object Translator extends WordBerrySethi {
+  @deprecated("Avoidance", since="2.10")
+  trait Translator extends WordBerrySethi
+  object Translator extends Translator {
     override val lang: ContentModel.this.type = ContentModel.this
   }
 
@@ -72,13 +82,14 @@ object ContentModel extends WordExp {
       case Letter(ElemName(name)) =>
         sb.append(name)
     }
-
 }
 
 sealed abstract class ContentModel {
   override def toString(): String = sbToString(buildString)
   def buildString(sb: StringBuilder): StringBuilder
 }
+
+import ContentModel.RegExp
 
 case object PCDATA extends ContentModel {
   override def buildString(sb: StringBuilder): StringBuilder = sb.append("(#PCDATA)")
@@ -91,7 +102,7 @@ case object ANY extends ContentModel {
 }
 sealed abstract class DFAContentModel extends ContentModel {
   import ContentModel.{ ElemName, Translator }
-  def r: ContentModel.RegExp
+  def r: RegExp
 
   lazy val dfa: DetWordAutom[ElemName] = {
     val nfa = Translator.automatonFrom(r, 1)
@@ -99,8 +110,8 @@ sealed abstract class DFAContentModel extends ContentModel {
   }
 }
 
-case class MIXED(r: ContentModel.RegExp) extends DFAContentModel {
-  import ContentModel.{ Alt, RegExp }
+case class MIXED(r: RegExp) extends DFAContentModel {
+  import ContentModel.Alt
 
   override def buildString(sb: StringBuilder): StringBuilder = {
     val newAlt = r match { case Alt(rs@_*) => Alt(rs drop 1: _*) }
@@ -111,7 +122,7 @@ case class MIXED(r: ContentModel.RegExp) extends DFAContentModel {
   }
 }
 
-case class ELEMENTS(r: ContentModel.RegExp) extends DFAContentModel {
+case class ELEMENTS(r: RegExp) extends DFAContentModel {
   override def buildString(sb: StringBuilder): StringBuilder =
     ContentModel.buildString(r, sb)
 }

--- a/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
+++ b/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
@@ -19,6 +19,7 @@ import scala.collection.{ immutable, mutable }
  *  @version 1.0
  */
 // TODO: still used in ContentModel -- @deprecated("This class will be removed", "2.10.0")
+@deprecated("This class will be removed", "2.10.0")
 private[dtd] abstract class WordBerrySethi extends BaseBerrySethi {
   override val lang: WordExp
 

--- a/src/main/scala/scala/xml/pull/XMLEventReader.scala
+++ b/src/main/scala/scala/xml/pull/XMLEventReader.scala
@@ -122,7 +122,7 @@ trait ProducerConsumerIterator[T >: Null] extends Iterator[T] {
   // defaults to unbounded - override to positive Int if desired
   val MaxQueueSize = -1
 
-  def interruptibly[T](body: => T): Option[T] = try Some(body) catch {
+  def interruptibly[A](body: => A): Option[A] = try Some(body) catch {
     case _: InterruptedException   =>
       Thread.currentThread.interrupt(); None
     case _: ClosedChannelException => None

--- a/src/test/scala/scala/xml/ShouldCompile.scala
+++ b/src/test/scala/scala/xml/ShouldCompile.scala
@@ -22,11 +22,11 @@ class Foo {
 }
 
 // t2281
-class A {
+class t2281A {
   def f(x: Boolean) = if (x) <br/><br/> else <br/>
 }
 
-class B {
+class t2281B {
   def splitSentences(text: String): ArrayBuffer[String] = {
     val outarr = new ArrayBuffer[String]
     var outstr = new StringBuffer

--- a/src/test/scala/scala/xml/XMLTest.scala
+++ b/src/test/scala/scala/xml/XMLTest.scala
@@ -1,5 +1,7 @@
 package scala.xml
 
+import language.postfixOps
+
 import org.junit.{Test => UnitTest}
 import org.junit.Ignore
 import org.junit.runner.RunWith


### PR DESCRIPTION
Rather than maintain a test to compile under multiple
regimes, just build under `-Xxml:coalescing`.

A few other flags are supplied. Deprecation is not yet
possible because of `WordExp` et al. Renamed test classes
`A` and `B` because sometimes it's nice to have a type
parameter called `A` or `B`.

`-Xlint:stars-align` must be off until 2.12.0-M2 arrives with https://github.com/scala/scala/pull/4537.

This tests for me with version 2.12, but I couldn't get it to fail, either, so I hope @adriaanm will verify at least with eyeballs.

Review by @biswanaths 

Isn't it supposed to autocomplete the maintainer's name?