### PR TITLE
Utility.trim collapse whitespace for adjacent text nodes #73

### DIFF
--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -46,8 +46,19 @@ object Utility extends AnyRef with parsing.TokenTests {
    */
   def trim(x: Node): Node = x match {
     case Elem(pre, lab, md, scp, child@_*) =>
-      val children = child flatMap trimProper
+      val children = combineAdjacentTextNodes(child:_*) flatMap trimProper
       Elem(pre, lab, md, scp, children.isEmpty, children: _*)
+  }
+
+  private def combineAdjacentTextNodes(children: Node*): Seq[Node] = {
+    children.foldLeft(Seq.empty[Node]) { (acc, n) =>
+      (acc.lastOption, n) match {
+        case (Some(Text(l)), Text(r)) => {
+          acc.dropRight(1) :+ Text(l + r)
+        }
+        case _ => acc :+ n
+      }
+    }
   }
 
   /**
@@ -56,7 +67,7 @@ object Utility extends AnyRef with parsing.TokenTests {
    */
   def trimProper(x: Node): Seq[Node] = x match {
     case Elem(pre, lab, md, scp, child@_*) =>
-      val children = child flatMap trimProper
+      val children = combineAdjacentTextNodes(child:_*) flatMap trimProper
       Elem(pre, lab, md, scp, children.isEmpty, children: _*)
     case Text(s) =>
       new TextBuffer().append(s).toText

--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -51,13 +51,9 @@ object Utility extends AnyRef with parsing.TokenTests {
   }
 
   private def combineAdjacentTextNodes(children: Node*): Seq[Node] = {
-    children.foldLeft(Seq.empty[Node]) { (acc, n) =>
-      (acc.lastOption, n) match {
-        case (Some(Text(l)), Text(r)) => {
-          acc.dropRight(1) :+ Text(l + r)
-        }
-        case _ => acc :+ n
-      }
+    children.foldRight(Seq.empty[Node]) {
+      case (Text(left), Text(right) +: accMinusLast) => Text(left + right) +: accMinusLast
+      case (n, acc) => n +: acc 
     }
   }
 

--- a/shared/src/test/scala/scala/xml/UtilityTest.scala
+++ b/shared/src/test/scala/scala/xml/UtilityTest.scala
@@ -194,4 +194,27 @@ class UtilityTest {
   ).toMap.withDefault {
     key: Char => key.toString
   }
+
+  def issue73StartsWithAndEndsWithWSInFirst: Unit = {
+    val x = <div>{Text("    My name is ")}{Text("Harry")}</div>
+    assertEquals(<div>My name is Harry</div>, Utility.trim(x))
+  }
+
+  @Test
+  def issue73EndsWithWSInLast: Unit = {
+    val x = <div>{Text("My name is ")}{Text("Harry    ")}</div>
+    assertEquals(<div>My name is Harry</div>, Utility.trim(x)) 
+  }
+
+  @Test
+  def issue73HasWSInMiddle: Unit = {
+    val x = <div>{Text("My name is")}{Text(" ")}{Text("Harry")}</div>
+    assertEquals(<div>My name is Harry</div>, Utility.trim(x))
+  }
+
+  @Test
+  def issue73HasWSEverywhere: Unit = {
+    val x = <div>{Text("   My name ")}{Text("  is  ")}{Text("  Harry   ")}</div>
+    assertEquals(<div>My name is Harry</div>, Utility.trim(x))
+  }
 }


### PR DESCRIPTION
This fixes #73. I've got a few unit tests that are passing that verify the text is trimmed.

I have a couple questions regarding the new `combineAdjacentTextNodes` method though:
1. I have it as private right now since it's internal to trimming, but should it be a general utility method? If so, is the method name ok?
2. In the `foldLeft` within that function, I'm accumulating with an immutable `Seq`. If we're going over a lot of nodes that seems like a lost of wasted time copying over arrays, would it be alright to use a mutable `Seq` here for performance, or is there some other buffer I should use? 
