### PR TITLE
Move Google copyright to file header

### DIFF
--- a/shared/src/main/scala/scala/xml/Elem.scala
+++ b/shared/src/main/scala/scala/xml/Elem.scala
@@ -4,6 +4,8 @@
 **  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
+**                                 Copyright 2008 Google Inc.           **
+**                                 All Rights Reserved.                 **
 \*                                                                      */
 
 package scala
@@ -14,9 +16,6 @@ package xml
  *  convenient construction and deconstruction. It is possible to deconstruct
  *  any `Node` instance (that is not a `SpecialNode` or a `Group`) using the
  *  syntax `case Elem(prefix, label, attribs, scope, child @ _*) => ...`
- *
- *  Copyright 2008 Google Inc. All Rights Reserved.
- *  @author Burak Emir <bqe@google.com>
  */
 object Elem {
   /**
@@ -83,9 +82,6 @@ object Elem {
  *  @param minimizeEmpty `true` if this element should be serialized as minimized (i.e. "&lt;el/&gt;") when
  *                       empty; `false` if it should be written out in long form.
  *  @param child         the children of this node
- *
- *  Copyright 2008 Google Inc. All Rights Reserved.
- *  @author Burak Emir <bqe@google.com>
  */
 class Elem(
   override val prefix: String,

--- a/shared/src/main/scala/scala/xml/MetaData.scala
+++ b/shared/src/main/scala/scala/xml/MetaData.scala
@@ -4,6 +4,8 @@
 **  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
+**                                 Copyright 2008 Google Inc.           **
+**                                 All Rights Reserved.                 **
 \*                                                                      */
 
 package scala
@@ -13,10 +15,6 @@ import Utility.sbToString
 import scala.annotation.tailrec
 import scala.collection.AbstractIterable
 
-/**
- * Copyright 2008 Google Inc. All Rights Reserved.
- * @author Burak Emir <bqe@google.com>
- */
 object MetaData {
   /**
    * appends all attributes from new_tail to attribs, without attempting to
@@ -78,9 +76,6 @@ object MetaData {
  *
  *  Namespace URIs are obtained by using the namespace scope of the element
  *  owning this attribute (see `getNamespace`).
- *
- *  Copyright 2008 Google Inc. All Rights Reserved.
- *  @author Burak Emir <bqe@google.com>
  */
 abstract class MetaData
   extends AbstractIterable[MetaData]


### PR DESCRIPTION
The copyright should just be in the source file header for the `Elem` and `MetaData` objects and classes, and not in their documentation.

Currently, these copyright notices are showing up in the HTML api docs (scaladocs) for those elements. 

![scala.xml.MetaData$](https://user-images.githubusercontent.com/358615/36342726-66082fee-13d0-11e8-8bb8-94c96d5347e5.png)

![scala.xml.Eleme$](https://user-images.githubusercontent.com/358615/36342727-661c95f6-13d0-11e8-8126-60b99c1dee37.png)

The rest of the library doesn't do this, so it's probably worth moving it out, rather than pasting copyright notices everywhere in the api docs for consistency.

According to the original author of scala-xml, Burak Emir:

  > The patch was built in 20% time while I was already working for
  Google, using Google's resources. The patch was formally reviewed
  and approved and Google is ok with it being part of Scala and people
  using, distributing, etc... it under the Scala license.

  > That is why the copyright notice is there. See "committed to open
  source" in
  https://abc.xyz/investor/other/google-code-of-conduct.html

I removed Burak Emir's contact information, since he's no longer involved in maintenance.  It's well documented he wrote this library.  It's not an intent to erase history.

The Google copyright was confusing to people in scala/bug#3405.  But evidence above of Burak's statements, it is no mistake.  Doesn't seem we can just remove them.  That would violate basic copyright requirements.

