### PR TITLE
Enabling builds for java 1.7 and 1.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,9 @@ scalaVersion               := crossScalaVersions.value.head
 
 crossScalaVersions         := {
   val java = System.getProperty("java.version")
-  if (java.startsWith("1.6."))
+  if (java.startsWith("1.6.") || java.startsWith("1.7."))
     Seq("2.11.7", "2.12.0-M1")
-  else if (java.startsWith("1.8."))
+  else if (java.startsWith("1.8.") || java.startsWith("1.9."))
     Seq("2.12.0-M2")
   else
     sys.error(s"don't know what Scala versions to build on $java")


### PR DESCRIPTION
Please see Issue https://github.com/scala/scala-xml/issues/86

The build file errors if you are trying to build on system with java 1.7. As suggest by @SethTisue , lumped 1.7 with 1.6 and future proofing 1.9 by lumping it together with 1.8.