### PR TITLE
Fix for #193:deprecate XMLEventReader

### DIFF
--- a/shared/src/main/scala/scala/xml/pull/XMLEvent.scala
+++ b/shared/src/main/scala/scala/xml/pull/XMLEvent.scala
@@ -14,6 +14,7 @@ package pull
  * An XML event for pull parsing.  All events received during
  * parsing will be one of the subclasses of this trait.
  */
+@deprecated("Consider javax.xml.stream.events.XMLEvent instead.", "1.1.1")
 trait XMLEvent
 
 /**

--- a/shared/src/main/scala/scala/xml/pull/XMLEventReader.scala
+++ b/shared/src/main/scala/scala/xml/pull/XMLEventReader.scala
@@ -24,6 +24,7 @@ import scala.xml.parsing.{ ExternalSources, MarkupHandler, MarkupParser }
  *  @author Burak Emir
  *  @author Paul Phillips
  */
+@deprecated("Consider javax.xml.stream.XMLEventReader instead.", "1.1.1")
 class XMLEventReader(src: Source)
   extends scala.collection.AbstractIterator[XMLEvent]
   with ProducerConsumerIterator[XMLEvent] {


### PR DESCRIPTION
class XMLEventReader in package pull is deprecated(since 1.1.1)