### PR TITLE
Reverting PR #150

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,21 +31,8 @@ lazy val xml = crossProject.in(file("."))
       // http://stackoverflow.com/questions/16934488
       file(System.getProperty("sun.boot.class.path").split(java.io.File.pathSeparator).filter(_.endsWith(java.io.File.separator + "rt.jar")).head)
         -> url("http://docs.oracle.com/javase/8/docs/api")
-    ),
-
-    mimaBinaryIssueFilters ++= {
-      import com.typesafe.tools.mima.core._
-      import com.typesafe.tools.mima.core.ProblemFilters._
-      Seq(
-        // Scala 2.12 deprecated mutable.Stack, so we broke
-        // binary compatibility for 1.1.0 in the following way:
-        exclude[IncompatibleMethTypeProblem]("scala.xml.parsing.FactoryAdapter.scopeStack_="),
-        exclude[IncompatibleResultTypeProblem]("scala.xml.parsing.FactoryAdapter.hStack"),
-        exclude[IncompatibleResultTypeProblem]("scala.xml.parsing.FactoryAdapter.scopeStack"),
-        exclude[IncompatibleResultTypeProblem]("scala.xml.parsing.FactoryAdapter.attribStack"),
-        exclude[IncompatibleResultTypeProblem]("scala.xml.parsing.FactoryAdapter.tagStack")
-      )
-    })
+    )
+  )
   .jvmSettings(
     OsgiKeys.exportPackage := Seq(s"scala.xml.*;version=${version.value}"),
 

--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -40,8 +40,8 @@ class XMLTestJVM {
       override def text = ""
     }
 
-    assertEquals(c, parsedxml11)
-    assertEquals(parsedxml1, parsedxml11)
+    assertTrue(c == parsedxml11)
+    assertTrue(parsedxml1 == parsedxml11)
     assertTrue(List(parsedxml1) sameElements List(parsedxml11))
     assertTrue(Array(parsedxml1).toList sameElements List(parsedxml11))
 
@@ -50,10 +50,10 @@ class XMLTestJVM {
     val i = new InputSource(new StringReader(x2))
     val x2p = scala.xml.XML.load(i)
 
-    assertEquals(Elem(null, "book", e, sc,
+    assertTrue(x2p == Elem(null, "book", e, sc,
       Elem(null, "author", e, sc, Text("Peter Buneman")),
       Elem(null, "author", e, sc, Text("Dan Suciu")),
-      Elem(null, "title", e, sc, Text("Data on ze web"))), x2p)
+      Elem(null, "title", e, sc, Text("Data on ze web"))))
 
   }
 
@@ -454,16 +454,16 @@ class XMLTestJVM {
   @UnitTest
   def t6939 = {
     val foo = <x:foo xmlns:x="http://foo.com/"><x:bar xmlns:x="http://bar.com/"><x:baz/></x:bar></x:foo>
-    assertEquals(foo.child.head.scope.toString, """ xmlns:x="http://bar.com/"""")
+    assertTrue(foo.child.head.scope.toString == """ xmlns:x="http://bar.com/"""")
 
     val fooDefault = <foo xmlns="http://foo.com/"><bar xmlns="http://bar.com/"><baz/></bar></foo>
-    assertEquals(fooDefault.child.head.scope.toString, """ xmlns="http://bar.com/"""")
+    assertTrue(fooDefault.child.head.scope.toString == """ xmlns="http://bar.com/"""")
 
     val foo2 = scala.xml.XML.loadString("""<x:foo xmlns:x="http://foo.com/"><x:bar xmlns:x="http://bar.com/"><x:baz/></x:bar></x:foo>""")
-    assertEquals(foo2.child.head.scope.toString, """ xmlns:x="http://bar.com/"""")
+    assertTrue(foo2.child.head.scope.toString == """ xmlns:x="http://bar.com/"""")
 
     val foo2Default = scala.xml.XML.loadString("""<foo xmlns="http://foo.com/"><bar xmlns="http://bar.com/"><baz/></bar></foo>""")
-    assertEquals(foo2Default.child.head.scope.toString, """ xmlns="http://bar.com/"""")
+    assertTrue(foo2Default.child.head.scope.toString == """ xmlns="http://bar.com/"""")
   }
 
   @UnitTest

--- a/shared/src/main/scala/scala/xml/dtd/impl/SubsetConstruction.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/SubsetConstruction.scala
@@ -32,9 +32,9 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
     val delta = new mutable.HashMap[immutable.BitSet, mutable.HashMap[T, immutable.BitSet]]
     var deftrans = mutable.Map(q0 -> sink, sink -> sink) // initial transitions
     var finals: mutable.Map[immutable.BitSet, Int] = mutable.Map()
-    var rest = immutable.List.empty[immutable.BitSet]
+    val rest = new mutable.Stack[immutable.BitSet]
 
-    rest = q0 :: sink :: rest
+    rest.push(sink, q0)
 
     def addFinal(q: immutable.BitSet) {
       if (nfa containsFinal q)
@@ -43,7 +43,7 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
     def add(Q: immutable.BitSet) {
       if (!states(Q)) {
         states += Q
-        rest = Q :: rest
+        rest push Q
         addFinal(Q)
       }
     }
@@ -51,8 +51,7 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
     addFinal(q0) // initial state may also be a final state
 
     while (!rest.isEmpty) {
-      val P = rest.head
-      rest = rest.tail
+      val P = rest.pop()
       // assign a number to this bitset
       indexMap = indexMap.updated(P, ix)
       invIndexMap = invIndexMap.updated(ix, P)

--- a/shared/src/main/scala/scala/xml/factory/XMLLoader.scala
+++ b/shared/src/main/scala/scala/xml/factory/XMLLoader.scala
@@ -37,9 +37,9 @@ trait XMLLoader[T <: Node] {
   def loadXML(source: InputSource, parser: SAXParser): T = {
     val newAdapter = adapter
 
-    newAdapter.scopeStack = TopScope :: newAdapter.scopeStack
+    newAdapter.scopeStack push TopScope
     parser.parse(source, newAdapter)
-    newAdapter.scopeStack = newAdapter.scopeStack.tail
+    newAdapter.scopeStack.pop()
 
     newAdapter.rootElem.asInstanceOf[T]
   }

--- a/shared/src/main/scala/scala/xml/include/sax/XIncluder.scala
+++ b/shared/src/main/scala/scala/xml/include/sax/XIncluder.scala
@@ -10,6 +10,7 @@ package scala
 package xml
 package include.sax
 
+import scala.collection.mutable
 import org.xml.sax.{ ContentHandler, Locator, Attributes }
 import org.xml.sax.ext.LexicalHandler
 import java.io.{ OutputStream, OutputStreamWriter, IOException }
@@ -125,7 +126,7 @@ class XIncluder(outs: OutputStream, encoding: String) extends ContentHandler wit
 
   // LexicalHandler methods
   private var inDTD: Boolean = false
-  private var entities = List.empty[String]
+  private val entities = new mutable.Stack[String]()
 
   def startDTD(name: String, publicID: String, systemID: String) {
     inDTD = true
@@ -144,12 +145,12 @@ class XIncluder(outs: OutputStream, encoding: String) extends ContentHandler wit
   }
   def endDTD() {}
 
-  def startEntity(name: String): Unit = {
-    entities =  name :: entities
+  def startEntity(name: String) {
+    entities push name
   }
 
-  def endEntity(name: String): Unit = {
-    entities = entities.tail
+  def endEntity(name: String) {
+    entities.pop()
   }
 
   def startCDATA() {}


### PR DESCRIPTION
This is a second attempt at reverting #150 after it was found out that binary compatabilities, which is discussed at #150.   This is based on a commit from Joe's first revert attempt in #159.  There is some non-critical test suite clean-up that is being reverted, too, which is no big loss.

We can try to resurrect the original removal of deprecation warnings (and test cleanup) at a later time.  These fixes are blocked by scala-xml version being pinned as a compiler dependency in sbt.