### PR TITLE
Changes in preparation for the 2.13 collections

### DIFF
--- a/jvm/src/test/scala/scala/xml/ReuseNodesTest.scala
+++ b/jvm/src/test/scala/scala/xml/ReuseNodesTest.scala
@@ -17,35 +17,35 @@ import org.junit.runner.RunWith
 object ReuseNodesTest {
  
   class OriginalTranformr(rules: RewriteRule*) extends RuleTransformer(rules:_*) {
-    override def transform(ns: Seq[Node]): Seq[Node] = {
+    override def transform(ns: collection.Seq[Node]): collection.Seq[Node] = {
       val xs = ns.toStream map transform
       val (xs1, xs2) = xs zip ns span { case (x, n) => unchanged(n, x) }
        
       if (xs2.isEmpty) ns
       else (xs1 map (_._2)) ++ xs2.head._1 ++ transform(ns drop (xs1.length + 1))
     }
-    override def transform(n:Node): Seq[Node] = super.transform(n)
+    override def transform(n:Node): collection.Seq[Node] = super.transform(n)
   }
 
   class ModifiedTranformr(rules: RewriteRule*) extends RuleTransformer(rules:_*) {
-    override def transform(ns: Seq[Node]): Seq[Node] = {
+    override def transform(ns: collection.Seq[Node]): collection.Seq[Node] = {
       val changed = ns flatMap transform
       
       if (changed.length != ns.length || (changed, ns).zipped.exists(_ != _)) changed
       else ns
     }
-    override def transform(n:Node): Seq[Node] = super.transform(n)
+    override def transform(n:Node): collection.Seq[Node] = super.transform(n)
   }
 
   class AlternateTranformr(rules: RewriteRule*) extends RuleTransformer(rules:_*) {
-    override def transform(ns: Seq[Node]): Seq[Node] = {
+    override def transform(ns: collection.Seq[Node]): collection.Seq[Node] = {
       val xs = ns.toStream map transform
       val (xs1, xs2) = xs zip ns span { case (x, n) => unchanged(n, x) }
        
       if (xs2.isEmpty) ns
       else (xs1 map (_._2)) ++ xs2.head._1 ++ transform(ns drop (xs1.length + 1))
     }
-    override def transform(n:Node): Seq[Node] = super.transform(n)
+    override def transform(n:Node): collection.Seq[Node] = super.transform(n)
   }
    
   def rewriteRule = new RewriteRule {
@@ -80,7 +80,7 @@ class ReuseNodesTest {
     recursiveAssert(original,transformed)
   }
   
-  def recursiveAssert(original:Seq[Node], transformed:Seq[Node]):Unit = {
+  def recursiveAssert(original: collection.Seq[Node], transformed: collection.Seq[Node]):Unit = {
     original zip transformed foreach { 
       case (x, y) => recursiveAssert(x, y) 
     }

--- a/jvm/src/test/scala/scala/xml/SerializationTest.scala
+++ b/jvm/src/test/scala/scala/xml/SerializationTest.scala
@@ -23,7 +23,7 @@ class SerializationTest {
   @Test
   def implicitConversion: Unit = {
     val parent = <parent><child></child><child/></parent>
-    val children: Seq[Node] = parent.child
+    val children: collection.Seq[Node] = parent.child
     val asNodeSeq: NodeSeq = children
     assertEquals(asNodeSeq, JavaByteSerialization.roundTrip(asNodeSeq))
   }

--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -489,9 +489,9 @@ class XMLTestJVM {
   def attributes = {
     val noAttr = <t/>
     val attrNull = <t a={ null: String }/>
-    val attrNone = <t a={ None: Option[Seq[Node]] }/>
+    val attrNone = <t a={ None: Option[collection.Seq[Node]] }/>
     val preAttrNull = <t p:a={ null: String }/>
-    val preAttrNone = <t p:a={ None: Option[Seq[Node]] }/>
+    val preAttrNone = <t p:a={ None: Option[collection.Seq[Node]] }/>
     assertEquals(noAttr, attrNull)
     assertEquals(noAttr, attrNone)
     assertEquals(noAttr, preAttrNull)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.12")
+addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.14")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")

--- a/shared/src/main/scala/scala/xml/Atom.scala
+++ b/shared/src/main/scala/scala/xml/Atom.scala
@@ -20,7 +20,7 @@ class Atom[+A](val data: A) extends SpecialNode with Serializable {
   if (data == null)
     throw new IllegalArgumentException("cannot construct " + getClass.getSimpleName + " with null")
 
-  override protected def basisForHashCode: Seq[Any] = Seq(data)
+  override protected def basisForHashCode: collection.Seq[Any] = Seq(data)
 
   override def strict_==(other: Equality) = other match {
     case x: Atom[_] => data == x.data

--- a/shared/src/main/scala/scala/xml/Attribute.scala
+++ b/shared/src/main/scala/scala/xml/Attribute.scala
@@ -23,18 +23,18 @@ object Attribute {
   }
 
   /** Convenience functions which choose Un/Prefixedness appropriately */
-  def apply(key: String, value: Seq[Node], next: MetaData): Attribute =
+  def apply(key: String, value: collection.Seq[Node], next: MetaData): Attribute =
     new UnprefixedAttribute(key, value, next)
 
   def apply(pre: String, key: String, value: String, next: MetaData): Attribute =
     if (pre == null || pre == "") new UnprefixedAttribute(key, value, next)
     else new PrefixedAttribute(pre, key, value, next)
 
-  def apply(pre: String, key: String, value: Seq[Node], next: MetaData): Attribute =
+  def apply(pre: String, key: String, value: collection.Seq[Node], next: MetaData): Attribute =
     if (pre == null || pre == "") new UnprefixedAttribute(key, value, next)
     else new PrefixedAttribute(pre, key, value, next)
 
-  def apply(pre: Option[String], key: String, value: Seq[Node], next: MetaData): Attribute =
+  def apply(pre: Option[String], key: String, value: collection.Seq[Node], next: MetaData): Attribute =
     pre match {
       case None    => new UnprefixedAttribute(key, value, next)
       case Some(p) => new PrefixedAttribute(p, key, value, next)
@@ -50,11 +50,11 @@ object Attribute {
 abstract trait Attribute extends MetaData {
   def pre: String // will be null if unprefixed
   val key: String
-  val value: Seq[Node]
+  val value: collection.Seq[Node]
   val next: MetaData
 
-  def apply(key: String): Seq[Node]
-  def apply(namespace: String, scope: NamespaceBinding, key: String): Seq[Node]
+  def apply(key: String): collection.Seq[Node]
+  def apply(namespace: String, scope: NamespaceBinding, key: String): collection.Seq[Node]
   def copy(next: MetaData): Attribute
 
   def remove(key: String) =

--- a/shared/src/main/scala/scala/xml/Document.scala
+++ b/shared/src/main/scala/scala/xml/Document.scala
@@ -30,7 +30,7 @@ class Document extends NodeSeq with pull.XMLEvent with Serializable {
    *  excluded. If there is a document type declaration, the list also
    *  contains a document type declaration information item.
    */
-  var children: Seq[Node] = _
+  var children: collection.Seq[Node] = _
 
   /** The element information item corresponding to the document element. */
   var docElem: Node = _
@@ -43,14 +43,14 @@ class Document extends NodeSeq with pull.XMLEvent with Serializable {
    *  declared in the DTD. If any notation is multiply declared, this property
    *  has no value.
    */
-  def notations: Seq[scala.xml.dtd.NotationDecl] =
+  def notations: collection.Seq[scala.xml.dtd.NotationDecl] =
     dtd.notations
 
   /**
    * An unordered set of unparsed entity information items, one for each
    *  unparsed entity declared in the DTD.
    */
-  def unparsedEntities: Seq[scala.xml.dtd.EntityDecl] =
+  def unparsedEntities: collection.Seq[scala.xml.dtd.EntityDecl] =
     dtd.unparsedEntities
 
   /** The base URI of the document entity. */
@@ -90,7 +90,7 @@ class Document extends NodeSeq with pull.XMLEvent with Serializable {
 
   // methods for NodeSeq
 
-  def theSeq: Seq[Node] = this.docElem
+  def theSeq: collection.Seq[Node] = this.docElem
 
   override def canEqual(other: Any) = other match {
     case _: Document => true

--- a/shared/src/main/scala/scala/xml/Elem.scala
+++ b/shared/src/main/scala/scala/xml/Elem.scala
@@ -111,7 +111,7 @@ class Elem(
   //  setting namespace scope if necessary
   //  cleaning adjacent text nodes if necessary
 
-  override protected def basisForHashCode: Seq[Any] =
+  override protected def basisForHashCode: collection.Seq[Any] =
     prefix :: label :: attributes :: child.toList
 
   /**
@@ -136,7 +136,7 @@ class Elem(
     attributes: MetaData = this.attributes,
     scope: NamespaceBinding = this.scope,
     minimizeEmpty: Boolean = this.minimizeEmpty,
-    child: Seq[Node] = this.child.toSeq): Elem = Elem(prefix, label, attributes, scope, minimizeEmpty, child: _*)
+    child: collection.Seq[Node] = this.child.toSeq): Elem = Elem(prefix, label, attributes, scope, minimizeEmpty, child: _*)
 
   /**
    * Returns concatenation of `text(n)` for each child `n`.

--- a/shared/src/main/scala/scala/xml/Equality.scala
+++ b/shared/src/main/scala/scala/xml/Equality.scala
@@ -30,7 +30,7 @@ package xml
  *
  *  Among the obstacles to sanity are/were:
  *
- *    Node extends NodeSeq extends Seq[Node]
+ *    Node extends NodeSeq extends collection.Seq[Node]
  *    MetaData extends Iterable[MetaData]
  *    The hacky "Group" xml node which throws exceptions
  *      with wild abandon, so don't get too close
@@ -69,7 +69,7 @@ object Equality {
 import Equality._
 
 trait Equality extends scala.Equals {
-  protected def basisForHashCode: Seq[Any]
+  protected def basisForHashCode: collection.Seq[Any]
 
   def strict_==(other: Equality): Boolean
   def strict_!=(other: Equality) = !strict_==(other)

--- a/shared/src/main/scala/scala/xml/Group.scala
+++ b/shared/src/main/scala/scala/xml/Group.scala
@@ -14,7 +14,7 @@ package xml
  *
  *  @author  Burak Emir
  */
-final case class Group(nodes: Seq[Node]) extends Node {
+final case class Group(nodes: collection.Seq[Node]) extends Node {
   override def theSeq = nodes
 
   override def canEqual(other: Any) = other match {

--- a/shared/src/main/scala/scala/xml/MetaData.scala
+++ b/shared/src/main/scala/scala/xml/MetaData.scala
@@ -99,9 +99,9 @@ abstract class MetaData
    * Gets value of unqualified (unprefixed) attribute with given key, null if not found
    *
    * @param  key
-   * @return value as Seq[Node] if key is found, null otherwise
+   * @return value as collection.Seq[Node] if key is found, null otherwise
    */
-  def apply(key: String): Seq[Node]
+  def apply(key: String): collection.Seq[Node]
 
   /**
    * convenience method, same as `apply(namespace, owner.scope, key)`.
@@ -110,7 +110,7 @@ abstract class MetaData
    *  @param owner the element owning this attribute list
    *  @param key   the attribute key
    */
-  final def apply(namespace_uri: String, owner: Node, key: String): Seq[Node] =
+  final def apply(namespace_uri: String, owner: Node, key: String): collection.Seq[Node] =
     apply(namespace_uri, owner.scope, key)
 
   /**
@@ -119,9 +119,9 @@ abstract class MetaData
    * @param  namespace_uri namespace uri of key
    * @param  scp a namespace scp (usually of the element owning this attribute list)
    * @param  k   to be looked for
-   * @return value as Seq[Node] if key is found, null otherwise
+   * @return value as collection.Seq[Node] if key is found, null otherwise
    */
-  def apply(namespace_uri: String, scp: NamespaceBinding, k: String): Seq[Node]
+  def apply(namespace_uri: String, scp: NamespaceBinding, k: String): collection.Seq[Node]
 
   /**
    * returns a copy of this MetaData item with next field set to argument.
@@ -147,7 +147,7 @@ abstract class MetaData
     case m: MetaData => this.asAttrMap == m.asAttrMap
     case _           => false
   }
-  protected def basisForHashCode: Seq[Any] = List(this.asAttrMap)
+  protected def basisForHashCode: collection.Seq[Any] = List(this.asAttrMap)
 
   /** filters this sequence of meta data */
   override def filter(f: MetaData => Boolean): MetaData =
@@ -158,7 +158,7 @@ abstract class MetaData
   def key: String
 
   /** returns value of this MetaData item */
-  def value: Seq[Node]
+  def value: collection.Seq[Node]
 
   /**
    * Returns a String containing "prefix:key" if the first key is
@@ -182,12 +182,12 @@ abstract class MetaData
    * Gets value of unqualified (unprefixed) attribute with given key, None if not found
    *
    * @param  key
-   * @return value in Some(Seq[Node]) if key is found, None otherwise
+   * @return value in Some(collection.Seq[Node]) if key is found, None otherwise
    */
-  final def get(key: String): Option[Seq[Node]] = Option(apply(key))
+  final def get(key: String): Option[collection.Seq[Node]] = Option(apply(key))
 
   /** same as get(uri, owner.scope, key) */
-  final def get(uri: String, owner: Node, key: String): Option[Seq[Node]] =
+  final def get(uri: String, owner: Node, key: String): Option[collection.Seq[Node]] =
     get(uri, owner.scope, key)
 
   /**
@@ -196,9 +196,9 @@ abstract class MetaData
    * @param  uri namespace of key
    * @param  scope a namespace scp (usually of the element owning this attribute list)
    * @param  key to be looked fore
-   * @return value as Some[Seq[Node]] if key is found, None otherwise
+   * @return value as Some[collection.Seq[Node]] if key is found, None otherwise
    */
-  final def get(uri: String, scope: NamespaceBinding, key: String): Option[Seq[Node]] =
+  final def get(uri: String, scope: NamespaceBinding, key: String): Option[collection.Seq[Node]] =
     Option(apply(uri, scope, key))
 
   protected def toString1(): String = sbToString(toString1)

--- a/shared/src/main/scala/scala/xml/NamespaceBinding.scala
+++ b/shared/src/main/scala/scala/xml/NamespaceBinding.scala
@@ -63,7 +63,7 @@ case class NamespaceBinding(prefix: String, uri: String, parent: NamespaceBindin
     case _                   => false
   }
 
-  def basisForHashCode: Seq[Any] = List(prefix, uri, parent)
+  def basisForHashCode: collection.Seq[Any] = List(prefix, uri, parent)
 
   def buildString(stop: NamespaceBinding): String = sbToString(buildString(_, stop))
 

--- a/shared/src/main/scala/scala/xml/Node.scala
+++ b/shared/src/main/scala/scala/xml/Node.scala
@@ -85,7 +85,7 @@ abstract class Node extends NodeSeq {
    * @return value of `UnprefixedAttribute` with given key
    *         in attributes, if it exists, otherwise `null`.
    */
-  final def attribute(key: String): Option[Seq[Node]] = attributes.get(key)
+  final def attribute(key: String): Option[collection.Seq[Node]] = attributes.get(key)
 
   /**
    * Convenience method, looks up a prefixed attribute in attributes of this node.
@@ -96,7 +96,7 @@ abstract class Node extends NodeSeq {
    * @return value of `PrefixedAttribute` with given namespace
    *         and given key, otherwise `'''null'''`.
    */
-  final def attribute(uri: String, key: String): Option[Seq[Node]] =
+  final def attribute(uri: String, key: String): Option[collection.Seq[Node]] =
     attributes.get(uri, this, key)
 
   /**
@@ -113,12 +113,12 @@ abstract class Node extends NodeSeq {
    *
    * @return all children of this node
    */
-  def child: Seq[Node]
+  def child: collection.Seq[Node]
 
   /**
    * Children which do not stringify to "" (needed for equality)
    */
-  def nonEmptyChildren: Seq[Node] = child filterNot (_.toString == "")
+  def nonEmptyChildren: collection.Seq[Node] = child filterNot (_.toString == "")
 
   /**
    * Descendant axis (all descendants of this node, not including node itself)
@@ -139,7 +139,7 @@ abstract class Node extends NodeSeq {
     case _        => false
   }
 
-  override protected def basisForHashCode: Seq[Any] =
+  override protected def basisForHashCode: collection.Seq[Any] =
     prefix :: label :: attributes :: nonEmptyChildren.toList
 
   override def strict_==(other: Equality) = other match {
@@ -159,7 +159,7 @@ abstract class Node extends NodeSeq {
   /**
    *  returns a sequence consisting of only this node
    */
-  def theSeq: Seq[Node] = this :: Nil
+  def theSeq: collection.Seq[Node] = this :: Nil
 
   /**
    * String representation of this node

--- a/shared/src/main/scala/scala/xml/NodeBuffer.scala
+++ b/shared/src/main/scala/scala/xml/NodeBuffer.scala
@@ -11,7 +11,7 @@ package xml
 
 /**
  * This class acts as a Buffer for nodes. If it is used as a sequence of
- * nodes `Seq[Node]`, it must be ensured that no updates occur after that
+ * nodes `collection.Seq[Node]`, it must be ensured that no updates occur after that
  * point, because `scala.xml.Node` is assumed to be immutable.
  *
  * Despite this being a sequence, don't use it as key in a hashtable.

--- a/shared/src/main/scala/scala/xml/NodeSeq.scala
+++ b/shared/src/main/scala/scala/xml/NodeSeq.scala
@@ -21,7 +21,7 @@ import scala.language.implicitConversions
  */
 object NodeSeq {
   final val Empty = fromSeq(Nil)
-  def fromSeq(s: Seq[Node]): NodeSeq = new NodeSeq {
+  def fromSeq(s: collection.Seq[Node]): NodeSeq = new NodeSeq {
     def theSeq = s
   }
   type Coll = NodeSeq
@@ -31,11 +31,11 @@ object NodeSeq {
       def apply() = newBuilder
     }
   def newBuilder: Builder[Node, NodeSeq] = new ListBuffer[Node] mapResult fromSeq
-  implicit def seqToNodeSeq(s: Seq[Node]): NodeSeq = fromSeq(s)
+  implicit def seqToNodeSeq(s: collection.Seq[Node]): NodeSeq = fromSeq(s)
 }
 
 /**
- * This class implements a wrapper around `Seq[Node]` that adds XPath
+ * This class implements a wrapper around `collection.Seq[Node]` that adds XPath
  *  and comprehension methods.
  *
  *  @author  Burak Emir
@@ -45,7 +45,7 @@ abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with S
   /** Creates a list buffer as builder for this class */
   override protected[this] def newBuilder = NodeSeq.newBuilder
 
-  def theSeq: Seq[Node]
+  def theSeq: collection.Seq[Node]
   def length = theSeq.length
   override def iterator = theSeq.iterator
 
@@ -62,7 +62,7 @@ abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with S
     !these.hasNext && !those.hasNext
   }
 
-  protected def basisForHashCode: Seq[Any] = theSeq
+  protected def basisForHashCode: collection.Seq[Any] = theSeq
 
   override def canEqual(other: Any) = other match {
     case _: NodeSeq => true

--- a/shared/src/main/scala/scala/xml/Null.scala
+++ b/shared/src/main/scala/scala/xml/Null.scala
@@ -41,7 +41,7 @@ case object Null extends MetaData {
     case x: MetaData => x.length == 0
     case _           => false
   }
-  override protected def basisForHashCode: Seq[Any] = Nil
+  override protected def basisForHashCode: collection.Seq[Any] = Nil
 
   def apply(namespace: String, scope: NamespaceBinding, key: String) = null
   def apply(key: String) =

--- a/shared/src/main/scala/scala/xml/PrefixedAttribute.scala
+++ b/shared/src/main/scala/scala/xml/PrefixedAttribute.scala
@@ -20,7 +20,7 @@ package xml
 class PrefixedAttribute(
   val pre: String,
   val key: String,
-  val value: Seq[Node],
+  val value: collection.Seq[Node],
   val next1: MetaData)
   extends Attribute {
   val next = if (value ne null) next1 else next1.remove(key)
@@ -30,7 +30,7 @@ class PrefixedAttribute(
     this(pre, key, if (value ne null) Text(value) else null: NodeSeq, next)
 
   /** same as this(pre, key, value.get, next), or no attribute if value is None */
-  def this(pre: String, key: String, value: Option[Seq[Node]], next: MetaData) =
+  def this(pre: String, key: String, value: Option[collection.Seq[Node]], next: MetaData) =
     this(pre, key, value.orNull, next)
 
   /**
@@ -44,12 +44,12 @@ class PrefixedAttribute(
     owner.getNamespace(pre)
 
   /** forwards the call to next (because caller looks for unprefixed attribute */
-  def apply(key: String): Seq[Node] = next(key)
+  def apply(key: String): collection.Seq[Node] = next(key)
 
   /**
    * gets attribute value of qualified (prefixed) attribute with given key
    */
-  def apply(namespace: String, scope: NamespaceBinding, key: String): Seq[Node] = {
+  def apply(namespace: String, scope: NamespaceBinding, key: String): collection.Seq[Node] = {
     if (key == this.key && scope.getURI(pre) == namespace)
       value
     else

--- a/shared/src/main/scala/scala/xml/PrettyPrinter.scala
+++ b/shared/src/main/scala/scala/xml/PrettyPrinter.scala
@@ -170,7 +170,7 @@ class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean) {
           makeBox(ind, stg.substring(0, len2))
           makeBreak() // todo: break the rest in pieces
           /*{ //@todo
-             val sq:Seq[String] = stg.split(" ");
+             val sq:collection.Seq[String] = stg.split(" ");
              val it = sq.iterator;
              it.next;
              for (c <- it) {
@@ -254,7 +254,7 @@ class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean) {
    *  @param nodes  the sequence of nodes to be serialized
    *  @param pscope the namespace to prefix mapping
    */
-  def formatNodes(nodes: Seq[Node], pscope: NamespaceBinding = TopScope): String =
+  def formatNodes(nodes: collection.Seq[Node], pscope: NamespaceBinding = TopScope): String =
     sbToString(formatNodes(nodes, pscope, _))
 
   /**
@@ -265,6 +265,6 @@ class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean) {
    *  @param pscope the namespace to prefix mapping
    *  @param sb     the string buffer to which to append to
    */
-  def formatNodes(nodes: Seq[Node], pscope: NamespaceBinding, sb: StringBuilder): Unit =
+  def formatNodes(nodes: collection.Seq[Node], pscope: NamespaceBinding, sb: StringBuilder): Unit =
     nodes foreach (n => sb append format(n, pscope))
 }

--- a/shared/src/main/scala/scala/xml/TextBuffer.scala
+++ b/shared/src/main/scala/scala/xml/TextBuffer.scala
@@ -27,7 +27,7 @@ class TextBuffer {
   /**
    * Appends this string to the text buffer, trimming whitespaces as needed.
    */
-  def append(cs: Seq[Char]): this.type = {
+  def append(cs: collection.Seq[Char]): this.type = {
     cs foreach { c =>
       if (!isSpace(c)) sb append c
       else if (sb.isEmpty || !isSpace(sb.last)) sb append ' '
@@ -40,7 +40,7 @@ class TextBuffer {
    *
    *  @return the text without whitespaces.
    */
-  def toText: Seq[Text] = sb.toString.trim match {
+  def toText: collection.Seq[Text] = sb.toString.trim match {
     case "" => Nil
     case s  => Seq(Text(s))
   }

--- a/shared/src/main/scala/scala/xml/UnprefixedAttribute.scala
+++ b/shared/src/main/scala/scala/xml/UnprefixedAttribute.scala
@@ -16,7 +16,7 @@ package xml
  */
 class UnprefixedAttribute(
   val key: String,
-  val value: Seq[Node],
+  val value: collection.Seq[Node],
   next1: MetaData)
   extends Attribute {
   final val pre = null
@@ -27,7 +27,7 @@ class UnprefixedAttribute(
     this(key, if (value ne null) Text(value) else null: NodeSeq, next)
 
   /** same as this(key, value.get, next), or no attribute if value is None */
-  def this(key: String, value: Option[Seq[Node]], next: MetaData) =
+  def this(key: String, value: Option[collection.Seq[Node]], next: MetaData) =
     this(key, value.orNull, next)
 
   /** returns a copy of this unprefixed attribute with the given next field*/
@@ -39,9 +39,9 @@ class UnprefixedAttribute(
    * Gets value of unqualified (unprefixed) attribute with given key, null if not found
    *
    * @param  key
-   * @return value as Seq[Node] if key is found, null otherwise
+   * @return value as collection.Seq[Node] if key is found, null otherwise
    */
-  def apply(key: String): Seq[Node] =
+  def apply(key: String): collection.Seq[Node] =
     if (key == this.key) value else next(key)
 
   /**
@@ -52,7 +52,7 @@ class UnprefixedAttribute(
    * @param  key
    * @return ..
    */
-  def apply(namespace: String, scope: NamespaceBinding, key: String): Seq[Node] =
+  def apply(namespace: String, scope: NamespaceBinding, key: String): collection.Seq[Node] =
     next(namespace, scope, key)
 }
 object UnprefixedAttribute {

--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -38,7 +38,7 @@ object Utility extends AnyRef with parsing.TokenTests {
    * Trims an element - call this method, when you know that it is an
    *  element (and not a text node) so you know that it will not be trimmed
    *  away. With this assumption, the function can return a `Node`, rather
-   *  than a `Seq[Node]`. If you don't know, call `trimProper` and account
+   *  than a `collection.Seq[Node]`. If you don't know, call `trimProper` and account
    *  for the fact that you may get back an empty sequence of nodes.
    *
    *  Precondition: node is not a text node (it might be trimmed)
@@ -53,7 +53,7 @@ object Utility extends AnyRef with parsing.TokenTests {
    * trim a child of an element. `Attribute` values and `Atom` nodes that
    *  are not `Text` nodes are unaffected.
    */
-  def trimProper(x: Node): Seq[Node] = x match {
+  def trimProper(x: Node): collection.Seq[Node] = x match {
     case Elem(pre, lab, md, scp, child@_*) =>
       val children = child flatMap trimProper
       Elem(pre, lab, md, scp, children.isEmpty, children: _*)
@@ -132,7 +132,7 @@ object Utility extends AnyRef with parsing.TokenTests {
    * Returns a set of all namespaces used in a sequence of nodes
    * and all their descendants, including the empty namespaces.
    */
-  def collectNamespaces(nodes: Seq[Node]): mutable.Set[String] =
+  def collectNamespaces(nodes: collection.Seq[Node]): mutable.Set[String] =
     nodes.foldLeft(new mutable.HashSet[String]) { (set, x) => collectNamespaces(x, set); set }
 
   /**
@@ -229,7 +229,7 @@ object Utility extends AnyRef with parsing.TokenTests {
     }
 
   def sequenceToXML(
-    children: Seq[Node],
+    children: collection.Seq[Node],
     pscope: NamespaceBinding = TopScope,
     sb: StringBuilder = new StringBuilder,
     stripComments: Boolean = false,
@@ -261,7 +261,7 @@ object Utility extends AnyRef with parsing.TokenTests {
   /**
    * Returns a hashcode for the given constituents of a node
    */
-  def hashCode(pre: String, label: String, attribHashCode: Int, scpeHash: Int, children: Seq[Node]) =
+  def hashCode(pre: String, label: String, attribHashCode: Int, scpeHash: Int, children: collection.Seq[Node]) =
     scala.util.hashing.MurmurHash3.orderedHash(label +: attribHashCode +: scpeHash +: children, pre.##)
 
   def appendQuoted(s: String): String = sbToString(appendQuoted(s, _))
@@ -321,7 +321,7 @@ object Utility extends AnyRef with parsing.TokenTests {
     null
   }
 
-  def parseAttributeValue(value: String): Seq[Node] = {
+  def parseAttributeValue(value: String): collection.Seq[Node] = {
     val sb = new StringBuilder
     var rfb: StringBuilder = null
     val nb = new NodeBuffer()

--- a/shared/src/main/scala/scala/xml/Xhtml.scala
+++ b/shared/src/main/scala/scala/xml/Xhtml.scala
@@ -21,7 +21,7 @@ object Xhtml {
    *
    * @param nodeSeq   the node sequence
    */
-  def toXhtml(nodeSeq: NodeSeq): String = sbToString(sb => sequenceToXML(nodeSeq: Seq[Node], sb = sb))
+  def toXhtml(nodeSeq: NodeSeq): String = sbToString(sb => sequenceToXML(nodeSeq: collection.Seq[Node], sb = sb))
 
   /**
    * Elements which we believe are safe to minimize if minimizeTags is true.
@@ -76,7 +76,7 @@ object Xhtml {
    * Amounts to calling toXhtml(node, ...) with the given parameters on each node.
    */
   def sequenceToXML(
-    children: Seq[Node],
+    children: collection.Seq[Node],
     pscope: NamespaceBinding = TopScope,
     sb: StringBuilder = new StringBuilder,
     stripComments: Boolean = false,

--- a/shared/src/main/scala/scala/xml/dtd/ContentModel.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ContentModel.scala
@@ -54,7 +54,7 @@ object ContentModel extends WordExp {
   def buildString(r: RegExp): String = sbToString(buildString(r, _))
 
   /* precond: rs.length >= 1 */
-  private def buildString(rs: Seq[RegExp], sb: StringBuilder, sep: Char) {
+  private def buildString(rs: collection.Seq[RegExp], sb: StringBuilder, sep: Char) {
     buildString(rs.head, sb)
     for (z <- rs.tail) {
       sb append sep

--- a/shared/src/main/scala/scala/xml/dtd/DTD.scala
+++ b/shared/src/main/scala/scala/xml/dtd/DTD.scala
@@ -20,8 +20,8 @@ import scala.collection.mutable
 abstract class DTD {
   var externalID: ExternalID = null
   var decls: List[Decl] = Nil
-  def notations: Seq[NotationDecl] = Nil
-  def unparsedEntities: Seq[EntityDecl] = Nil
+  def notations: collection.Seq[NotationDecl] = Nil
+  def unparsedEntities: collection.Seq[EntityDecl] = Nil
 
   var elem: mutable.Map[String, ElemDecl] = new mutable.HashMap[String, ElemDecl]()
   var attr: mutable.Map[String, AttListDecl] = new mutable.HashMap[String, AttListDecl]()

--- a/shared/src/main/scala/scala/xml/dtd/DocType.scala
+++ b/shared/src/main/scala/scala/xml/dtd/DocType.scala
@@ -19,7 +19,7 @@ package dtd
  *  @param  extID  NoExternalID or the external ID of this doctype
  *  @param  intSubset sequence of internal subset declarations
  */
-case class DocType(name: String, extID: ExternalID, intSubset: Seq[dtd.Decl]) {
+case class DocType(name: String, extID: ExternalID, intSubset: collection.Seq[dtd.Decl]) {
   if (!Utility.isName(name))
     throw new IllegalArgumentException(name + " must be an XML Name")
 

--- a/shared/src/main/scala/scala/xml/dtd/ElementValidator.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ElementValidator.scala
@@ -47,7 +47,7 @@ class ElementValidator() extends Function1[Node, Boolean] {
   /** set meta data, enabling attribute validation */
   def setMetaData(adecls: List[AttrDecl]) { this.adecls = adecls }
 
-  def getIterable(nodes: Seq[Node], skipPCDATA: Boolean): Iterable[ElemName] = {
+  def getIterable(nodes: collection.Seq[Node], skipPCDATA: Boolean): Iterable[ElemName] = {
     def isAllWhitespace(a: Atom[_]) = cond(a.data) { case s: String if s.trim == "" => true }
 
     nodes.filter {
@@ -100,7 +100,7 @@ class ElementValidator() extends Function1[Node, Boolean] {
    * check children, return true if conform to content model
    *  @note contentModel != null
    */
-  def check(nodes: Seq[Node]): Boolean = contentModel match {
+  def check(nodes: collection.Seq[Node]): Boolean = contentModel match {
     case ANY    => true
     case EMPTY  => getIterable(nodes, skipPCDATA = false).isEmpty
     case PCDATA => getIterable(nodes, skipPCDATA = true).isEmpty

--- a/shared/src/main/scala/scala/xml/dtd/Scanner.scala
+++ b/shared/src/main/scala/scala/xml/dtd/Scanner.scala
@@ -48,7 +48,7 @@ class Scanner extends Tokens with parsing.TokenTests {
     if (c == d) next() else scala.sys.error("expected '" + d + "' found '" + c + "' !")
   }
 
-  final def accS(ds: Seq[Char]) { ds foreach acc }
+  final def accS(ds: collection.Seq[Char]) { ds foreach acc }
 
   final def readToken: Int =
     if (isSpace(c)) {

--- a/shared/src/main/scala/scala/xml/dtd/impl/BaseBerrySethi.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/BaseBerrySethi.scala
@@ -58,7 +58,7 @@ private[dtd] abstract class BaseBerrySethi {
    *  precondition: pos is final
    *               pats are successor patterns of a Sequence node
    */
-  protected def compFollow(rs: Seq[RegExp]): Set[Int] = {
+  protected def compFollow(rs: collection.Seq[RegExp]): Set[Int] = {
     follow(0) =
       if (rs.isEmpty) emptySet
       else rs.foldRight(Set(pos))((p, fol) => {

--- a/shared/src/main/scala/scala/xml/dtd/impl/Inclusion.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/Inclusion.scala
@@ -18,7 +18,7 @@ package xml.dtd.impl
 @deprecated("This class will be removed", "2.10.0")
 private[dtd] trait Inclusion[A <: AnyRef] {
 
-  val labels: Seq[A]
+  val labels: collection.Seq[A]
 
   /**
    * Returns true if `dfa1` is included in `dfa2`.

--- a/shared/src/main/scala/scala/xml/dtd/impl/NondetWordAutom.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/NondetWordAutom.scala
@@ -47,7 +47,7 @@ private[dtd] abstract class NondetWordAutom[T <: AnyRef] {
   def nextDefault(Q: immutable.BitSet): immutable.BitSet = next(Q, default)
 
   private def next(Q: immutable.BitSet, f: (Int) => immutable.BitSet): immutable.BitSet =
-    (Q map f).foldLeft(immutable.BitSet.empty)(_ ++ _)
+    ((Q: Set[Int]) map f).foldLeft(immutable.BitSet.empty)(_ ++ _)
 
   private def finalStates = 0 until nstates filter isFinal
   override def toString = {

--- a/shared/src/main/scala/scala/xml/dtd/impl/NondetWordAutom.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/NondetWordAutom.scala
@@ -22,7 +22,7 @@ import scala.collection.{ immutable, mutable }
 // TODO: still used in ContentModel -- @deprecated("This class will be removed", "2.10.0")
 private[dtd] abstract class NondetWordAutom[T <: AnyRef] {
   val nstates: Int
-  val labels: Seq[T]
+  val labels: collection.Seq[T]
   val finals: Array[Int] // 0 means not final
   val delta: Array[mutable.Map[T, immutable.BitSet]]
   val default: Array[immutable.BitSet]

--- a/shared/src/main/scala/scala/xml/dtd/impl/SubsetConstruction.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/SubsetConstruction.scala
@@ -20,8 +20,8 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
 
   def determinize: DetWordAutom[T] = {
     // for assigning numbers to bitsets
-    var indexMap = scala.collection.Map[immutable.BitSet, Int]()
-    var invIndexMap = scala.collection.Map[Int, immutable.BitSet]()
+    var indexMap = scala.collection.immutable.Map[immutable.BitSet, Int]()
+    var invIndexMap = scala.collection.immutable.Map[Int, immutable.BitSet]()
     var ix = 0
 
     // we compute the dfa with states = bitsets
@@ -37,8 +37,11 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
     rest.push(sink, q0)
 
     def addFinal(q: immutable.BitSet) {
-      if (nfa containsFinal q)
-        finals = finals.updated(q, selectTag(q, nfa.finals))
+      if (nfa containsFinal q) {
+        val finalsClone = finals.clone
+        finalsClone(q) = selectTag(q, nfa.finals)
+        finals = finalsClone
+      }
     }
     def add(Q: immutable.BitSet) {
       if (!states(Q)) {
@@ -69,7 +72,8 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
 
       // collect default transitions
       val Pdef = nfa nextDefault P
-      deftrans = deftrans.updated(P, Pdef)
+      deftrans = deftrans.clone
+      deftrans(P) = Pdef
       add(Pdef)
     }
 

--- a/shared/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
@@ -97,7 +97,7 @@ private[dtd] abstract class WordBerrySethi extends BaseBerrySethi {
     q.update(label, dest :: q.getOrElse(label, Nil))
   }
 
-  protected def initialize(subexpr: Seq[RegExp]): Unit = {
+  protected def initialize(subexpr: collection.Seq[RegExp]): Unit = {
     this.labelAt = immutable.Map()
     this.follow = mutable.HashMap()
     this.labels = mutable.HashSet()

--- a/shared/src/main/scala/scala/xml/factory/LoggedNodeFactory.scala
+++ b/shared/src/main/scala/scala/xml/factory/LoggedNodeFactory.scala
@@ -47,7 +47,7 @@ trait LoggedNodeFactory[A <: Node] extends NodeFactory[A] {
 
   /** logged version of makeNode method */
   override def makeNode(pre: String, label: String, attrSeq: MetaData,
-                        scope: NamespaceBinding, children: Seq[Node]): A = {
+                        scope: NamespaceBinding, children: collection.Seq[Node]): A = {
     if (logNode)
       log("[makeNode for " + label + "]")
 
@@ -73,13 +73,13 @@ trait LoggedNodeFactory[A <: Node] extends NodeFactory[A] {
     super.makeText(s)
   }
 
-  override def makeComment(s: String): Seq[Comment] = {
+  override def makeComment(s: String): collection.Seq[Comment] = {
     if (logComment)
       log("[makeComment:\"" + s + "\"]")
     super.makeComment(s)
   }
 
-  override def makeProcInstr(t: String, s: String): Seq[ProcInstr] = {
+  override def makeProcInstr(t: String, s: String): collection.Seq[ProcInstr] = {
     if (logProcInstr)
       log("[makeProcInstr:\"" + t + " " + s + "\"]")
     super.makeProcInstr(t, s)

--- a/shared/src/main/scala/scala/xml/factory/NodeFactory.scala
+++ b/shared/src/main/scala/scala/xml/factory/NodeFactory.scala
@@ -17,25 +17,25 @@ trait NodeFactory[A <: Node] {
   /* default behaviour is to use hash-consing */
   val cache = new scala.collection.mutable.HashMap[Int, List[A]]
 
-  protected def create(pre: String, name: String, attrs: MetaData, scope: NamespaceBinding, children: Seq[Node]): A
+  protected def create(pre: String, name: String, attrs: MetaData, scope: NamespaceBinding, children: collection.Seq[Node]): A
 
-  protected def construct(hash: Int, old: List[A], pre: String, name: String, attrSeq: MetaData, scope: NamespaceBinding, children: Seq[Node]): A = {
+  protected def construct(hash: Int, old: List[A], pre: String, name: String, attrSeq: MetaData, scope: NamespaceBinding, children: collection.Seq[Node]): A = {
     val el = create(pre, name, attrSeq, scope, children)
     cache.update(hash, el :: old)
     el
   }
 
-  def eqElements(ch1: Seq[Node], ch2: Seq[Node]): Boolean =
+  def eqElements(ch1: collection.Seq[Node], ch2: collection.Seq[Node]): Boolean =
     ch1.view.zipAll(ch2.view, null, null) forall { case (x, y) => x eq y }
 
-  def nodeEquals(n: Node, pre: String, name: String, attrSeq: MetaData, scope: NamespaceBinding, children: Seq[Node]) =
+  def nodeEquals(n: Node, pre: String, name: String, attrSeq: MetaData, scope: NamespaceBinding, children: collection.Seq[Node]) =
     n.prefix == pre &&
       n.label == name &&
       n.attributes == attrSeq &&
       // scope?
       eqElements(n.child, children)
 
-  def makeNode(pre: String, name: String, attrSeq: MetaData, scope: NamespaceBinding, children: Seq[Node]): A = {
+  def makeNode(pre: String, name: String, attrSeq: MetaData, scope: NamespaceBinding, children: collection.Seq[Node]): A = {
     val hash = Utility.hashCode(pre, name, attrSeq.##, scope.##, children)
     def cons(old: List[A]) = construct(hash, old, pre, name, attrSeq, scope, children)
 
@@ -50,8 +50,8 @@ trait NodeFactory[A <: Node] {
   }
 
   def makeText(s: String) = Text(s)
-  def makeComment(s: String): Seq[Comment] =
+  def makeComment(s: String): collection.Seq[Comment] =
     if (ignoreComments) Nil else List(Comment(s))
-  def makeProcInstr(t: String, s: String): Seq[ProcInstr] =
+  def makeProcInstr(t: String, s: String): collection.Seq[ProcInstr] =
     if (ignoreProcInstr) Nil else List(ProcInstr(t, s))
 }

--- a/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
@@ -75,7 +75,7 @@ abstract class FactoryAdapter extends DefaultHandler with factory.XMLLoader[Node
   /**
    * creates a new processing instruction node.
    */
-  def createProcInstr(target: String, data: String): Seq[ProcInstr]
+  def createProcInstr(target: String, data: String): collection.Seq[ProcInstr]
 
   //
   // ContentHandler methods

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
@@ -358,7 +358,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     }
     nextch()
     val str = cbuf.toString()
-    cbuf.length = 0
+    cbuf.clear()
     str
   }
 
@@ -390,7 +390,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     xToken("--")
     while (!eof) {
       if (ch == '-' && { sb.append(ch); nextch(); ch == '-' }) {
-        sb.length = sb.length - 1
+        sb.setLength(sb.length - 1)
         nextch()
         xToken('>')
         return handle.comment(pos, sb.toString())
@@ -608,7 +608,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
       exit = eof || (ch == '<') || (ch == '&')
     }
     val str = cbuf.toString
-    cbuf.length = 0
+    cbuf.clear()
     str
   }
 
@@ -630,7 +630,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     }
     nextch()
     val str = cbuf.toString()
-    cbuf.length = 0
+    cbuf.clear()
     str
   }
 
@@ -653,7 +653,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     }
     nextch()
     val str = cbuf.toString
-    cbuf.length = 0
+    cbuf.clear()
     str
   }
 
@@ -799,7 +799,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     //Console.println("END["+ch+"]")
     nextch()
     val cmstr = cbuf.toString()
-    cbuf.length = 0
+    cbuf.clear()
     handle.elemDecl(n, cmstr)
   }
 
@@ -826,7 +826,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
         nextch()
       }
       val atpe = cbuf.toString
-      cbuf.length = 0
+      cbuf.clear()
 
       val defdecl: DefaultDecl = ch match {
         case '\'' | '"' =>
@@ -846,7 +846,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
       xSpaceOpt()
 
       attList ::= AttrDecl(aname, atpe, defdecl)
-      cbuf.length = 0
+      cbuf.clear()
     }
     nextch()
     handle.attListDecl(n, attList.reverse)

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
@@ -203,7 +203,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
     if (ch == that) nextch()
     else xHandleError(that, "'%s' expected instead of '%s'".format(that, ch))
   }
-  def xToken(that: Seq[Char]) { that foreach xToken }
+  def xToken(that: collection.Seq[Char]) { that foreach xToken }
 
   /** scan [S] '=' [S]*/
   def xEQ() = { xSpaceOpt(); xToken('='); xSpaceOpt() }

--- a/shared/src/main/scala/scala/xml/parsing/NoBindingFactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/NoBindingFactoryAdapter.scala
@@ -21,7 +21,7 @@ class NoBindingFactoryAdapter extends FactoryAdapter with NodeFactory[Elem] {
   def nodeContainsText(label: String) = true
 
   /** From NodeFactory.  Constructs an instance of scala.xml.Elem -- TODO: deprecate as in Elem */
-  protected def create(pre: String, label: String, attrs: MetaData, scope: NamespaceBinding, children: Seq[Node]): Elem =
+  protected def create(pre: String, label: String, attrs: MetaData, scope: NamespaceBinding, children: collection.Seq[Node]): Elem =
     Elem(pre, label, attrs, scope, children.isEmpty, children: _*)
 
   /** From FactoryAdapter.  Creates a node. never creates the same node twice, using hash-consing.

--- a/shared/src/main/scala/scala/xml/parsing/TokenTests.scala
+++ b/shared/src/main/scala/scala/xml/parsing/TokenTests.scala
@@ -29,7 +29,7 @@ trait TokenTests {
    *  (#x20 | #x9 | #xD | #xA)+
    *  }}}
    */
-  final def isSpace(cs: Seq[Char]): Boolean = cs.nonEmpty && (cs forall isSpace)
+  final def isSpace(cs: collection.Seq[Char]): Boolean = cs.nonEmpty && (cs forall isSpace)
 
   /** These are 99% sure to be redundant but refactoring on the safe side. */
   def isAlpha(c: Char) = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
@@ -96,7 +96,7 @@ trait TokenTests {
    *
    * @param ianaEncoding The IANA encoding name.
    */
-  def isValidIANAEncoding(ianaEncoding: Seq[Char]) = {
+  def isValidIANAEncoding(ianaEncoding: collection.Seq[Char]) = {
     def charOK(c: Char) = isAlphaDigit(c) || ("._-" contains c)
 
     ianaEncoding.nonEmpty && isAlpha(ianaEncoding.head) &&

--- a/shared/src/main/scala/scala/xml/transform/BasicTransformer.scala
+++ b/shared/src/main/scala/scala/xml/transform/BasicTransformer.scala
@@ -16,27 +16,27 @@ package transform
  *  @author  Burak Emir
  */
 abstract class BasicTransformer extends Function1[Node, Node] {
-  protected def unchanged(n: Node, ns: Seq[Node]) =
+  protected def unchanged(n: Node, ns: collection.Seq[Node]) =
     ns.length == 1 && (ns.head == n)
 
   /**
    * Call transform(Node) for each node in ns, append results
    *  to NodeBuffer.
    */
-  def transform(it: Iterator[Node], nb: NodeBuffer): Seq[Node] =
+  def transform(it: Iterator[Node], nb: NodeBuffer): collection.Seq[Node] =
     it.foldLeft(nb)(_ ++= transform(_)).toSeq
 
   /**
    * Call transform(Node) to each node in ns, yield ns if nothing changes,
    *  otherwise a new sequence of concatenated results.
    */
-  def transform(ns: Seq[Node]): Seq[Node] = {
+  def transform(ns: collection.Seq[Node]): collection.Seq[Node] = {
     val changed = ns flatMap transform
     if (changed.length != ns.length || (changed, ns).zipped.exists(_ != _)) changed
     else ns
 }
 
-  def transform(n: Node): Seq[Node] = {
+  def transform(n: Node): collection.Seq[Node] = {
     if (n.doTransform) n match {
       case Group(xs) => Group(transform(xs)) // un-group the hack Group tag
       case _ =>

--- a/shared/src/main/scala/scala/xml/transform/RewriteRule.scala
+++ b/shared/src/main/scala/scala/xml/transform/RewriteRule.scala
@@ -20,7 +20,7 @@ package transform
 abstract class RewriteRule extends BasicTransformer {
   /** a name for this rewrite rule */
   val name = this.toString()
-  override def transform(ns: Seq[Node]): Seq[Node] = super.transform(ns)
-  override def transform(n: Node): Seq[Node] = n
+  override def transform(ns: collection.Seq[Node]): collection.Seq[Node] = super.transform(ns)
+  override def transform(n: Node): collection.Seq[Node] = n
 }
 

--- a/shared/src/main/scala/scala/xml/transform/RuleTransformer.scala
+++ b/shared/src/main/scala/scala/xml/transform/RuleTransformer.scala
@@ -11,6 +11,6 @@ package xml
 package transform
 
 class RuleTransformer(rules: RewriteRule*) extends BasicTransformer {
-  override def transform(n: Node): Seq[Node] =
+  override def transform(n: Node): collection.Seq[Node] =
     rules.foldLeft(super.transform(n)) { (res, rule) => rule transform res }
 }

--- a/shared/src/test/scala/scala/xml/PatternMatching.scala
+++ b/shared/src/test/scala/scala/xml/PatternMatching.scala
@@ -12,7 +12,7 @@ class PatternMatching extends {
     assertTrue(matchList(li))
   }
 
-  def matchSeq(args: Seq[String]) = args match {
+  def matchSeq(args: collection.Seq[String]) = args match {
     case Seq(a, b, c, d @ _*) => true
   }
 
@@ -56,8 +56,8 @@ class PatternMatching extends {
   }
 
   object SafeNodeSeq {
-    def unapplySeq(any: Any): Option[Seq[Node]] = any match {
-      case s: Seq[_] => Some(s flatMap (_ match {
+    def unapplySeq(any: Any): Option[collection.Seq[Node]] = any match {
+      case s: collection.Seq[_] => Some(s flatMap (_ match {
         case n: Node => n case _ => NodeSeq.Empty
       })) case _ => None
     }

--- a/shared/src/test/scala/scala/xml/ShouldCompile.scala
+++ b/shared/src/test/scala/scala/xml/ShouldCompile.scala
@@ -14,7 +14,7 @@ object o {
 
 // t1761
 class Foo {
-  val elements: Seq[Node] = Nil
+  val elements: collection.Seq[Node] = Nil
   val innerTransform: PartialFunction[Elem, String] = {
     case Elem(_, l: String, _, _, _@ _*) if elements.exists(_.label == l) =>
       l
@@ -76,7 +76,7 @@ class Floozy {
 
 object guardedMatch { // SI-3705
   // guard caused verifyerror in oldpatmat -- TODO: move this to compiler test suite
-  def updateNodes(ns: Seq[Node]): Seq[Node] =
+  def updateNodes(ns: collection.Seq[Node]): collection.Seq[Node] =
     for (subnode <- ns) yield subnode match {
       case <d>{ _ }</d> if true => <d>abc</d>
       case Elem(prefix, label, attribs, scope, children @ _*) =>

--- a/shared/src/test/scala/scala/xml/Transformers.scala
+++ b/shared/src/test/scala/scala/xml/Transformers.scala
@@ -38,7 +38,7 @@ class Transformers {
       </root>
 
     object t1 extends RewriteRule {
-      override def transform(n: Node): Seq[Node] = n match {
+      override def transform(n: Node): collection.Seq[Node] = n match {
         case <version>{ x }</version> if x.toString.toInt < 4 => <version>{ x.toString.toInt + 1 }</version>
         case other => other
       }
@@ -63,7 +63,7 @@ class Transformers {
     val xmlNode = <a><b><c><h1>Hello Example</h1></c></b></a>
 
     new RuleTransformer(new RewriteRule {
-      override def transform(n: Node): Seq[Node] = {
+      override def transform(n: Node): collection.Seq[Node] = {
         n match {
           case t: Text if !t.text.trim.isEmpty => {
             i += 1

--- a/shared/src/test/scala/scala/xml/XMLSyntaxTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLSyntaxTest.scala
@@ -48,16 +48,16 @@ class XMLSyntaxTest {
     assertFalse(xh.child.map(_.isInstanceOf[Text]).exists(identity))
   }
 
-  /** see SVN r13821 (emir): support for <elem key={x:Option[Seq[Node]]} />,
+  /** see SVN r13821 (emir): support for <elem key={x:Option[collection.Seq[Node]]} />,
    *  so that Options can be used for optional attributes.
    */
   @Test
   def test2(): Unit = {
-    val x1: Option[Seq[Node]] = Some(<b>hello</b>)
+    val x1: Option[collection.Seq[Node]] = Some(<b>hello</b>)
     val n1 = <elem key={x1} />;
     assertEquals(x1, n1.attribute("key"))
 
-    val x2: Option[Seq[Node]] = None
+    val x2: Option[collection.Seq[Node]] = None
     val n2 = <elem key={x2} />;
     assertEquals(x2, n2.attribute("key"))
   }

--- a/shared/src/test/scala/scala/xml/XMLTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLTest.scala
@@ -471,9 +471,9 @@ Ours is the portal of hope, come as you are."
   def attributes = {
     val noAttr = <t/>
     val attrNull = <t a={ null: String }/>
-    val attrNone = <t a={ None: Option[Seq[Node]] }/>
+    val attrNone = <t a={ None: Option[collection.Seq[Node]] }/>
     val preAttrNull = <t p:a={ null: String }/>
-    val preAttrNone = <t p:a={ None: Option[Seq[Node]] }/>
+    val preAttrNone = <t p:a={ None: Option[collection.Seq[Node]] }/>
     assertEquals(noAttr, attrNull)
     assertEquals(noAttr, attrNone)
     assertEquals(noAttr, preAttrNull)


### PR DESCRIPTION
Changes uses of `scala.Seq` to `collection.Seq`, as in 2.13 the `scala.Seq` alias changes to be `scala.immutable.Seq`.

Some other changes that enable cross-building 2.11 ---> 2.13.

Also update the sbt-scala-module plugin.