### PR TITLE
Fix 2.12 warnings

### DIFF
--- a/jvm/src/test/scala/scala/xml/XMLSyntaxTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLSyntaxTest.scala
@@ -1,7 +1,6 @@
 package scala.xml
 
 import org.junit.Test
-import org.junit.Ignore
 import org.junit.Assert.assertEquals
 
 class XMLSyntaxTestJVM {

--- a/jvm/src/test/scala/scala/xml/parsing/Ticket0632Test.scala
+++ b/jvm/src/test/scala/scala/xml/parsing/Ticket0632Test.scala
@@ -1,7 +1,6 @@
 package scala.xml.parsing
 
 import org.junit.Test
-import org.junit.Ignore
 import scala.xml.JUnitAssertsForXML.assertEquals
 
 class Ticket0632TestJVM {

--- a/shared/src/test/scala/scala/xml/PatternMatching.scala
+++ b/shared/src/test/scala/scala/xml/PatternMatching.scala
@@ -80,7 +80,7 @@ class PatternMatching extends {
     })
 
     // SI-1059
-    var m: PartialFunction[Any, Any] = { case SafeNodeSeq(s @ _*) => s }
+    val m: PartialFunction[Any, Any] = { case SafeNodeSeq(s @ _*) => s }
 
     assertEquals(m(<a/> ++ <b/>), List(<a/>, <b/>))
     assertTrue(m.isDefinedAt(<a/> ++ <b/>))

--- a/shared/src/test/scala/scala/xml/Transformers.scala
+++ b/shared/src/test/scala/scala/xml/Transformers.scala
@@ -3,7 +3,6 @@ package scala.xml
 import scala.xml.transform._
 
 import org.junit.Test
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
 
 class Transformers {

--- a/shared/src/test/scala/scala/xml/XMLTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLTest.scala
@@ -261,7 +261,6 @@ class XMLTest {
 
   @UnitTest
   def XmlEy {
-    val z = ax \ "@{the namespace from outer space}foo"
     assertTrue((ax \ "@{the namespace from outer space}foo") xml_== "baz")
     assertTrue((cx \ "@{the namespace from outer space}foo") xml_== "baz")
 


### PR DESCRIPTION
This is a follow-up to #143

- Unused imports
- Unused code (in tests)
- Local var never set (convert to val)
```
[warn] scala-xml/jvm/src/test/scala/scala/xml/XMLSyntaxTest.scala:4: Unused import
[warn] import org.junit.Ignore
[warn]
[warn] jvm/src/test/scala/scala/xml/parsing/Ticket0632Test.scala:4: Unused import
[warn] import org.junit.Ignore
[warn]                  ^
[warn] shared/src/test/scala/scala/xml/PatternMatching.scala:83: local var m in method nodeSeq is never set: consider using immutable val
[warn]     var m: PartialFunction[Any, Any] = { case SafeNodeSeq(s @ _*) => s }
[warn]         ^
[warn] shared/src/test/scala/scala/xml/Transformers.scala:6: Unused import
[warn] import org.junit.Assert.assertTrue
[warn]                         ^
[warn] shared/src/test/scala/scala/xml/XMLTest.scala:264: local val z in method XmlEy is never used
[warn]     val z = ax \ "@{the namespace from outer space}foo"
[warn]                ^
[warn] three warnings found
[warn] 3 warnings found
```

This will fix all the warnings for 2.12 except for the ones from `Stack`, which see #147 