### PR TITLE
Fix compiler warning about non-exhaustive match

### DIFF
--- a/src/test/scala/scala/xml/ReuseNodesTest.scala
+++ b/src/test/scala/scala/xml/ReuseNodesTest.scala
@@ -4,6 +4,7 @@ import scala.xml.transform._
 import org.junit.Test
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.experimental.theories.Theories
 import org.junit.experimental.theories.Theory
 import org.junit.experimental.theories.DataPoints
@@ -72,7 +73,7 @@ class ReuseNodesTest {
   def transformReferentialEquality(rt:RuleTransformer) = { 
     val original = <p><lost/></p>
     val tranformed = rt.transform(original)
-    assertTrue(original eq tranformed)
+    assertSame(original, tranformed)
   }
       
   @Theory
@@ -93,7 +94,7 @@ class ReuseNodesTest {
       case "changed" => // do nothing expect this node to be changed
         recursiveAssert(original.child,transformed.child)
       case _ => {
-        assertTrue(original eq transformed)
+        assertSame(original, transformed)
         // No need to check for children, node being immuatable 
         // children can't be different if parents are referentially equal
       }

--- a/src/test/scala/scala/xml/ReuseNodesTest.scala
+++ b/src/test/scala/scala/xml/ReuseNodesTest.scala
@@ -9,11 +9,11 @@ import org.junit.experimental.theories.Theory
 import org.junit.experimental.theories.DataPoints
 import org.junit.runner.RunWith
 /**
- * This test verify that after the tranform, the resultant xml node
+ * This test verifies that after the transform, the resultant xml node
  * uses as many old nodes as possible. 
  * 
  * Three transformers class for case - 
- * One for orginal, one for modified, and one proposed which shows 
+ * One for original, one for modified, and one proposed which shows 
  * all are equivalent when it comes to reusing as many nodes as possible
  */
 object ReuseNodesTest {
@@ -83,13 +83,9 @@ class ReuseNodesTest {
   }
   
   def recursiveAssert(original:Seq[Node], transformed:Seq[Node]):Unit = {
-    (original.toList,transformed.toList) match {
-      case (Nil, Nil) => {}
-      case (x::xs,y::ys) => { 
-        recursiveAssert(x,y)
-        recursiveAssert(xs,ys)
-      }
-    } 
+    original zip transformed foreach { 
+      case (x, y) => recursiveAssert(x, y) 
+    }
   }
   
   def recursiveAssert(original:Node, transformed:Node):Unit = {
@@ -98,8 +94,8 @@ class ReuseNodesTest {
         recursiveAssert(original.child,transformed.child)
       case _ => {
         assertTrue(original eq transformed)
-        // No need to check for childrens, node being immuatable 
-        // childs can't be differnt if parents are refertially equal
+        // No need to check for children, node being immuatable 
+        // children can't be different if parents are referentially equal
       }
     }
   }


### PR DESCRIPTION
Specific warning looks like this:
```
src/test/scala/scala/xml/ReuseNodesTest.scala:86: match may not be exhaustive.
It would fail on the following inputs: (List(_), Nil), (Nil, List(_))
    (original.toList,transformed.toList) match {
    ^
one warning found
```
Seems like the method could be rewritten to just use `zip` and `foreach`.  Could someone review to make sure the assertion still works, though?  I wasn't sure how to break `scala.xml.transform.BasicTransformer` to verify.