### PR TITLE
upgrade to sbt 0.13.13

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.13


### PR DESCRIPTION
this is a good thing in general, to be on a modern sbt version.

but also, in the Scala community build some weird dbuild issue
I don't understand is causing scala-xml to be built with 0.13.8
instead of being overridden by dbuild to 0.13.13 like all the
other projects. rather than mess with it, let's just upgrade.