### PR TITLE
Revert imperative Utility.escape from 81d7e2a

### DIFF
--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -102,7 +102,7 @@ object Utility extends AnyRef with parsing.TokenTests {
     val escMap = (pairs - "apos") map { case (s, c) => c -> ("&%s;" format s) }
     val unescMap = pairs
   }
-  import Escapes.unescMap
+  import Escapes.{ escMap, unescMap }
 
   /**
    * Appends escaped string to `s`.
@@ -113,7 +113,7 @@ object Utility extends AnyRef with parsing.TokenTests {
     text.iterator.foldLeft(s) { (s, c) =>
       escMap.get(c) match {
         case Some(str)                             => s ++= str
-        case _ => if c >= ' ' || "\n\r\t".contains(c) => s += c
+        case _ if c >= ' ' || "\n\r\t".contains(c) => s += c
         case _ => s // noop
       }
     }

--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -110,25 +110,13 @@ object Utility extends AnyRef with parsing.TokenTests {
   final def escape(text: String, s: StringBuilder): StringBuilder = {
     // Implemented per XML spec:
     // http://www.w3.org/International/questions/qa-controls
-    // imperative code 3x-4x faster than current implementation
-    // dpp (David Pollak) 2010/02/03
-    val len = text.length
-    var pos = 0
-    while (pos < len) {
-      text.charAt(pos) match {
-        case '<'  => s.append("&lt;")
-        case '>'  => s.append("&gt;")
-        case '&'  => s.append("&amp;")
-        case '"'  => s.append("&quot;")
-        case '\n' => s.append('\n')
-        case '\r' => s.append('\r')
-        case '\t' => s.append('\t')
-        case c    => if (c >= ' ') s.append(c)
+    text.iterator.foldLeft(s) { (s, c) =>
+      escMap.get(c) match {
+        case Some(str)                             => s ++= str
+        case _ => if c >= ' ' || "\n\r\t".contains(c) => s += c
+        case _ => s // noop
       }
-
-      pos += 1
     }
-    s
   }
 
   /**


### PR DESCRIPTION
The current version of `scala.xml.Utility.escape` was contributed in 81d7e2a for scala/bug#3014.  The method was changed for an issue concerning control characters.  Benchmarking at that time happened to show that Scala 2.7 had either a poor performing implementation for `Iterator` or `Map` or both. This produced an `escape` function that was "3x-4x" slower than an imperative version using a while-loop and a pattern match.

Attached to the Jira issue is an `XmlThing.scala` benchmark program.  I've re-run the benchmark program, and there's no evidence that the implementation is any faster than the original code in fc79c582.

I modified the `XmlThing.scala` program: I limited the test to 1-million iterations, down from 100-million so that the tests would take a second rather than a minute.  I then ran the tests in groups of 384, and ran the implementations in different order.  

![benchmark program spreadsheet](https://cloud.githubusercontent.com/assets/358615/25758232/aa87129c-319b-11e7-8b57-36e1426c6e63.png)

I ran it with JMH, as well:

![JMH benchmark spreadsheet](https://cloud.githubusercontent.com/assets/358615/25758299/fe6ea410-319b-11e7-8986-be6ffe769dd7.png)

Here's the trial data (JMH is the second sheet):

https://docs.google.com/spreadsheets/d/1xZakvCKpZjaRO1QRMv3WySz4H6nGsNUgSMDm52pqKpM/edit?usp=sharing

Cheers to @vshalts for writing an SBT task that can run a program _X_ times.

https://gist.github.com/vshalts/ed389bfb69b017f4dac7150cf0875529
