### PR TITLE
Fix exclude rule for circular dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ lazy val xml = crossProject.in(file("."))
     libraryDependencies += "junit" % "junit" % "4.11" % "test",
     libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test",
     libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.5" % "test",
-    libraryDependencies += ("org.scala-lang" % "scala-compiler" % scalaVersion.value % "test").exclude("org.scala-lang.modules", s"scala-xml_${scalaVersion.value}")
+    libraryDependencies += ("org.scala-lang" % "scala-compiler" % scalaVersion.value % "test").exclude("org.scala-lang.modules", s"scala-xml_${scalaBinaryVersion.value}")
   )
   .jsSettings(
     // Scala.js cannot run forked tests


### PR DESCRIPTION
Despite my effort in #126, the exclude rule was using the full scala version number, when it should only be the binary version, e.g. 2.12., and therefore failing to exclude.

```
> xmlJVM/test:dependencyTree
[info] org.scala-lang.modules:scala-xml_2.12:1.1.0-SNAPSHOT [S]
[info]   +-com.novocode:junit-interface:0.10
[info]   | +-junit:junit-dep:4.10
[info]   | | +-org.hamcrest:hamcrest-core:1.1 (evicted by: 1.3)
[info]   | | +-org.hamcrest:hamcrest-core:1.3
[info]   | | 
[info]   | +-org.scala-tools.testing:test-interface:0.5
[info]   | 
[info]   +-junit:junit:4.11
[info]   | +-org.hamcrest:hamcrest-core:1.1 (evicted by: 1.3)
[info]   | +-org.hamcrest:hamcrest-core:1.3
[info]   | 
[info]   +-org.apache.commons:commons-lang3:3.5
[info]   +-org.scala-lang:scala-compiler:2.12.4 [S]
[info]     +-org.scala-lang.modules:scala-xml_2.12:1.0.6 <--- !!!
[info]     +-org.scala-lang:scala-reflect:2.12.4 [S]
[info]     
```
