### PR TITLE
Discard control characters in Utility.escape

### DIFF
--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -113,7 +113,7 @@ object Utility extends AnyRef with parsing.TokenTests {
     text.iterator.foldLeft(s) { (s, c) =>
       escMap.get(c) match {
         case Some(str)                             => s ++= str
-        case _ if c >= ' ' || "\n\r\t".contains(c) => s += c
+        case _ if !c.isControl || "\n\r\t".contains(c) => s += c
         case _ => s // noop
       }
     }


### PR DESCRIPTION
I encountered some input that happened to contain some control characters. This PR removes them from the output.

The previous behaviour used to exclude control characters in the smaller range. This PR excludes the ones between [`0x7F` (ASCII 127) and `0x9F` (ASCII 159)](https://docs.oracle.com/javase/10/docs/api/java/lang/Character.html#isISOControl(char)), plus possible future updates that Java supports.