### PR TITLE
Nested XML adds empty xmlns attribute #45

### DIFF
--- a/src/main/scala/scala/xml/NamespaceBinding.scala
+++ b/src/main/scala/scala/xml/NamespaceBinding.scala
@@ -73,7 +73,7 @@ case class NamespaceBinding(prefix: String, uri: String, parent: NamespaceBindin
   }
 
   private def doBuildString(sb: StringBuilder, stop: NamespaceBinding) {
-    if ((this == null) || (this eq stop)) return // contains?
+    if (List(null, stop, TopScope).contains(this)) return
 
     val s = " xmlns%s=\"%s\"".format(
       (if (prefix != null) ":" + prefix else ""),

--- a/src/test/scala/scala/xml/XMLTest.scala
+++ b/src/test/scala/scala/xml/XMLTest.scala
@@ -163,6 +163,15 @@ class XMLTest {
   }
 
   @UnitTest
+  def namespacesWithNestedXmls: Unit = {
+    val foo = <f:foo xmlns:f="fooUrl"></f:foo>
+    val bar = <b:bar xmlns:b="barUrl">{foo}</b:bar>
+    val expected = """<b:bar xmlns:b="barUrl"><f:foo xmlns:f="fooUrl"></f:foo></b:bar>"""
+    val actual = bar.toString
+    assertEquals(expected, actual)
+  }
+
+  @UnitTest
   def validationOfElements: Unit = {
     val vtor = new scala.xml.dtd.ElementValidator();
     {


### PR DESCRIPTION
	* src/test/scala/scala/xml/XMLTest.scala (namespacesWithNestedXmls):
	Modified test case by Muntis Grūbe.

	* src/main/scala/scala/xml/NamespaceBinding.scala (doBuildString):
	Add TopScope as a value to avoid building the namespace attribute
	string.