### PR TITLE
Fix Scala 2.12.0-M4 pattern match warnings

### DIFF
--- a/src/test/scala/scala/xml/PatternMatching.scala
+++ b/src/test/scala/scala/xml/PatternMatching.scala
@@ -93,21 +93,25 @@ class PatternMatching extends {
     assertTrue((body: AnyRef, "foo") match {
       case (node: Node, "bar") => false
       case (ser: Serializable, "foo") => true
+      case (_, _) => false
     })
 
     assertTrue((body, "foo") match {
       case (node: Node, "bar") => false
       case (ser: Serializable, "foo") => true
+      case (_, _) => false
     })
 
     assertTrue((body: AnyRef, "foo") match {
       case (node: Node, "foo") => true
       case (ser: Serializable, "foo") => false
+      case (_, _) => false
     })
 
     assertTrue((body: AnyRef, "foo") match {
       case (node: Node, "foo") => true
       case (ser: Serializable, "foo") => false
+      case (_, _) => false
     })
   }
 }


### PR DESCRIPTION
After updating the build to 2.12.0-M4 for JDK 1.8 and higher in #100, I noticed some new pattern match warnings in the build:

    [warn] src/test/scala/scala/xml/PatternMatching.scala:93: match may not be exhaustive.
    [warn] It would fail on the following inputs: ((_ : Serializable), "bar"), ((_ : Serializable), _), (Node(), "foo"), (Node(), _), (Object(), _), (_, "bar"), (_, "foo"), (_, String()), (_, _)
    [warn]     assertTrue((body: AnyRef, "foo") match {
    [warn]                ^
    [warn] src/test/scala/scala/xml/PatternMatching.scala:98: match may not be exhaustive.
    [warn] It would fail on the following inputs: ((_ : scala.xml.Node with Serializable), _), (_, "foo"), (_, _)
    [warn]     assertTrue((body, "foo") match {
    [warn]                ^
    [warn] src/test/scala/scala/xml/PatternMatching.scala:103: match may not be exhaustive.
    [warn] It would fail on the following inputs: ((_ : Serializable), _), (Node(), _), (Object(), _), (_, "foo"), (_, _)
    [warn]     assertTrue((body: AnyRef, "foo") match {
    [warn]                ^
    [warn] src/test/scala/scala/xml/PatternMatching.scala:108: match may not be exhaustive.
    [warn] It would fail on the following inputs: ((_ : Serializable), _), (Node(), _), (Object(), _), (_, "foo"), (_, _)
    [warn]     assertTrue((body: AnyRef, "foo") match {
    [warn]                ^
    [warn] four warnings found

I added some wildcard case matches to silence the warnings, and it doesn't appear they broke the tests nor undermined their purpose.