### PR TITLE
XML attributes parsed in reverse order

### DIFF
--- a/jvm/src/test/scala/scala/xml/AttributeTest.scala
+++ b/jvm/src/test/scala/scala/xml/AttributeTest.scala
@@ -1,0 +1,37 @@
+package scala.xml
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+
+class AttributeTestJVM {
+
+  @Test
+  def attributeOrder: Unit = {
+    val x = <x y="1" z="2"/>
+    assertEquals("""<x y="1" z="2"/>""", x.toString)
+  }
+
+  @Test
+  def attributesFromString: Unit = {
+    val str = """<x y="1" z="2"/>"""
+    val doc = XML.loadString(str)
+    assertEquals(str, doc.toString)
+  }
+
+  @Test
+  def attributesAndNamespaceFromString: Unit = {
+    val str = """<x xmlns:w="w" y="1" z="2"/>"""
+    val doc = XML.loadString(str)
+    assertNotEquals(str, doc.toString)
+    val str2 = """<x y="1" z="2" xmlns:w="w"/>"""
+    val doc2 = XML.loadString(str2)
+    assertEquals(str2, doc2.toString)
+  }
+
+  @Test(expected=classOf[SAXParseException])
+  def attributesFromStringWithDuplicate: Unit = {
+    val str = """<elem one="test" one="test1" two="test2" three="test3"></elem>"""
+    XML.loadString(str)
+  }
+}

--- a/jvm/src/test/scala/scala/xml/parsing/ConstructingParserTest.scala
+++ b/jvm/src/test/scala/scala/xml/parsing/ConstructingParserTest.scala
@@ -71,4 +71,14 @@ class ConstructingParserTest {
 
     ConstructingParser.fromSource(source, true).content(TopScope)
   }
+
+  @Test
+  def SI6341issue65: Unit = {
+    val str = """<elem one="test" two="test2" three="test3"/>"""
+    val cpa = ConstructingParser.fromSource(io.Source.fromString(str), preserveWS = true)
+    val cpadoc = cpa.document()
+    val ppr = new PrettyPrinter(80,5)
+    val out = ppr.format(cpadoc.docElem)
+    assertEquals(str, out)
+  }
 }

--- a/shared/src/main/scala/scala/xml/MetaData.scala
+++ b/shared/src/main/scala/scala/xml/MetaData.scala
@@ -155,6 +155,11 @@ abstract class MetaData
     if (f(this)) copy(next filter f)
     else next filter f
 
+  def reverse: MetaData =
+    foldLeft(Null: MetaData) { (x, xs) =>
+        xs.copy(x)
+    }
+
   /** returns key of this MetaData item */
   def key: String
 

--- a/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
@@ -158,7 +158,7 @@ abstract class FactoryAdapter extends DefaultHandler with factory.XMLLoader[Node
         if (scopeStack.isEmpty) TopScope
         else scopeStack.head
 
-      for (i <- 0 until attributes.getLength()) {
+      for (i <- (0 until attributes.getLength).reverse) {
         val qname = attributes getQName i
         val value = attributes getValue i
         val (pre, key) = splitName(qname)

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
@@ -339,7 +339,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     if (!aMap.wellformed(scope))
       reportSyntaxError("double attribute")
 
-    (aMap, scope)
+    (aMap.reverse, scope)
   }
 
   /**

--- a/shared/src/test/scala/scala/xml/AttributeTest.scala
+++ b/shared/src/test/scala/scala/xml/AttributeTest.scala
@@ -49,6 +49,11 @@ class AttributeTest {
   }
 
   @Test
+  def attributeOrder: Unit = {
+    val x = <x y="1" z="2"/>
+    assertEquals("""<x y="1" z="2"/>""", x.toString)
+  }
+
   def attributeToString: Unit = {
     val expected: String = """<b x="&amp;"/>"""
     assertEquals(expected, (<b x="&amp;"/>).toString)

--- a/shared/src/test/scala/scala/xml/MetaDataTest.scala
+++ b/shared/src/test/scala/scala/xml/MetaDataTest.scala
@@ -54,4 +54,11 @@ class MetaDataTest {
     assertEquals(new Atom(3), domatch(z2))
   }
 
+  @Test
+  def reverseTest: Unit = {
+    assertEquals("", Null.reverse.toString)
+    assertEquals(""" b="c"""", <a b="c"/>.attributes.reverse.toString)
+    assertEquals(""" d="e" b="c"""", <a b="c" d="e"/>.attributes.reverse.toString)
+  }
+
 }

--- a/shared/src/test/scala/scala/xml/UtilityTest.scala
+++ b/shared/src/test/scala/scala/xml/UtilityTest.scala
@@ -38,6 +38,8 @@ class UtilityTest {
 
   @Test
   def sort: Unit = {
+    assertEquals("", xml.Utility.sort(<a/>.attributes).toString)
+    assertEquals(""" b="c"""", xml.Utility.sort(<a b="c"/>.attributes).toString)
     val q = xml.Utility.sort(<a g='3' j='2' oo='2' a='2'/>)
     assertEquals(" a=\"2\" g=\"3\" j=\"2\" oo=\"2\"", xml.Utility.sort(q.attributes).toString)
     val pp = new xml.PrettyPrinter(80,5)


### PR DESCRIPTION
This would fix #65 and scala/bug#6341