### PR TITLE
Change default encoding in XML.save to UTF-8

### DIFF
--- a/shared/src/main/scala/scala/xml/XML.scala
+++ b/shared/src/main/scala/scala/xml/XML.scala
@@ -63,7 +63,7 @@ object XML extends XMLLoader[Elem] {
   val preserve = "preserve"
   val space = "space"
   val lang = "lang"
-  val encoding = "ISO-8859-1"
+  val encoding = "UTF-8"
 
   /** Returns an XMLLoader whose load* methods will use the supplied SAXParser. */
   def withSAXParser(p: SAXParser): XMLLoader[Elem] =
@@ -82,7 +82,7 @@ object XML extends XMLLoader[Elem] {
   final def save(
     filename: String,
     node: Node,
-    enc: String = encoding,
+    enc: String = "UTF-8",
     xmlDecl: Boolean = false,
     doctype: dtd.DocType = null): Unit =
     {

--- a/shared/src/main/scala/scala/xml/XML.scala
+++ b/shared/src/main/scala/scala/xml/XML.scala
@@ -74,7 +74,7 @@ object XML extends XMLLoader[Elem] {
    *  optionally with xmldecl and doctype declaration.
    *
    *  Note: default encoding was ISO-8859-1 (latin1) in pre-1.0.7 scala-xml versions.
-   *  If your code depends on charaters in non-ASCII latin1 range, specify
+   *  If your code depends on characters in non-ASCII latin1 range, specify
    *  ISO-8859-1 encoding explicitly.
    *
    *  @param filename the filename

--- a/shared/src/main/scala/scala/xml/XML.scala
+++ b/shared/src/main/scala/scala/xml/XML.scala
@@ -73,6 +73,10 @@ object XML extends XMLLoader[Elem] {
    * Saves a node to a file with given filename using given encoding
    *  optionally with xmldecl and doctype declaration.
    *
+   *  Note: default encoding was ISO-8859-1 (latin1) in pre-1.0.7 scala-xml versions.
+   *  If your code depends on charaters in non-ASCII latin1 range, specify
+   *  ISO-8859-1 encoding explicitly.
+   *
    *  @param filename the filename
    *  @param node     the xml node we want to write
    *  @param enc      encoding to use


### PR DESCRIPTION
Was ISO-8859-1, which resulted in encoding errors at runtime if document
contained non-latin1 characters. Also XML spec states that
documents without xml declaration are expected to contain UTF-8 or UTF-16,
 so writing in ISO-8859-1 without xml declaration (which was the default)
can easily break compliant parsers.