### PR TITLE
Fix unused imports

### DIFF
--- a/jvm/src/test/scala/scala/xml/ReuseNodesTest.scala
+++ b/jvm/src/test/scala/scala/xml/ReuseNodesTest.scala
@@ -1,9 +1,6 @@
 package scala.xml
 
 import scala.xml.transform._
-import org.junit.Test
-import org.junit.Assert.assertTrue
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.experimental.theories.Theories
 import org.junit.experimental.theories.Theory

--- a/jvm/src/test/scala/scala/xml/XMLSyntaxTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLSyntaxTest.scala
@@ -2,10 +2,6 @@ package scala.xml
 
 import org.junit.Test
 import org.junit.Ignore
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Assert.assertTrue
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
 
 class XMLSyntaxTestJVM {

--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -3,15 +3,11 @@ package scala.xml
 import language.postfixOps
 
 import org.junit.{Test => UnitTest}
-import org.junit.Ignore
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
 import scala.xml.parsing.ConstructingParser
 import java.io.StringWriter
-import java.io.BufferedOutputStream
 import java.io.ByteArrayOutputStream
 import java.io.StringReader
 import scala.collection.Iterable
@@ -495,7 +491,6 @@ class XMLTestJVM {
   }
 
   import java.io.{ Console => _, _ }
-  import scala.io._
   import scala.xml.parsing._
   @UnitTest
   def dontLoop: Unit = {

--- a/jvm/src/test/scala/scala/xml/parsing/PiParsingTest.scala
+++ b/jvm/src/test/scala/scala/xml/parsing/PiParsingTest.scala
@@ -1,9 +1,6 @@
 package scala.xml.parsing
 
 import org.junit.Test
-import org.junit.Ignore
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import scala.xml.JUnitAssertsForXML.assertEquals
 
 class PiParsingTestJVM {

--- a/jvm/src/test/scala/scala/xml/parsing/Ticket0632Test.scala
+++ b/jvm/src/test/scala/scala/xml/parsing/Ticket0632Test.scala
@@ -2,15 +2,13 @@ package scala.xml.parsing
 
 import org.junit.Test
 import org.junit.Ignore
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import scala.xml.JUnitAssertsForXML.assertEquals
 
 class Ticket0632TestJVM {
 
   import scala.io.Source.fromString
   import scala.xml.parsing.ConstructingParser.fromSource
-  import scala.xml.{NodeSeq, TopScope}
+  import scala.xml.TopScope
   private def parse(s:String) = fromSource(fromString(s), false).element(TopScope)
 
   @Test

--- a/shared/src/main/scala/scala/xml/MetaData.scala
+++ b/shared/src/main/scala/scala/xml/MetaData.scala
@@ -11,7 +11,7 @@ package xml
 
 import Utility.sbToString
 import scala.annotation.tailrec
-import scala.collection.{ AbstractIterable, Iterator }
+import scala.collection.AbstractIterable
 
 /**
  * Copyright 2008 Google Inc. All Rights Reserved.

--- a/shared/src/main/scala/scala/xml/NodeSeq.scala
+++ b/shared/src/main/scala/scala/xml/NodeSeq.scala
@@ -43,7 +43,6 @@ object NodeSeq {
  *  @version 1.0
  */
 abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with SeqLike[Node, NodeSeq] with Equality {
-  import NodeSeq.seqToNodeSeq // import view magic for NodeSeq wrappers
 
   /** Creates a list buffer as builder for this class */
   override protected[this] def newBuilder = NodeSeq.newBuilder

--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -10,7 +10,6 @@ package scala
 package xml
 
 import scala.collection.mutable
-import parsing.XhtmlEntities
 import scala.language.implicitConversions
 
 /**
@@ -105,7 +104,7 @@ object Utility extends AnyRef with parsing.TokenTests {
     val escMap = pairs map { case (s, c) => c -> ("&%s;" format s) }
     val unescMap = pairs ++ Map("apos" -> '\'')
   }
-  import Escapes.{ escMap, unescMap }
+  import Escapes.unescMap
 
   /**
    * Appends escaped string to `s`.

--- a/shared/src/main/scala/scala/xml/XML.scala
+++ b/shared/src/main/scala/scala/xml/XML.scala
@@ -9,10 +9,9 @@
 package scala
 package xml
 
-import parsing.NoBindingFactoryAdapter
 import factory.XMLLoader
 import java.io.{ File, FileDescriptor, FileInputStream, FileOutputStream }
-import java.io.{ InputStream, Reader, StringReader, Writer }
+import java.io.{ InputStream, Reader, StringReader }
 import java.nio.channels.Channels
 import scala.util.control.Exception.ultimately
 

--- a/shared/src/main/scala/scala/xml/dtd/impl/DetWordAutom.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/DetWordAutom.scala
@@ -9,8 +9,6 @@
 package scala
 package xml.dtd.impl
 
-import scala.collection.{ mutable, immutable }
-
 /**
  * A deterministic automaton. States are integers, where
  *  0 is always the only initial state. Transitions are represented
@@ -26,7 +24,7 @@ import scala.collection.{ mutable, immutable }
 private[dtd] abstract class DetWordAutom[T <: AnyRef] {
   val nstates: Int
   val finals: Array[Int]
-  val delta: Array[mutable.Map[T, Int]]
+  val delta: Array[scala.collection.mutable.Map[T, Int]]
   val default: Array[Int]
 
   def isFinal(q: Int) = finals(q) != 0

--- a/shared/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
@@ -23,7 +23,7 @@ import scala.collection.{ immutable, mutable }
 private[dtd] abstract class WordBerrySethi extends BaseBerrySethi {
   override val lang: WordExp
 
-  import lang.{ Alt, Eps, Letter, RegExp, Sequ, Star, _labelT }
+  import lang.{ Eps, Letter, RegExp, Sequ, _labelT }
 
   protected var labels: mutable.HashSet[_labelT] = _
   // don't let this fool you, only labelAt is a real, surjective mapping

--- a/shared/src/main/scala/scala/xml/factory/NodeFactory.scala
+++ b/shared/src/main/scala/scala/xml/factory/NodeFactory.scala
@@ -10,9 +10,6 @@ package scala
 package xml
 package factory
 
-import parsing.{ FactoryAdapter, NoBindingFactoryAdapter }
-import java.io.{ InputStream, Reader, StringReader, File, FileDescriptor, FileInputStream }
-
 trait NodeFactory[A <: Node] {
   val ignoreComments = false
   val ignoreProcInstr = false

--- a/shared/src/main/scala/scala/xml/include/sax/EncodingHeuristics.scala
+++ b/shared/src/main/scala/scala/xml/include/sax/EncodingHeuristics.scala
@@ -11,7 +11,6 @@ package xml
 package include.sax
 
 import java.io.InputStream
-import scala.util.matching.Regex
 
 /**
  * `EncodingHeuristics` reads from a stream

--- a/shared/src/main/scala/scala/xml/include/sax/XIncludeFilter.scala
+++ b/shared/src/main/scala/scala/xml/include/sax/XIncludeFilter.scala
@@ -15,7 +15,7 @@ import scala.xml.include._
 import org.xml.sax.{ Attributes, XMLReader, Locator }
 import org.xml.sax.helpers.{ XMLReaderFactory, XMLFilterImpl, NamespaceSupport, AttributesImpl }
 
-import java.io.{ InputStream, BufferedInputStream, InputStreamReader, IOException, UnsupportedEncodingException }
+import java.io.{ BufferedInputStream, InputStreamReader, IOException, UnsupportedEncodingException }
 import java.util.Stack
 import java.net.{ URL, MalformedURLException }
 

--- a/shared/src/main/scala/scala/xml/include/sax/XIncluder.scala
+++ b/shared/src/main/scala/scala/xml/include/sax/XIncluder.scala
@@ -11,9 +11,9 @@ package xml
 package include.sax
 
 import scala.collection.mutable
-import org.xml.sax.{ ContentHandler, XMLReader, Locator, Attributes }
+import org.xml.sax.{ ContentHandler, Locator, Attributes }
 import org.xml.sax.ext.LexicalHandler
-import java.io.{ File, OutputStream, OutputStreamWriter, Writer, IOException }
+import java.io.{ OutputStream, OutputStreamWriter, IOException }
 
 /**
  * XIncluder is a SAX `ContentHandler` that writes its XML document onto

--- a/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
@@ -10,7 +10,6 @@ package scala
 package xml
 package parsing
 
-import java.io.{ InputStream, Reader, File, FileDescriptor, FileInputStream }
 import scala.collection.{ mutable, Iterator }
 import org.xml.sax.Attributes
 import org.xml.sax.helpers.DefaultHandler

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
@@ -10,10 +10,6 @@ package scala
 package xml
 package parsing
 
-import scala.io.Source
-import scala.annotation.switch
-import Utility.Escapes.{ pairs => unescape }
-
 import Utility.SU
 
 /**

--- a/shared/src/main/scala/scala/xml/persistent/CachedFileStorage.scala
+++ b/shared/src/main/scala/scala/xml/persistent/CachedFileStorage.scala
@@ -11,7 +11,6 @@ package xml
 package persistent
 
 import java.io.{ File, FileOutputStream }
-import java.nio.ByteBuffer
 import java.nio.channels.Channels
 import java.lang.Thread
 

--- a/shared/src/test/scala/scala/xml/AttributeTest.scala
+++ b/shared/src/test/scala/scala/xml/AttributeTest.scala
@@ -1,11 +1,6 @@
 package scala.xml
 
 import org.junit.Test
-import org.junit.Ignore
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Assert.assertTrue
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
 
 class AttributeTest {

--- a/shared/src/test/scala/scala/xml/MetaDataTest.scala
+++ b/shared/src/test/scala/scala/xml/MetaDataTest.scala
@@ -1,9 +1,6 @@
 package scala.xml
 
 import org.junit.Test
-import org.junit.Ignore
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import org.junit.Assert.assertEquals
 
 class MetaDataTest {

--- a/shared/src/test/scala/scala/xml/PrintEmptyElementsTest.scala
+++ b/shared/src/test/scala/scala/xml/PrintEmptyElementsTest.scala
@@ -1,9 +1,6 @@
 package scala.xml
 
 import org.junit.Test
-import org.junit.Ignore
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import JUnitAssertsForXML.assertEquals
 
 class PrintEmptyElementsTest {

--- a/shared/src/test/scala/scala/xml/UtilityTest.scala
+++ b/shared/src/test/scala/scala/xml/UtilityTest.scala
@@ -1,9 +1,6 @@
 package scala.xml
 
 import org.junit.Test
-import org.junit.Ignore
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals

--- a/shared/src/test/scala/scala/xml/XMLEmbeddingTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLEmbeddingTest.scala
@@ -1,11 +1,6 @@
 package scala.xml
 
 import org.junit.Test
-import org.junit.Ignore
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Assert.assertTrue
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
 
 class XMLEmbeddingTest {

--- a/shared/src/test/scala/scala/xml/XMLSyntaxTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLSyntaxTest.scala
@@ -1,9 +1,6 @@
 package scala.xml
 
 import org.junit.Test
-import org.junit.Ignore
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals

--- a/shared/src/test/scala/scala/xml/XMLTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLTest.scala
@@ -3,17 +3,11 @@ package scala.xml
 import language.postfixOps
 
 import org.junit.{Test => UnitTest}
-import org.junit.Ignore
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
 // import scala.xml.parsing.ConstructingParser
 import java.io.StringWriter
-import java.io.BufferedOutputStream
-import java.io.ByteArrayOutputStream
-import java.io.StringReader
 import scala.collection.Iterable
 import scala.xml.Utility.sort
 
@@ -23,8 +17,6 @@ object XMLTest {
 }
 
 class XMLTest {
-  import XMLTest.{ e, sc }
-
   @UnitTest
   def nodeSeq: Unit = {
     val p = <foo>
@@ -247,8 +239,6 @@ class XMLTest {
     val x = <flog xmlns:ee="http://ee.com"><foo xmlns:dog="http://dog.com"><dog:cat/></foo></flog>
     assertTrue(x.toString.matches(".*xmlns:dog=\"http://dog.com\".*"));
   }
-
-  import NodeSeq.seqToNodeSeq
 
   val ax = <hello foo="bar" x:foo="baz" xmlns:x="the namespace from outer space">
              <world/>

--- a/shared/src/test/scala/scala/xml/parsing/PiParsingTest.scala
+++ b/shared/src/test/scala/scala/xml/parsing/PiParsingTest.scala
@@ -1,23 +1,15 @@
 package scala.xml.parsing
 
 import org.junit.Test
-import org.junit.Ignore
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import scala.xml.JUnitAssertsForXML.assertEquals
 
 class PiParsingTest {
-
-
-  import scala.io.Source.fromString
-  import scala.xml.TopScope
 
   @Test
   def piNoWSLiteral: Unit = {
     val expected = "<foo>a<?pi?>b</foo>"
     assertEquals(expected, <foo>a<?pi?>b</foo>)
   }
-
 
   @Test
   def piLiteral: Unit = {

--- a/shared/src/test/scala/scala/xml/parsing/Ticket0632Test.scala
+++ b/shared/src/test/scala/scala/xml/parsing/Ticket0632Test.scala
@@ -1,15 +1,9 @@
 package scala.xml.parsing
 
 import org.junit.Test
-import org.junit.Ignore
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import scala.xml.JUnitAssertsForXML.assertEquals
 
 class Ticket0632Test {
-
-  import scala.io.Source.fromString
-  import scala.xml.{NodeSeq, TopScope}
 
   @Test
   def singleAmp: Unit = {


### PR DESCRIPTION
More warnings are enabled by default linter starting in Scala 2.12.2

See scala/scala#5402