### PR TITLE
Fix circular dependency exclude rule

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val xml = crossProject.in(file("."))
       OsgiKeys.exportPackage := Seq(s"scala.xml.*;version=${version.value}"),
       libraryDependencies += "junit" % "junit" % "4.11" % "test",
       libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test",
-      libraryDependencies += ("org.scala-lang" % "scala-compiler" % scalaVersion.value % "test").exclude("org.scala-lang.modules", s"scala-xml*"),
+      libraryDependencies += ("org.scala-lang" % "scala-compiler" % scalaVersion.value % "test").exclude("org.scala-lang.modules", s"scala-xml_${scalaVersion.value}"),
       mimaPreviousVersion := Some("1.0.6")): _*)
   .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
 


### PR DESCRIPTION
Seems there's no evidence that SBT supports Ivy's exclude globbing even though it was trying to be used to exclude `scala-xml` from `scala-compiler` as a test dependency.  See Ivy documentation http://ant.apache.org/ivy/history/2.4.0/ivyfile/artifact-exclude.html

~~This will revert forking for test in #112.~~
