### PR TITLE
Exception in JUnit test after disabling JVM forking

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,3 +37,8 @@ libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test"
 libraryDependencies += ("org.scala-lang" % "scala-compiler" % scalaVersion.value % "test").exclude("org.scala-lang.modules", s"scala-xml*")
 
 mimaPreviousVersion := Some("1.0.5")
+
+// You cannot disable JVM test forking when working on scala modules
+// that are distributed with the compiler because of an SBT
+// classloader leaking issue (scala/scala-xml#20 and #112).
+fork in Test := true


### PR DESCRIPTION
Disabling JVM forking while working on #110 causes a JUnit test to fail.

```
$ sbt
> testOnly scala.xml.pull.XMLEventReaderTest 
```

This unit test hasn't been an issue in the past, but was found while trying to troubleshoot a different Travis build error after adding a Scalacheck test suite to scala-xml.  It's not clear if this is the actual issue that adding Scalacheck introduce.  Very likely, it could just be a false lead after desperately trying to understand the original problem.
