### PR TITLE
Fix contention due to lzycompute synchronised access in Metadata.normalize

### DIFF
--- a/shared/src/main/scala/scala/xml/MetaData.scala
+++ b/shared/src/main/scala/scala/xml/MetaData.scala
@@ -37,7 +37,7 @@ object MetaData {
    */
   def normalize(attribs: MetaData, scope: NamespaceBinding): MetaData = {
     def iterate(md: MetaData, normalized_attribs: MetaData, set: Set[String]): MetaData = {
-      lazy val key = getUniversalKey(md, scope)
+      def key = getUniversalKey(md, scope)
       if (md eq Null) normalized_attribs
       else if ((md.value eq null) || set(key)) iterate(md.next, normalized_attribs, set)
       else md copy iterate(md.next, normalized_attribs, set + key)

--- a/shared/src/main/scala/scala/xml/MetaData.scala
+++ b/shared/src/main/scala/scala/xml/MetaData.scala
@@ -37,10 +37,18 @@ object MetaData {
    */
   def normalize(attribs: MetaData, scope: NamespaceBinding): MetaData = {
     def iterate(md: MetaData, normalized_attribs: MetaData, set: Set[String]): MetaData = {
-      def key = getUniversalKey(md, scope)
-      if (md eq Null) normalized_attribs
-      else if ((md.value eq null) || set(key)) iterate(md.next, normalized_attribs, set)
-      else md copy iterate(md.next, normalized_attribs, set + key)
+      if (md eq Null) {
+        normalized_attribs
+      } else if (md.value eq null) {
+        iterate(md.next, normalized_attribs, set)
+      } else {
+        val key = getUniversalKey(md, scope)
+        if (set(key)) {
+          iterate(md.next, normalized_attribs, set)
+        } else {
+          md copy iterate(md.next, normalized_attribs, set + key)
+        }
+      }
     }
     iterate(attribs, Null, Set())
   }


### PR DESCRIPTION
Our performance traces show that `Metadata.normalize` uses a `lazy val` which leads to `lzycompute` synchronised access and lock contention. 

```Stack Trace	Count	Duration
scala.xml.MetaData$.key$lzycompute$1(NamespaceBinding, MetaData, ObjectRef, VolatileByteRef)	4,954	120,519,787,655
   scala.xml.MetaData$.key$1(NamespaceBinding, MetaData, ObjectRef, VolatileByteRef)	4,954	120,519,787,655
      scala.xml.MetaData$.iterate$1(MetaData, MetaData, Set, NamespaceBinding)	4,954	120,519,787,655
         scala.xml.MetaData$.iterate$1(MetaData, MetaData, Set, NamespaceBinding)	3,028	73,017,044,016
         scala.xml.MetaData$.normalize(MetaData, NamespaceBinding)	1,926	47,502,743,639
            scala.xml.Elem.<init>(String, String, MetaData, NamespaceBinding, boolean, Seq)	1,926	47,502,743,639
               scala.xml.Elem$.apply(String, String, MetaData, NamespaceBinding, boolean, Seq)	1,387	33,803,514,665
```

Replacing it with a `def` should resolve this, which this PR does.