### PR TITLE
Fix Scaladoc warnings for JDK refs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,9 +21,12 @@ lazy val xml = crossProject.in(file("."))
     version := "1.0.7-SNAPSHOT",
     scalacOptions         ++= "-deprecation:false -feature -Xlint:-stars-align,-nullary-unit,_".split("\\s+").to[Seq],
     scalacOptions in Test  += "-Xxml:coalescing",
-    apiMappings += (
+    apiMappings ++= Map(
       scalaInstance.value.libraryJar
-        -> url(s"http://www.scala-lang.org/api/${scalaVersion.value}/")
+        -> url(s"http://www.scala-lang.org/api/${scalaVersion.value}/"),
+      // http://stackoverflow.com/questions/16934488
+      file(System.getProperty("sun.boot.class.path").split(java.io.File.pathSeparator).filter(_.endsWith(java.io.File.separator + "rt.jar")).head)
+        -> url("http://docs.oracle.com/javase/8/docs/api")
     )
   )
   .jvmSettings(

--- a/shared/src/main/scala/scala/xml/include/sax/EncodingHeuristics.scala
+++ b/shared/src/main/scala/scala/xml/include/sax/EncodingHeuristics.scala
@@ -41,7 +41,7 @@ object EncodingHeuristics {
    * [[http://www.w3.org/TR/xml/#sec-guessing w3]].
    *
    * @param    in   `InputStream` to read from.
-   * @throws IOException if the stream cannot be reset
+   * @throws java.io.IOException if the stream cannot be reset
    * @return         the name of the encoding.
    */
   def readEncodingFromStream(in: InputStream): String = {


### PR DESCRIPTION
For now just validate and create a link and avoid the warning.  The links don't deep-link currently, but that can be a follow-up.

Based on code posted at http://stackoverflow.com/questions/16934488

Possibly lift java version from https://github.com/scala/sbt-scala-modules plugin `scalaVersionsByJvm`.