### PR TITLE
Fix Java 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ env:
 
 script: admin/build.sh
 
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+
 jdk:
   - openjdk6
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val xml = crossProject.in(file("."))
 
     libraryDependencies += "junit" % "junit" % "4.11" % "test",
     libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test",
-    libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.6" % "test",
+    libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.5" % "test",
     libraryDependencies += ("org.scala-lang" % "scala-compiler" % scalaVersion.value % "test").exclude("org.scala-lang.modules", s"scala-xml_${scalaVersion.value}")
   )
   .jsSettings(

--- a/jvm/src/test/scala/scala/xml/JavaByteSerialization.scala
+++ b/jvm/src/test/scala/scala/xml/JavaByteSerialization.scala
@@ -1,7 +1,6 @@
 package scala.xml
 
 import java.io.Serializable
-import java.util.Base64
 import org.apache.commons.lang3.SerializationUtils
 
 object JavaByteSerialization {
@@ -15,13 +14,5 @@ object JavaByteSerialization {
 
   def deserialize[T <: Serializable](in: Array[Byte]): T = {
     SerializationUtils.deserialize(in)
-  }
-
-  def base64Encode[T <: Serializable](in: T): String = {
-    Base64.getEncoder.encodeToString(serialize[T](in))
-  }
-
-  def base64Decode[T <: Serializable](in: String): T = {
-    deserialize[T](Base64.getDecoder.decode(in))
   }
 }

--- a/jvm/src/test/scala/scala/xml/SerializationTest.scala
+++ b/jvm/src/test/scala/scala/xml/SerializationTest.scala
@@ -27,11 +27,4 @@ class SerializationTest {
     val asNodeSeq: NodeSeq = children
     assertEquals(asNodeSeq, JavaByteSerialization.roundTrip(asNodeSeq))
   }
-
-  @Test
-  def base64Encode: Unit = {
-    val str = JavaByteSerialization.base64Encode(NodeSeq.Empty)
-    assertEquals("rO0ABXNy", str.take(8))
-    assertEquals("AHhweA==", str.takeRight(8))
-  }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.12")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")


### PR DESCRIPTION
Seth noticed that the Java 6 build should be failing in #168.  This wasn't noticed in Travis because of a defect in their build system.  Part (1) of this is getting Java 6 builds working again in Travis, then (2) is verify Seth's report that it should fail, then (3) is fixing the failure which is removing base64 functions available in Java 7 and later.