### PR TITLE
Update crossScalaVersions to 2.11.8 and 2.12.0-M5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,9 @@ scalaVersion               := crossScalaVersions.value.head
 crossScalaVersions         := {
   val java = System.getProperty("java.version")
   if (java.startsWith("1.6.") || java.startsWith("1.7."))
-    Seq("2.11.7", "2.12.0-M1")
+    Seq("2.11.8", "2.12.0-M1")
   else if (java.startsWith("1.8.") || java.startsWith("1.9."))
-    Seq("2.12.0-M2")
+    Seq("2.12.0-M5")
   else
     sys.error(s"don't know what Scala versions to build on $java")
 }


### PR DESCRIPTION
I mentioned doing this before release version 1.0.6 in #97.

I assume this is the right thing to do, but I wouldn't know if this has any unintended side effects.

