### PR TITLE
Fix #72 XMLEventReader does not handle &apos; properly

### DIFF
--- a/jvm/src/test/scala/scala/xml/pull/XMLEventReaderTest.scala
+++ b/jvm/src/test/scala/scala/xml/pull/XMLEventReaderTest.scala
@@ -2,7 +2,7 @@ package scala.xml
 package pull
 
 import org.junit.Test
-import org.junit.Assert.{assertFalse, assertTrue}
+import org.junit.Assert.{assertEquals,assertFalse, assertTrue}
 
 import scala.io.Source
 import scala.xml.parsing.FatalError
@@ -170,7 +170,7 @@ class XMLEventReaderTest {
   }
 
   @Test
-  def entityRefTest: Unit = {
+  def entityRefTest: Unit = { // SI-7796
     val source = Source.fromString("<text>&quot;&apos;&lt;&gt;&amp;</text>")
     val er = new XMLEventReader(source)
 
@@ -178,30 +178,18 @@ class XMLEventReaderTest {
       case EvElemStart(_, "text", _, _) => true
       case _ => false
     })
-    assertTrue(er.next match {
-      case EvEntityRef("quot") => true
-      case e => false
-    })
-    assertTrue(er.next match {
-      case EvEntityRef("apos") => true
-      case _ => false
-    })
-    assertTrue(er.next match {
-      case EvEntityRef("lt") => true
-      case _ => false
-    })
-    assertTrue(er.next match {
-      case EvEntityRef("gt") => true
-      case _ => false
-    })
-    assertTrue(er.next match {
-      case EvEntityRef("amp") => true
-      case _ => false
-    })
+
+    assertEquals(EvEntityRef("quot"), er.next)
+    assertEquals(EvEntityRef("apos"), er.next)
+    assertEquals(EvEntityRef("lt"), er.next)
+    assertEquals(EvEntityRef("gt"), er.next)
+    assertEquals(EvEntityRef("amp"), er.next)
+
     assertTrue(er.next match {
       case EvElemEnd(_, "text") => true
       case _ => false
     })
-    assert(er.isEmpty)
+
+    assertTrue(er.isEmpty)
   }
 }

--- a/jvm/src/test/scala/scala/xml/pull/XMLEventReaderTest.scala
+++ b/jvm/src/test/scala/scala/xml/pull/XMLEventReaderTest.scala
@@ -168,4 +168,40 @@ class XMLEventReaderTest {
     while(er.hasNext) er.next()
     er.stop()
   }
+
+  @Test
+  def entityRefTest: Unit = {
+    val source = Source.fromString("<text>&quot;&apos;&lt;&gt;&amp;</text>")
+    val er = new XMLEventReader(source)
+
+    assertTrue(er.next match {
+      case EvElemStart(_, "text", _, _) => true
+      case _ => false
+    })
+    assertTrue(er.next match {
+      case EvEntityRef("quot") => true
+      case e => false
+    })
+    assertTrue(er.next match {
+      case EvEntityRef("apos") => true
+      case _ => false
+    })
+    assertTrue(er.next match {
+      case EvEntityRef("lt") => true
+      case _ => false
+    })
+    assertTrue(er.next match {
+      case EvEntityRef("gt") => true
+      case _ => false
+    })
+    assertTrue(er.next match {
+      case EvEntityRef("amp") => true
+      case _ => false
+    })
+    assertTrue(er.next match {
+      case EvElemEnd(_, "text") => true
+      case _ => false
+    })
+    assert(er.isEmpty)
+  }
 }

--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -96,13 +96,11 @@ object Utility extends AnyRef with parsing.TokenTests {
       "lt" -> '<',
       "gt" -> '>',
       "amp" -> '&',
-      "quot" -> '"'
-    // enigmatic comment explaining why this isn't escaped --
-    // is valid xhtml but not html, and IE doesn't know it, says jweb
-    // "apos"  -> '\''
+      "quot" -> '"',
+      "apos"  -> '\''
     )
-    val escMap = pairs map { case (s, c) => c -> ("&%s;" format s) }
-    val unescMap = pairs ++ Map("apos" -> '\'')
+    val escMap = (pairs - "apos") map { case (s, c) => c -> ("&%s;" format s) }
+    val unescMap = pairs
   }
   import Escapes.unescMap
 


### PR DESCRIPTION
```
Fix #72 XMLEventReader does not handle &apos; properly

* jvm/src/main/scala/scala/xml/Utility.scala: Uncomment apos in
unescape map.

* jvm/src/test/scala/scala/xml/pull/XMLEventReaderTest.scala (entityRefTest):
Unit test from Fehmi Can Saglam <fehmican.saglam@gmail.com>

```
