### PR TITLE
Fix #44 SI-9060 XML 5th edition name characters

### DIFF
--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -390,7 +390,7 @@ class XMLTestJVM {
   }
 
   @UnitTest
-  def t5052 {
+  def t5052 = {
     assertTrue(<elem attr={ null: String }/> xml_== <elem/>)
     assertTrue(<elem attr={ None }/> xml_== <elem/>)
     assertTrue(<elem/> xml_== <elem attr={ null: String }/>)
@@ -412,7 +412,7 @@ class XMLTestJVM {
   }
 
   @UnitTest
-  def t5843 {
+  def t5843 = {
     val foo = scala.xml.Attribute(null, "foo", "1", scala.xml.Null)
     val bar = scala.xml.Attribute(null, "bar", "2", foo)
     val ns = scala.xml.NamespaceBinding(null, "uri", scala.xml.TopScope)
@@ -444,7 +444,7 @@ class XMLTestJVM {
   }
 
   @UnitTest
-  def t7074 {
+  def t7074 = {
     assertEquals("""<a/>""", sort(<a/>) toString)
     assertEquals("""<a b="2" c="3" d="1"/>""", sort(<a d="1" b="2" c="3"/>) toString)
     assertEquals("""<a b="2" c="4" d="1" e="3" f="5"/>""", sort(<a d="1" b="2" e="3" c="4" f="5"/>) toString)
@@ -454,6 +454,12 @@ class XMLTestJVM {
     assertEquals("""<a a:b="2" a:c="4" a:d="1" a:e="3" a:f="5"/>""", sort(<a a:d="1" a:b="2" a:e="3" a:c="4" a:f="5"/>) toString)
     assertEquals("""<a a:b="5" a:c="4" a:d="3" a:e="2" a:f="1"/>""", sort(<a a:f="1" a:e="2" a:d="3" a:c="4" a:b="5"/>) toString)
     assertEquals("""<a a:b="1" a:c="2" a:d="3" a:e="4" a:f="5"/>""", sort(<a a:b="1" a:c="2" a:d="3" a:e="4" a:f="5"/>) toString)
+  }
+
+  @UnitTest
+  def t9060 = {
+    val expected = """<a xmlns:b·="http://example.com"/>"""
+    assertEquals(expected, XML.loadString(expected).toString)
   }
 
   @UnitTest

--- a/jvm/src/test/scala/scala/xml/parsing/ConstructingParserTest.scala
+++ b/jvm/src/test/scala/scala/xml/parsing/ConstructingParserTest.scala
@@ -1,0 +1,22 @@
+package scala.xml
+package parsing
+
+import scala.io.Source
+import org.junit.Test
+import scala.xml.JUnitAssertsForXML.{ assertEquals => assertXml }
+
+class ConstructingParserTest {
+
+  @Test
+  def t9060 = {
+    val a = """<a xmlns:b·="http://example.com"/>"""
+    val source = new Source {
+      val iter = a.iterator
+      override def reportError(pos: Int, msg: String, out: java.io.PrintStream = Console.err) = {}
+    }
+    val doc = ConstructingParser.fromSource(source, false).content(TopScope)
+    assertXml(a, doc)
+
+  }
+
+}

--- a/shared/src/main/scala/scala/xml/parsing/TokenTests.scala
+++ b/shared/src/main/scala/scala/xml/parsing/TokenTests.scala
@@ -56,13 +56,13 @@ trait TokenTests {
 
   /**
    * {{{
-   *  NameStart ::= ( Letter | '_' )
+   *  NameStart ::= ( Letter | '_' | ':' )
    *  }}}
    *  where Letter means in one of the Unicode general
    *  categories `{ Ll, Lu, Lo, Lt, Nl }`.
    *
    *  We do not allow a name to start with `:`.
-   *  See [3] and Appendix B of XML 1.0 specification
+   *  See [4] and Appendix B of XML 1.0 specification
    */
   def isNameStart(ch: Char) = {
     import java.lang.Character._
@@ -71,7 +71,7 @@ trait TokenTests {
       case LOWERCASE_LETTER |
         UPPERCASE_LETTER | OTHER_LETTER |
         TITLECASE_LETTER | LETTER_NUMBER => true
-      case _ => ch == '_'
+      case _ => ":_".contains(ch)
     }
   }
 

--- a/shared/src/main/scala/scala/xml/parsing/TokenTests.scala
+++ b/shared/src/main/scala/scala/xml/parsing/TokenTests.scala
@@ -37,10 +37,10 @@ trait TokenTests {
 
   /**
    * {{{
-   *  NameChar ::= Letter | Digit | '.' | '-' | '_' | ':'
+   *  NameChar ::= Letter | Digit | '.' | '-' | '_' | ':' | #xB7
    *             | CombiningChar | Extender
    *  }}}
-   *  See [4] and Appendix B of XML 1.0 specification.
+   *  See [4] and [4a] of Appendix B of XML 1.0 specification.
    */
   def isNameChar(ch: Char) = {
     import java.lang.Character._
@@ -50,7 +50,7 @@ trait TokenTests {
       case COMBINING_SPACING_MARK |
         ENCLOSING_MARK | NON_SPACING_MARK |
         MODIFIER_LETTER | DECIMAL_DIGIT_NUMBER => true
-      case _ => ".-:" contains ch
+      case _ => ".-:·" contains ch
     })
   }
 

--- a/shared/src/test/scala/scala/xml/UtilityTest.scala
+++ b/shared/src/test/scala/scala/xml/UtilityTest.scala
@@ -2,7 +2,6 @@ package scala.xml
 
 import org.junit.Test
 import org.junit.Assert.assertTrue
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
 
 class UtilityTest {
@@ -10,7 +9,7 @@ class UtilityTest {
   @Test
   def isNameStart: Unit = {
     assertTrue(Utility.isNameStart('b'))
-    assertFalse(Utility.isNameStart(':'))
+    assertTrue(Utility.isNameStart(':'))
   }
 
   @Test


### PR DESCRIPTION
Refactored PR from #44 by @som-snytt to only make minimal changes to tokenization code, namely the acceptance of the "MIDDLE DOT" character, #xB7, from the original ticket.

To follow the standard, a colon should be allowed to start a name.  It seems that a colon could always start an XML name -- in addition to a letter or an underscore.  Not sure why it was avoided, but it's probably pretty rare, anyway.

https://www.w3.org/TR/2008/REC-xml-20081126
https://www.w3.org/TR/2006/REC-xml-20060816
https://www.w3.org/TR/2004/REC-xml-20040204
https://www.w3.org/TR/2000/REC-xml-20001006
https://www.w3.org/TR/1998/REC-xml-19980210
