### PR TITLE
Fix OOM on malformed input

### DIFF
--- a/src/main/scala/scala/xml/parsing/MarkupParser.scala
+++ b/src/main/scala/scala/xml/parsing/MarkupParser.scala
@@ -265,7 +265,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     }
     if (1 != elemCount) {
       reportSyntaxError("document must contain exactly one element")
-      Console.println(children.toList)
+      //Console.println(children.toList)
     }
 
     doc.children = children
@@ -389,7 +389,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
   def xComment: NodeSeq = {
     val sb: StringBuilder = new StringBuilder()
     xToken("--")
-    while (true) {
+    while (!eof) {
       if (ch == '-' && { sb.append(ch); nextch(); ch == '-' }) {
         sb.length = sb.length - 1
         nextch()
@@ -398,7 +398,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
       } else sb.append(ch)
       nextch()
     }
-    throw FatalError("this cannot happen")
+    throw truncatedError("broken comment")
   }
 
   /* todo: move this into the NodeBuilder class */
@@ -678,10 +678,10 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
 
   def markupDecl1() = {
     def doInclude() = {
-      xToken('['); while (']' != ch) markupDecl(); nextch() // ']'
+      xToken('['); while (']' != ch && !eof) markupDecl(); nextch() // ']'
     }
     def doIgnore() = {
-      xToken('['); while (']' != ch) nextch(); nextch() // ']'
+      xToken('['); while (']' != ch && !eof) nextch(); nextch() // ']'
     }
     if ('?' == ch) {
       nextch()
@@ -747,7 +747,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
 
         case _ =>
           curInput.reportError(pos, "unexpected character '" + ch + "', expected some markupdecl")
-          while (ch != '>')
+          while (ch != '>' && !eof)
             nextch()
       }
     }
@@ -780,7 +780,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
   def intSubset() {
     //Console.println("(DEBUG) intSubset()")
     xSpace()
-    while (']' != ch)
+    while (']' != ch && !eof)
       markupDecl()
   }
 
@@ -792,7 +792,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     xSpace()
     val n = xName
     xSpace()
-    while ('>' != ch) {
+    while ('>' != ch && !eof) {
       //Console.println("["+ch+"]")
       putChar(ch)
       nextch()
@@ -817,7 +817,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     var attList: List[AttrDecl] = Nil
 
     // later: find the elemDecl for n
-    while ('>' != ch) {
+    while ('>' != ch && !eof) {
       val aname = xName
       xSpace()
       // could be enumeration (foo,bar) parse this later :-/

--- a/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
+++ b/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
@@ -247,7 +247,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
       while (true) {
         if (ch == head && peek(rest))
           return handler(positioner(), sb.toString)
-        else if (ch == SU)
+        else if (ch == SU || eof)
           truncatedError("") // throws TruncatedXMLControl in compiler
 
         sb append ch

--- a/src/test/scala/scala/xml/pull/XMLEventReaderTest.scala
+++ b/src/test/scala/scala/xml/pull/XMLEventReaderTest.scala
@@ -5,6 +5,7 @@ import org.junit.Test
 import org.junit.Assert.{assertFalse, assertTrue}
 
 import scala.io.Source
+import scala.xml.parsing.FatalError
 
 class XMLEventReaderTest {
 
@@ -49,28 +50,32 @@ class XMLEventReaderTest {
     assertTrue(r.next.isInstanceOf[EvElemStart])
   }
 
-  @Test
+  @Test(expected = classOf[FatalError])
   def malformedCDATA: Unit = {
     val data = "<broken><![CDATA[A"
     val r = new XMLEventReader(toSource(data))
 
     assertTrue(r.next.isInstanceOf[EvElemStart])
+    // error when returning EvText of CDATA
+    r.next
   }
 
-  @Test
+  @Test(expected = classOf[FatalError])
   def malformedComment1: Unit = {
-    val data = "<broken><!"
+    val data = "<!"
     val r = new XMLEventReader(toSource(data))
 
-    assertTrue(r.next.isInstanceOf[EvElemStart])
+    // error when returning EvComment
+    r.next
   }
 
-  @Test
+  @Test(expected = classOf[FatalError])
   def malformedComment2: Unit = {
-    val data = "<broken><!-- comment "
+    val data = "<!-- comment "
     val r = new XMLEventReader(toSource(data))
 
-    assertTrue(r.next.isInstanceOf[EvElemStart])
+    // error when returning EvComment
+    r.next
   }
 
   @Test

--- a/src/test/scala/scala/xml/pull/XMLEventReaderTest.scala
+++ b/src/test/scala/scala/xml/pull/XMLEventReaderTest.scala
@@ -2,18 +2,18 @@ package scala.xml
 package pull
 
 import org.junit.Test
-import org.junit.Ignore
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Assert.assertTrue
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertFalse, assertTrue}
 
 import scala.io.Source
 
 class XMLEventReaderTest {
 
   val src = Source.fromString("<hello><world/>!</hello>")
+
+  private def toSource(s: String) = new Source {
+    val iter = s.iterator
+    override def reportError(pos: Int, msg: String, out: java.io.PrintStream = Console.err) {}
+  }
 
   @Test
   def pull: Unit = {
@@ -44,17 +44,110 @@ class XMLEventReaderTest {
   @Test
   def issue35: Unit = {
     val broken = "<broken attribute='is truncated"
-    val x = new Source {
-      val iter = broken.iterator
-      override def reportError(pos: Int, msg: String, out: java.io.PrintStream = Console.err) {}
-    }
-    val r = new XMLEventReader(x)
+    val r = new XMLEventReader(toSource(broken))
+
     assertTrue(r.next.isInstanceOf[EvElemStart])
   }
 
- @Test(expected = classOf[Exception]) 
- def missingTagTest: Unit = {
-   val data=
+  @Test
+  def malformedCDATA: Unit = {
+    val data = "<broken><![CDATA[A"
+    val r = new XMLEventReader(toSource(data))
+
+    assertTrue(r.next.isInstanceOf[EvElemStart])
+  }
+
+  @Test
+  def malformedComment1: Unit = {
+    val data = "<broken><!"
+    val r = new XMLEventReader(toSource(data))
+
+    assertTrue(r.next.isInstanceOf[EvElemStart])
+  }
+
+  @Test
+  def malformedComment2: Unit = {
+    val data = "<broken><!-- comment "
+    val r = new XMLEventReader(toSource(data))
+
+    assertTrue(r.next.isInstanceOf[EvElemStart])
+  }
+
+  @Test
+  def malformedDTD1: Unit = {
+    // broken ELEMENT
+    val data =
+      """<?xml version="1.0" encoding="utf-8"?>
+        |<!DOCTYPE broken [
+        |  <!ELE
+      """.stripMargin
+    val r = new XMLEventReader(toSource(data))
+
+    assertFalse(r.hasNext)
+  }
+
+  @Test
+  def malformedDTD2: Unit = {
+    val data =
+      """<!DOCTYPE broken [
+        |  <!ELEMENT data (#PCDATA)>
+      """.stripMargin
+    val r = new XMLEventReader(toSource(data))
+
+    assertFalse(r.hasNext)
+  }
+
+  @Test
+  def malformedDTD3: Unit = {
+    // broken ATTLIST
+    val data =
+      """<!DOCTYPE broken [
+        |  <!ATTL
+      """.stripMargin
+    val r = new XMLEventReader(toSource(data))
+
+    assertFalse(r.hasNext)
+  }
+
+  @Test
+  def malformedDTD4: Unit = {
+    // unexpected declaration
+    val data =
+      """<!DOCTYPE broken [
+        |  <!UNEXPECTED
+      """.stripMargin
+    val r = new XMLEventReader(toSource(data))
+
+    assertFalse(r.hasNext)
+  }
+
+  @Test
+  def malformedDTD5: Unit = {
+    val data =
+      """<!DOCTYPE broken [
+        |  <!ENTITY % foo 'INCLUDE'>
+        |  <![%foo;[
+      """.stripMargin
+    val r = new XMLEventReader(toSource(data))
+
+    assertFalse(r.hasNext)
+  }
+
+  @Test
+  def malformedDTD6: Unit = {
+    val data =
+      """<!DOCTYPE broken [
+        |  <!ENTITY % foo 'IGNORE'>
+        |  <![%foo;[
+      """.stripMargin
+    val r = new XMLEventReader(toSource(data))
+
+    assertFalse(r.hasNext)
+  }
+
+  @Test(expected = classOf[Exception])
+  def missingTagTest: Unit = {
+    val data=
       """<?xml version="1.0" ?>
         |<verbosegc xmlns="http://www.ibm.com/j9/verbosegc">
         |
@@ -66,8 +159,8 @@ class XMLEventReaderTest {
         |</exclusive-start>
         |""".stripMargin
 
-   val er = new XMLEventReader(Source.fromString(data))
-   while(er.hasNext) er.next()
-   er.stop()
- }
+    val er = new XMLEventReader(toSource(data))
+    while(er.hasNext) er.next()
+    er.stop()
+  }
 }


### PR DESCRIPTION
Hi.

I tried in the latest master version since the bug (#35) have been merged.
But the survey found that there are still cases that OOM occur.
Specifically, CDATA sections, comment, DTD.

```scala
// broken CDATA
val r = new XMLEventReader(Source.fromString("<broken><![CDATA[A"))

// broken comment
val r = new XMLEventReader(Source.fromString("<!-- broken "))

// broken DTD
val r = new XMLEventReader(Source.fromString(
    """<?xml version="1.0" encoding="utf-8"?>
      |<!DOCTYPE broken [
      |  <!ELE
    """.stripMargin))
```

All of the above cases occur OOM.

```
[error] (XMLEventReader) java.lang.OutOfMemoryError: Java heap space
```

I am in trouble since OOM have a large impact on the production.

This PR is going to avoid the OOM caused by the above-mentioned.
This commit make up for the lack of #35. Specifically,
CDATA sections, comment, DTD.