### PR TITLE
Update sbt-scala-module to 1.0.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,43 +13,53 @@ scalaVersionsByJvm in ThisBuild := {
 
 lazy val root = project.in(file("."))
   .aggregate(xmlJS, xmlJVM)
-  .settings(publish := {}, publishLocal := {})
+  .settings(disablePublishing)
 
 lazy val xml = crossProject.in(file("."))
+  .settings(scalaModuleSettings)
+  .jvmSettings(scalaModuleSettingsJVM)
   .settings(
     name    := "scala-xml",
     version := "1.0.7-SNAPSHOT",
+
     scalacOptions         ++= "-deprecation:false -feature -Xlint:-stars-align,-nullary-unit,_".split("\\s+").to[Seq],
     scalacOptions in Test  += "-Xxml:coalescing",
+
     apiMappings ++= Map(
       scalaInstance.value.libraryJar
         -> url(s"http://www.scala-lang.org/api/${scalaVersion.value}/"),
       // http://stackoverflow.com/questions/16934488
       file(System.getProperty("sun.boot.class.path").split(java.io.File.pathSeparator).filter(_.endsWith(java.io.File.separator + "rt.jar")).head)
         -> url("http://docs.oracle.com/javase/8/docs/api")
-    )
-  )
+    ),
+
+    mimaBinaryIssueFilters ++= {
+      import com.typesafe.tools.mima.core._
+      import com.typesafe.tools.mima.core.ProblemFilters._
+      Seq(
+        // Scala 2.12 deprecated mutable.Stack, so we broke
+        // binary compatability for 1.0.7 in the following way:
+        exclude[IncompatibleMethTypeProblem]("scala.xml.parsing.FactoryAdapter.scopeStack_="),
+        exclude[IncompatibleResultTypeProblem]("scala.xml.parsing.FactoryAdapter.hStack"),
+        exclude[IncompatibleResultTypeProblem]("scala.xml.parsing.FactoryAdapter.scopeStack"),
+        exclude[IncompatibleResultTypeProblem]("scala.xml.parsing.FactoryAdapter.attribStack"),
+        exclude[IncompatibleResultTypeProblem]("scala.xml.parsing.FactoryAdapter.tagStack")
+      )
+    })
   .jvmSettings(
-    scalaModuleSettings ++
-    List(
-      OsgiKeys.exportPackage := Seq(s"scala.xml.*;version=${version.value}"),
-      libraryDependencies += "junit" % "junit" % "4.11" % "test",
-      libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test",
-      libraryDependencies += ("org.scala-lang" % "scala-compiler" % scalaVersion.value % "test").exclude("org.scala-lang.modules", s"scala-xml_${scalaVersion.value}"),
-      mimaBinaryIssueFilters ++= {
-        import com.typesafe.tools.mima.core._
-        import com.typesafe.tools.mima.core.ProblemFilters._
-        Seq(
-          // Scala 2.12 deprecated mutable.Stack, so we broke
-          // binary compatability for 1.0.7 in the following way:
-          exclude[IncompatibleMethTypeProblem]("scala.xml.parsing.FactoryAdapter.scopeStack_="),
-          exclude[IncompatibleResultTypeProblem]("scala.xml.parsing.FactoryAdapter.hStack"),
-          exclude[IncompatibleResultTypeProblem]("scala.xml.parsing.FactoryAdapter.scopeStack"),
-          exclude[IncompatibleResultTypeProblem]("scala.xml.parsing.FactoryAdapter.attribStack"),
-          exclude[IncompatibleResultTypeProblem]("scala.xml.parsing.FactoryAdapter.tagStack")
-        )
-      },
-      mimaPreviousVersion := Some("1.0.6")): _*)
+    OsgiKeys.exportPackage := Seq(s"scala.xml.*;version=${version.value}"),
+
+    // there is currently no previous released JS version, therefore MiMa is enabled only on JVM
+    mimaPreviousVersion := Some("1.0.6"),
+
+    libraryDependencies += "junit" % "junit" % "4.11" % "test",
+    libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test",
+    libraryDependencies += ("org.scala-lang" % "scala-compiler" % scalaVersion.value % "test").exclude("org.scala-lang.modules", s"scala-xml_${scalaVersion.value}")
+  )
+  .jsSettings(
+    // Scala.js cannot run forked tests
+    fork in Test := false
+  )
   .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
 
 lazy val xmlJVM = xml.jvm

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.8")
+addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.8")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.16")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.8")
+addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.12")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.16")


### PR DESCRIPTION
Upgrade the shared sbt plugin to pick up the improvement from scala/sbt-scala-module#27 in preparation of making release, see #152.