### PR TITLE
Fix ignored stripComments parameter of Utility.serialize

### DIFF
--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -201,7 +201,7 @@ object Utility extends AnyRef with parsing.TokenTests {
     minimizeTags: MinimizeMode.Value = MinimizeMode.Default): StringBuilder =
     {
       x match {
-        case c: Comment if !stripComments => c buildString sb
+        case c: Comment                   => if (!stripComments) c buildString sb; sb
         case s: SpecialNode               => s buildString sb
         case g: Group                     =>
           for (c <- g.nodes) serialize(c, g.scope, sb, stripComments, decodeEntities, preserveWhitespace, minimizeTags); sb

--- a/shared/src/test/scala/scala/xml/UtilityTest.scala
+++ b/shared/src/test/scala/scala/xml/UtilityTest.scala
@@ -56,4 +56,11 @@ class UtilityTest {
     assertEquals("<node><leaf/></node>", Utility.serialize(x, minimizeTags = MinimizeMode.Always).toString)
   }
 
+  @Test
+  def issue183: Unit = {
+    val x = <node><!-- comment  --></node>
+    assertEquals("<node></node>", Utility.serialize(x, stripComments = true).toString)
+    assertEquals("<node><!-- comment  --></node>", Utility.serialize(x, stripComments = false).toString)
+  }
+
 }


### PR DESCRIPTION
Fixes issue #183 - stripComments parameter not working 