### PR TITLE
Add test for ISO-8859-1 defect found with XML.save in #121

### DIFF
--- a/src/test/scala/scala/xml/XMLTest.scala
+++ b/src/test/scala/scala/xml/XMLTest.scala
@@ -631,6 +631,29 @@ expected closing tag of foo
     </wsdl:definitions>""", wsdlTemplate4("service4", () => "target4") toString)
   }
 
+  // Issue found with ISO-8859-1 in #121 that was fixed with UTF-8 default
+  @UnitTest
+  def writeReadNoDeclarationDefaultEncoding: Unit = {
+    val chars = ((32 to 126) ++ (160 to 255)).map(_.toChar)
+    val xml = <x>{ chars.mkString }</x>
+
+    // com.sun.org.apache.xerces.internal.impl.io.MalformedByteSequenceException:
+    // Invalid byte 1 of 1-byte UTF-8 sequence.
+    // scala.xml.XML.save("foo.xml", xml)
+    // scala.xml.XML.loadFile("foo.xml").toString)
+
+    val outputStream = new java.io.ByteArrayOutputStream
+    val streamWriter = new java.io.OutputStreamWriter(outputStream, XML.encoding)
+
+    XML.write(streamWriter, xml, XML.encoding, false, null)
+    streamWriter.flush
+
+    val inputStream = new java.io.ByteArrayInputStream(outputStream.toByteArray)
+    val streamReader = new java.io.InputStreamReader(inputStream)
+
+    assertEquals(xml.toString, XML.load(streamReader).toString)
+  }
+
   @UnitTest
   def t0663 = {
     val src = scala.io.Source.fromString("<?xml version='1.0' encoding='UTF-8'?><feed/>")


### PR DESCRIPTION
Try to closely mimic bug in `XML.save` and `XML.loadFile`, but write tests
that don't use the file system.

Will fail in 1.0.6 and earlier:

    expected:<...klmnopqrstuvwxyz{|}~[ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ]</x>>
    but was:<...klmnopqrstuvwxyz{|}~[????????????????????????????????????????????????????????????????????????????????????????????????]</x>>

Will be fixed in #122.