### PR TITLE
Fix UTF-8 test on JDK6

### DIFF
--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -309,16 +309,16 @@ class XMLTestJVM {
     // com.sun.org.apache.xerces.internal.impl.io.MalformedByteSequenceException:
     // Invalid byte 1 of 1-byte UTF-8 sequence.
     // scala.xml.XML.save("foo.xml", xml)
-    // scala.xml.XML.loadFile("foo.xml").toString)
+    // scala.xml.XML.loadFile("foo.xml").toString
 
     val outputStream = new java.io.ByteArrayOutputStream
-    val streamWriter = new java.io.OutputStreamWriter(outputStream, XML.encoding)
+    val streamWriter = new java.io.OutputStreamWriter(outputStream, "UTF-8")
 
     XML.write(streamWriter, xml, XML.encoding, false, null)
     streamWriter.flush
 
     val inputStream = new java.io.ByteArrayInputStream(outputStream.toByteArray)
-    val streamReader = new java.io.InputStreamReader(inputStream)
+    val streamReader = new java.io.InputStreamReader(inputStream, XML.encoding)
 
     assertEquals(xml.toString, XML.load(streamReader).toString)
   }


### PR DESCRIPTION
In particular, on a Mac the file.encoding is MacRoman

scala> sys.props.get("file.encoding")
res0: Option[String] = Some(MacRoman)

The test better represents the file-based defect:

```scala
scala.xml.XML.save("foo.xml", xml)
scala.xml.XML.loadFile("foo.xml").toString
```

It will still fail before the original defect was fixed in e15ce87.

Fixes #189.