### PR TITLE
Improve wording on stack deprecation

### DIFF
--- a/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
@@ -42,28 +42,28 @@ abstract class FactoryAdapter extends DefaultHandler with factory.XMLLoader[Node
     * 
     * Previously was a mutable [[scala.collection.mutable.Stack Stack]], but is now a mutable reference to an immutable [[scala.collection.immutable.List List]].
     * 
-    * @since 1.0.7 
+    * @since 1.1.0 
     */
   var attribStack = List.empty[MetaData]
   /** List of elements
     * 
     * Previously was a mutable [[scala.collection.mutable.Stack Stack]], but is now a mutable reference to an immutable [[scala.collection.immutable.List List]].
     * 
-    * @since 1.0.7 
+    * @since 1.1.0 
     */
   var hStack = List.empty[Node] // [ element ] contains siblings
   /** List of element names
     * 
     * Previously was a mutable [[scala.collection.mutable.Stack Stack]], but is now a mutable reference to an immutable [[scala.collection.immutable.List List]].
     * 
-    * @since 1.0.7 
+    * @since 1.1.0 
     */
   var tagStack = List.empty[String]
   /** List of namespaces
     * 
     * Previously was a mutable [[scala.collection.mutable.Stack Stack]], but is now a mutable reference to an immutable [[scala.collection.immutable.List List]].
     * 
-    * @since 1.0.7 
+    * @since 1.1.0 
     */
   var scopeStack = List.empty[NamespaceBinding]
 

--- a/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
@@ -40,28 +40,28 @@ abstract class FactoryAdapter extends DefaultHandler with factory.XMLLoader[Node
   val buffer = new StringBuilder()
   /** List of attributes
     * 
-    * Previously was a [[scala.collection.mutable.Stack]], but is now a mutable [[scala.collection.immutable.List]].
+    * Previously was a mutable [[scala.collection.mutable.Stack Stack]], but is now a mutable reference to an immutable [[scala.collection.immutable.List List]].
     * 
     * @since 1.0.7 
     */
   var attribStack = List.empty[MetaData]
   /** List of elements
     * 
-    * Previously was a [[scala.collection.mutable.Stack]], but is now a mutable [[scala.collection.immutable.List]].
+    * Previously was a mutable [[scala.collection.mutable.Stack Stack]], but is now a mutable reference to an immutable [[scala.collection.immutable.List List]].
     * 
     * @since 1.0.7 
     */
   var hStack = List.empty[Node] // [ element ] contains siblings
   /** List of element names
     * 
-    * Previously was a [[scala.collection.mutable.Stack]], but is now a mutable [[scala.collection.immutable.List]].
+    * Previously was a mutable [[scala.collection.mutable.Stack Stack]], but is now a mutable reference to an immutable [[scala.collection.immutable.List List]].
     * 
     * @since 1.0.7 
     */
   var tagStack = List.empty[String]
   /** List of namespaces
     * 
-    * Previously was a [[scala.collection.mutable.Stack]], but is now a mutable [[scala.collection.immutable.List]].
+    * Previously was a mutable [[scala.collection.mutable.Stack Stack]], but is now a mutable reference to an immutable [[scala.collection.immutable.List List]].
     * 
     * @since 1.0.7 
     */


### PR DESCRIPTION
A usability study of one person found that the note documenting the compatibility change in `FactoryAdapter` in #150 was confusing.  This is the improved wording as suggested by the same participant in the study.