### PR TITLE
Remove final keyword from scala.xml.MetaData per note

### DIFF
--- a/src/main/scala/scala/xml/MetaData.scala
+++ b/src/main/scala/scala/xml/MetaData.scala
@@ -26,8 +26,8 @@ object MetaData {
    *
    * Duplicates can be removed with `normalize`.
    */
-  @tailrec // temporarily marked final so it will compile under -Xexperimental
-  final def concatenate(attribs: MetaData, new_tail: MetaData): MetaData =
+  @tailrec
+  def concatenate(attribs: MetaData, new_tail: MetaData): MetaData =
     if (attribs eq Null) new_tail
     else concatenate(attribs.next, attribs copy new_tail)
 


### PR DESCRIPTION
The `-Xexperimental` compiler options is not enabled in the project's SBT file, so presumably, this line isn't needed anymore per the comment in the code.

I added `-Xexperimental` to` scalacOption`and didn't have a problem compiling in either 2.12.0.M2 and 2.11.7.