### PR TITLE
Modify SBT to have api mapping to Scala library for scaladoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,12 @@ lazy val xml = crossProject.in(file("."))
     name    := "scala-xml",
     version := "1.0.7-SNAPSHOT",
     scalacOptions         ++= "-deprecation:false -feature -Xlint:-stars-align,-nullary-unit,_".split("\\s+").to[Seq],
-    scalacOptions in Test  += "-Xxml:coalescing")
+    scalacOptions in Test  += "-Xxml:coalescing",
+    apiMappings += (
+      scalaInstance.value.libraryJar
+        -> url(s"http://www.scala-lang.org/api/${scalaVersion.value}/")
+    )
+  )
   .jvmSettings(
     scalaModuleSettings ++
     scalaModuleOsgiSettings ++


### PR DESCRIPTION
This is the solution that I ran across here:

http://stackoverflow.com/questions/18747265/sbt-scaladoc-configuration-for-the-standard-library
