### PR TITLE
Unit test for verifying complexity of basic transformer

### DIFF
--- a/src/test/scala/scala/xml/Transformers.scala
+++ b/src/test/scala/scala/xml/Transformers.scala
@@ -56,4 +56,25 @@ class Transformers {
         </contents>
       </root>)
   }
+
+  @Test
+  def preserveReferentialComplexityInLinearComplexity = { // SI-4528
+    var i = 0
+ 
+    val xmlNode = <a><b><c><h1>Hello Example</h1></c></b></a>
+
+    new RuleTransformer(new RewriteRule {
+      override def transform(n: Node): Seq[Node] = {
+        n match {
+          case t: Text if !t.text.trim.isEmpty => {
+            i += 1
+            Text(t.text + "!")
+          }
+          case _ => n
+        }
+      }
+    }).transform(xmlNode)
+
+    assertEquals(1, i)
+  }
 }


### PR DESCRIPTION
A new unit test -- taken from code example in [SI-4528](https://issues.scala-lang.org/browse/SI-4528) -- to verify changes in #58 for maintaining linear complexity of `scala.xml.transform.BasicTransformer.transform`.

Adding this test is motivated on refactoring of #58 to remove a compiler warning -- see #83.

Here is how I verified the unit test of this PR.  I cherry-picked it on to the revision before the fix in #58 (b2eef1f), and then after (master). As you can see, it fails for before, but succeeds on the current master.

```
$ git checkout -b complexity-before b2eef1f^
Switched to a new branch 'complexity-before'
$ git cherry-pick SI-4528-transformer-complexity
[complexity-before bd4dd2b] Unit test for verifying complexity of basic transformer
 Date: Tue Oct 13 11:34:42 2015 -0400
 1 file changed, 22 insertions(+), 1 deletion(-)
$ sbt "testOnly scala.xml.Transformers"
[error] Test scala.xml.Transformers.preserveReferentialComplexityInLinearComplexity failed: expected:<1> but was:<32>
[error] Failed: Total 4, Failed 1, Errors 0, Passed 3
[error] Failed tests:
[error] 	scala.xml.Transformers
[error] (test:testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 4 s, completed Nov 3, 2015 10:32:30 PM
$ git checkout -b complexity-after master
Switched to a new branch 'complexity-after'
$ git cherry-pick SI-4528-transformer-complexity
[complexity-after cb5dd60] Unit test for verifying complexity of basic transformer
 Date: Tue Oct 13 11:34:42 2015 -0400
 1 file changed, 22 insertions(+), 1 deletion(-)
$ sbt "testOnly scala.xml.Transformers"
[info] Passed: Total 4, Failed 0, Errors 0, Passed 4
[success] Total time: 4 s, completed Nov 3, 2015 9:39:50 PM
$ git checkout master
Switched to branch 'master'
$ git branch -D complexity-before
Deleted branch complexity-before (was bd4dd2b).
$ git branch -D complexity-after
Deleted branch complexity-after (was cb5dd60).
```