### PR TITLE
Add new config for PrettyPrinter to minimize empty tags

### DIFF
--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -555,4 +555,11 @@ class XMLTestJVM {
     assertEquals("<node/>", pp.format(x.copy(minimizeEmpty = true)))
   }
 
+  @UnitTest
+  def issue90: Unit = {
+    val pp = new xml.PrettyPrinter(80, 2, minimizeEmpty = true)
+    val x = <node><leaf></leaf></node>
+    assertEquals("<node>\n  <leaf/>\n</node>", pp.format(x))
+  }
+
 }

--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -542,4 +542,17 @@ class XMLTestJVM {
     pp.format(x, sb)
     assertEquals(expected, sb.toString)
   }
+
+  @UnitTest
+  def issue46: Unit = {
+    // val x = <node/>
+    val x = <node></node>
+    // val x = Elem(null, "node", e, sc)
+    val pp = new xml.PrettyPrinter(80, 2)
+    // This assertion passed
+    assertEquals("<node></node>", x.toString)
+    // This was the bug, producing <node></node>
+    assertEquals("<node/>", pp.format(x.copy(minimizeEmpty = true)))
+  }
+
 }

--- a/shared/src/main/scala/scala/xml/PrettyPrinter.scala
+++ b/shared/src/main/scala/scala/xml/PrettyPrinter.scala
@@ -23,7 +23,9 @@ import Utility.sbToString
  *  @param width the width to fit the output into
  *  @param step  indentation
  */
-class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean = false) {
+class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean) {
+
+  def this(width: Int, step: Int) = this(width, step, minimizeEmpty = false)
 
   val minimizeMode = if (minimizeEmpty) MinimizeMode.Always else MinimizeMode.Default
   class BrokenException() extends java.lang.Exception

--- a/shared/src/main/scala/scala/xml/PrettyPrinter.scala
+++ b/shared/src/main/scala/scala/xml/PrettyPrinter.scala
@@ -23,8 +23,9 @@ import Utility.sbToString
  *  @param width the width to fit the output into
  *  @param step  indentation
  */
-class PrettyPrinter(width: Int, step: Int) {
+class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean = false) {
 
+  val minimizeMode = if (minimizeEmpty) MinimizeMode.Always else MinimizeMode.Default
   class BrokenException() extends java.lang.Exception
 
   class Item
@@ -150,7 +151,7 @@ class PrettyPrinter(width: Int, step: Int) {
     case _ =>
       val test = {
         val sb = new StringBuilder()
-        Utility.serialize(node, pscope, sb, stripComments = false)
+        Utility.serialize(node, pscope, sb, stripComments = false, minimizeTags = minimizeMode)
         if (doPreserve(node)) sb.toString
         else TextBuffer.fromString(sb.toString).toText(0).data
       }

--- a/shared/src/test/scala/scala/xml/UtilityTest.scala
+++ b/shared/src/test/scala/scala/xml/UtilityTest.scala
@@ -51,4 +51,10 @@ class UtilityTest {
     </hi>.hashCode // Bug #777
   }
 
+  @Test
+  def issue90: Unit = {
+    val x = <node><leaf></leaf></node>
+    assertEquals("<node><leaf/></node>", Utility.serialize(x, minimizeTags = MinimizeMode.Always).toString)
+  }
+
 }


### PR DESCRIPTION
This commit containing a unit test was mentioned last year in #46, and I thought the copy constructor using `minimizeEmpty=true` was broken, but it appears scala-xml does the right thing!
