### PR TITLE
opt-in to Travis's newer/faster container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# opt-in to Travis's newer/faster container-based infrastructure
+sudo: false
+
 language: scala
 
 env:


### PR DESCRIPTION
this worked fine over in scala-partest, presumably will work
fine here too