### PR TITLE
Update mimaPreviousVersion to 1.0.5 and scala-module-plugin to 1.0.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,4 +36,4 @@ libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test"
 // used in CompilerErrors test
 libraryDependencies += ("org.scala-lang" % "scala-compiler" % scalaVersion.value % "test").exclude("org.scala-lang.modules", s"scala-xml*")
 
-mimaPreviousVersion := Some("1.0.1")
+mimaPreviousVersion := Some("1.0.5")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.3")
+addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.4")


### PR DESCRIPTION
Running the test suite on Java 8 with the [Migration Manager](http://github.com/typesafehub/migration-manager) results in the warning, "MiMa will NOT run because the previous artifact "org.scala-lang.modules" % "scala-xml_2.12.0-M1" %
  "1.0.1" could not be resolved (note the binary Scala version)."

Looking around, it seems the scala-2.12 builds started witih scala-xml 1.0.4.  Below is the old build log.

```
$ env JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" sbt clean +test
[info] Loading project definition from scala-xml/project
[info] Set current project to scala-xml (in build file:scala-xml/)
[warn] Credentials file ~/.ivy2/.credentials does not exist
[success] Total time: 0 s, completed Apr 25, 2016 11:46:09 AM
[info] Setting version to 2.12.0-M2
[info] Reapplying settings...
[info] Set current project to scala-xml (in build file:scala-xml/)
[warn] Credentials file ~/.ivy2/.credentials does not exist
[info] Updating {file:scala-xml/}scala-xml...
[info] Resolving org.scala-lang.modules#scala-xml_2.12.0-M2;1.0.1 ...
[warn] 	module not found: org.scala-lang.modules#scala-xml_2.12.0-M2;1.0.1
[warn] ==== local: tried
[warn]   ~/.ivy2/local/org.scala-lang.modules/scala-xml_2.12.0-M2/1.0.1/ivys/ivy.xml
[warn] ==== public: tried
[warn]   https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12.0-M2/1.0.1/scala-xml_2.12.0-M2-1.0.1.pom
[warn] ==== sonatype-releases: tried
[warn]   https://oss.sonatype.org/content/repositories/releases/org/scala-lang/modules/scala-xml_2.12.0-M2/1.0.1/scala-xml_2.12.0-M2-1.0.1.pom
[warn] ==== sonatype-snapshots: tried
[warn]   https://oss.sonatype.org/content/repositories/snapshots/org/scala-lang/modules/scala-xml_2.12.0-M2/1.0.1/scala-xml_2.12.0-M2-1.0.1.pom
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	::          UNRESOLVED DEPENDENCIES         ::
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	:: org.scala-lang.modules#scala-xml_2.12.0-M2;1.0.1: not found
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] MiMa will NOT run because the previous artifact "org.scala-lang.modules" % "scala-xml_2.12.0-M2" % "1.0.1" could not be resolved (note the binary Scala version).
[info] Resolving org.scala-lang#scala-compiler;2.12.0-M2 ...
[warn] circular dependency found: org.scala-lang.modules#scala-xml_2.12.0-M2;1.0.6-SNAPSHOT->org.scala-lang#scala-compiler;2.12.0-M2->org.scala-lang.modules#scala-xml_2.12.0-M2;1.0.4
[info] Resolving jline#jline;2.12.1 ...
[info] Done updating.
[info] Compiling 84 Scala sources to scala-xml/target/scala-2.12.0-M2/classes...
[info] Compiling 16 Scala sources to scala-xml/target/scala-2.12.0-M2/test-classes...
[warn] scala-xml/src/test/scala/scala/xml/ReuseNodesTest.scala:86: match may not be exhaustive.
[warn] It would fail on the following inputs: (List(_), Nil), (Nil, List(_))
[warn]     (original.toList,transformed.toList) match {
[warn]     ^
[warn] one warning found
Testing scala-xml version 1.0.6-SNAPSHOT.
Testing scala-xml version 1.0.6-SNAPSHOT.
Testing scala-xml version 1.0.6-SNAPSHOT.
Testing scala-xml version 1.0.6-SNAPSHOT.
:9:19: '/' expected instead of ''                  ^
:9:19: name expected, but char '' cannot start a name                  ^
[info] Passed: Total 110, Failed 0, Errors 0, Passed 110
[success] Total time: 48 s, completed Apr 25, 2016 11:46:57 AM
[info] Setting version to 2.12.0-M2
[info] Reapplying settings...
[info] Set current project to scala-xml (in build file:scala-xml/)
```

After fixing the dependency issue, it seems that MiMa not running was hiding a thrown exception error.  Presumably, the Travis build will confirm this to be the case, and not simply be a consequence of something peculiar to my environment.

```
$ env JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" sbt clean +test
[info] Loading project definition from scala-xml/project
[info] Updating {file:scala-xml/project/}scala-xml-build...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[info] Set current project to scala-xml (in build file:scala-xml/)
[warn] Credentials file ~/.ivy2/.credentials does not exist
[success] Total time: 0 s, completed Apr 25, 2016 12:04:40 PM
[info] Setting version to 2.12.0-M2
[info] Reapplying settings...
[info] Set current project to scala-xml (in build file:scala-xml/)
[warn] Credentials file ~/.ivy2/.credentials does not exist
[info] Updating {file:scala-xml/}scala-xml...
[info] Resolving org.scala-lang#scala-compiler;2.12.0-M2 ...
[warn] circular dependency found: org.scala-lang.modules#scala-xml_2.12.0-M2;1.0.6-SNAPSHOT->org.scala-lang#scala-compiler;2.12.0-M2->org.scala-lang.modules#scala-xml_2.12.0-M2;1.0.4
[info] Resolving jline#jline;2.12.1 ...
[info] Done updating.
[info] Resolving org.scala-lang#scala-library;2.12.0-M2 ...
[info] Compiling 84 Scala sources to scala-xml/target/scala-2.12.0-M2/classes...
[info] 'compiler-interface' not yet compiled for Scala 2.12.0-M2. Compiling...
	[info]   Compilation completed in 22.506 s
[info] Compiling 16 Scala sources to scala-xml/target/scala-2.12.0-M2/test-classes...
[warn] scala-xml/src/test/scala/scala/xml/ReuseNodesTest.scala:86: match may not be exhaustive.
[warn] It would fail on the following inputs: (List(_), Nil), (Nil, List(_))
[warn]     (original.toList,transformed.toList) match {
[warn]     ^
[warn] one warning found
Testing scala-xml version 1.0.6-SNAPSHOT.
Testing scala-xml version 1.0.6-SNAPSHOT.
Testing scala-xml version 1.0.6-SNAPSHOT.
Testing scala-xml version 1.0.6-SNAPSHOT.
:9:19: '/' expected instead of ''                  ^
:9:19: name expected, but char '' cannot start a name                  ^
[info] Passed: Total 110, Failed 0, Errors 0, Passed 110
java.lang.RuntimeException: bad constant pool tag 15 at byte 1259
	at com.typesafe.tools.mima.core.ClassfileParser$ConstantPool.errorBadTag(ClassfileParser.scala:201)
	at com.typesafe.tools.mima.core.ClassfileParser$ConstantPool.<init>(ClassfileParser.scala:103)
	at com.typesafe.tools.mima.core.ClassfileParser.parseAll(ClassfileParser.scala:67)
	at com.typesafe.tools.mima.core.ClassfileParser.parse(ClassfileParser.scala:59)
	at com.typesafe.tools.mima.core.ClassInfo.ensureLoaded(ClassInfo.scala:72)
	at com.typesafe.tools.mima.core.WithAccessModifier$class.isPublic(WithAccessModifier.scala:6)
	at com.typesafe.tools.mima.core.ClassInfo.isPublic(ClassInfo.scala:36)
	at com.typesafe.tools.mima.core.PackageInfo.com$typesafe$tools$mima$core$PackageInfo$$isAccessible$1(PackageInfo.scala:79)
	at com.typesafe.tools.mima.core.PackageInfo$$anonfun$1.apply(PackageInfo.scala:69)
	at com.typesafe.tools.mima.core.PackageInfo$$anonfun$1.apply(PackageInfo.scala:69)
	at scala.collection.Iterator$$anon$14.hasNext(Iterator.scala:390)
	at scala.collection.Iterator$class.foreach(Iterator.scala:727)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1157)
	at scala.collection.generic.Growable$class.$plus$plus$eq(Growable.scala:48)
	at scala.collection.mutable.SetBuilder.$plus$plus$eq(SetBuilder.scala:22)
	at scala.collection.TraversableOnce$class.to(TraversableOnce.scala:273)
	at scala.collection.AbstractIterator.to(Iterator.scala:1157)
	at scala.collection.TraversableOnce$class.toSet(TraversableOnce.scala:267)
	at scala.collection.AbstractIterator.toSet(Iterator.scala:1157)
	at com.typesafe.tools.mima.core.PackageInfo.accessibleClassesUnder$1(PackageInfo.scala:69)
	at com.typesafe.tools.mima.core.PackageInfo.accessibleClasses$lzycompute(PackageInfo.scala:82)
	at com.typesafe.tools.mima.core.PackageInfo.accessibleClasses(PackageInfo.scala:66)
	at com.typesafe.tools.mima.lib.MiMaLib.comparePackages(MiMaLib.scala:47)
	at com.typesafe.tools.mima.lib.MiMaLib.com$typesafe$tools$mima$lib$MiMaLib$$traversePackages(MiMaLib.scala:64)
	at com.typesafe.tools.mima.lib.MiMaLib$$anonfun$com$typesafe$tools$mima$lib$MiMaLib$$traversePackages$1$$anonfun$apply$mcV$sp$1.apply(MiMaLib.scala:71)
	at com.typesafe.tools.mima.lib.MiMaLib$$anonfun$com$typesafe$tools$mima$lib$MiMaLib$$traversePackages$1$$anonfun$apply$mcV$sp$1.apply(MiMaLib.scala:66)
	at scala.collection.Iterator$class.foreach(Iterator.scala:727)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1157)
	at com.typesafe.tools.mima.lib.MiMaLib$$anonfun$com$typesafe$tools$mima$lib$MiMaLib$$traversePackages$1.apply$mcV$sp(MiMaLib.scala:66)
	at com.typesafe.tools.mima.lib.MiMaLib$$anonfun$com$typesafe$tools$mima$lib$MiMaLib$$traversePackages$1.apply(MiMaLib.scala:66)
	at com.typesafe.tools.mima.lib.MiMaLib$$anonfun$com$typesafe$tools$mima$lib$MiMaLib$$traversePackages$1.apply(MiMaLib.scala:66)
	at com.typesafe.tools.mima.core.util.IndentedOutput$.indented(IndentedOutput.scala:11)
	at com.typesafe.tools.mima.lib.MiMaLib.com$typesafe$tools$mima$lib$MiMaLib$$traversePackages(MiMaLib.scala:65)
	at com.typesafe.tools.mima.lib.MiMaLib$$anonfun$com$typesafe$tools$mima$lib$MiMaLib$$traversePackages$1$$anonfun$apply$mcV$sp$1.apply(MiMaLib.scala:71)
	at com.typesafe.tools.mima.lib.MiMaLib$$anonfun$com$typesafe$tools$mima$lib$MiMaLib$$traversePackages$1$$anonfun$apply$mcV$sp$1.apply(MiMaLib.scala:66)
	at scala.collection.Iterator$class.foreach(Iterator.scala:727)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1157)
	at com.typesafe.tools.mima.lib.MiMaLib$$anonfun$com$typesafe$tools$mima$lib$MiMaLib$$traversePackages$1.apply$mcV$sp(MiMaLib.scala:66)
	at com.typesafe.tools.mima.lib.MiMaLib$$anonfun$com$typesafe$tools$mima$lib$MiMaLib$$traversePackages$1.apply(MiMaLib.scala:66)
	at com.typesafe.tools.mima.lib.MiMaLib$$anonfun$com$typesafe$tools$mima$lib$MiMaLib$$traversePackages$1.apply(MiMaLib.scala:66)
	at com.typesafe.tools.mima.core.util.IndentedOutput$.indented(IndentedOutput.scala:11)
	at com.typesafe.tools.mima.lib.MiMaLib.com$typesafe$tools$mima$lib$MiMaLib$$traversePackages(MiMaLib.scala:65)
	at com.typesafe.tools.mima.lib.MiMaLib.collectProblems(MiMaLib.scala:84)
	at com.typesafe.tools.mima.plugin.SbtMima$.runMima(SbtMima.scala:32)
	at com.typesafe.tools.mima.plugin.MimaPlugin$$anonfun$mimaReportSettings$2.apply(MimaPlugin.scala:17)
	at com.typesafe.tools.mima.plugin.MimaPlugin$$anonfun$mimaReportSettings$2.apply(MimaPlugin.scala:14)
	at scala.Function5$$anonfun$tupled$1.apply(Function5.scala:35)
	at scala.Function5$$anonfun$tupled$1.apply(Function5.scala:34)
	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:237)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
[error] (*:mimaFindBinaryIssues) bad constant pool tag 15 at byte 1259
[error] Total time: 56 s, completed Apr 25, 2016 12:05:37 PM
```