### PR TITLE
Use NodeSeq.fromSeq instead of new NodeSeq { val theSeq = ... }

### DIFF
--- a/src/main/scala/scala/xml/parsing/MarkupParser.scala
+++ b/src/main/scala/scala/xml/parsing/MarkupParser.scala
@@ -443,7 +443,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     val ts = new NodeBuffer
     var exit = eof
     // todo: optimize seq repr.
-    def done = new NodeSeq { val theSeq = ts.toList }
+    def done = NodeSeq.fromSeq(ts.toList)
 
     while (!exit) {
       tmppos = pos

--- a/src/test/scala/scala/xml/PatternMatching.scala
+++ b/src/test/scala/scala/xml/PatternMatching.scala
@@ -74,7 +74,7 @@ class PatternMatching extends {
         <title>Baaaaaaalabla</title>
       </bks>;
 
-    assertTrue(new NodeSeq { val theSeq = books.child } match {
+    assertTrue(NodeSeq.fromSeq(books.child) match {
       case t @ Seq(<title>Blabla</title>) => false
       case _ => true
     })

--- a/src/test/scala/scala/xml/XMLTest.scala
+++ b/src/test/scala/scala/xml/XMLTest.scala
@@ -37,7 +37,7 @@ class XMLTest {
       Text(x.attributes("value").toString + y.attributes("bazValue").toString + "!")
     };
 
-    val pelems_2 = new NodeSeq { val theSeq = List(Text("38!"), Text("58!")) };
+    val pelems_2 = NodeSeq.fromSeq(List(Text("38!"), Text("58!")));
     assertTrue(pelems_1 sameElements pelems_2)
     assertTrue(Text("8") sameElements (p \\ "@bazValue"))
   }
@@ -94,7 +94,7 @@ class XMLTest {
     assertEquals(results1Expected, results1)
 
     {
-      val actual = for (t @ <book><title>Blabla</title></book> <- new NodeSeq { val theSeq = books.child }.toList)
+      val actual = for (t @ <book><title>Blabla</title></book> <- NodeSeq.fromSeq(books.child).toList)
         yield t
       val expected = List(<book><title>Blabla</title></book>)
       assertEquals(expected, actual)
@@ -312,7 +312,7 @@ class XMLTest {
       (parsedxml2 \\ "book") { n: Node => (n \ "title") xml_== "Data on ze web" } toString)
 
     assertTrue(
-      ((new NodeSeq { val theSeq = List(parsedxml2) }) \\ "_") sameElements List(
+      ((NodeSeq.fromSeq(List(parsedxml2))) \\ "_") sameElements List(
         Elem(null, "bib", e, sc,
           Elem(null, "book", e, sc,
             Elem(null, "author", e, sc, Text("Peter Buneman")),


### PR DESCRIPTION
Seems like ```NodeSeq.fromSeq``` was added in a3cf1ea in 2005 by Buraq Emir.  It is used in only a few places in the code.  Instead, code internally was more often using a constructor expression to instantiate a NodeSeq object.