### PR TITLE
Fix #35 OOM on malformed input

### DIFF
--- a/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
+++ b/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
@@ -63,7 +63,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
    */
   def xAttributeValue(endCh: Char): String = {
     val buf = new StringBuilder
-    while (ch != endCh) {
+    while (ch != endCh && !eof) {
       // well-formedness constraint
       if (ch == '<') return errorAndResult("'<' not allowed in attrib value", "")
       else if (ch == SU) truncatedError("")

--- a/src/test/scala/scala/xml/XMLTest.scala
+++ b/src/test/scala/scala/xml/XMLTest.scala
@@ -838,6 +838,12 @@ expected closing tag of foo
     assertEquals("""<x:foo xmlns:x="gaga"/>""", pp.format(x))
   }
 
+  @UnitTest( expected = classOf[scala.xml.SAXParseException] )
+  def issue35: Unit = {
+    val broken = "<broken attribute='is truncated"
+    XML.loadString(broken)
+  }
+
   @UnitTest
   def nodeSeqNs: Unit = {
     val x = {

--- a/src/test/scala/scala/xml/pull/XMLEventReaderTest.scala
+++ b/src/test/scala/scala/xml/pull/XMLEventReaderTest.scala
@@ -1,4 +1,5 @@
-package scala.xml.pull
+package scala.xml
+package pull
 
 import org.junit.Test
 import org.junit.Ignore
@@ -38,6 +39,17 @@ class XMLEventReaderTest {
       case _ => false
     })
     er.stop  // allow thread to be garbage-collected
+  }
+
+  @Test
+  def issue35: Unit = {
+    val broken = "<broken attribute='is truncated"
+    val x = new Source {
+      val iter = broken.iterator
+      override def reportError(pos: Int, msg: String, out: java.io.PrintStream = Console.err) {}
+    }
+    val r = new XMLEventReader(x)
+    assertTrue(r.next.isInstanceOf[EvElemStart])
   }
 
  @Test(expected = classOf[Exception]) 


### PR DESCRIPTION
This takes the fix from #44 by @som-snytt, but I've also added 2 unit tests to document the specific bug in #35.

I needed access to `scala.xml.Source`, so I modified the `package` declarations in the tests.

A unit test follows the convention of muting console output when the event reader is under test, see #82.