### PR TITLE
Check secure feature processing enabled

### DIFF
--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -547,27 +547,27 @@ class XMLTestJVM {
 
   @UnitTest
   def issue17ExternalGeneralEntities: Unit = {
-    assertFalse(defaultParserFactory.getFeature("http://xml.org/sax/features/external-general-entities"))
+    assertTrue(defaultParserFactory.getFeature("http://xml.org/sax/features/external-general-entities"))
   }
 
   @UnitTest
   def issue17LoadExternalDtd: Unit = {
-    assertFalse(defaultParserFactory.getFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd"))
+    assertTrue(defaultParserFactory.getFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd"))
   }
 
   @UnitTest
   def issue17DisallowDoctypeDecl: Unit = {
-    assertTrue(defaultParserFactory.getFeature("http://apache.org/xml/features/disallow-doctype-decl"))
+    assertFalse(defaultParserFactory.getFeature("http://apache.org/xml/features/disallow-doctype-decl"))
   }
 
   @UnitTest
   def issue17ExternalParameterEntities: Unit = {
-    assertFalse(defaultParserFactory.getFeature("http://xml.org/sax/features/external-parameter-entities"))
+    assertTrue(defaultParserFactory.getFeature("http://xml.org/sax/features/external-parameter-entities"))
   }
 
   @UnitTest
   def issue17ResolveDtdUris: Unit = {
-    assertFalse(defaultParserFactory.getFeature("http://xml.org/sax/features/resolve-dtd-uris"))
+    assertTrue(defaultParserFactory.getFeature("http://xml.org/sax/features/resolve-dtd-uris"))
   }
 
   @UnitTest

--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -532,6 +532,54 @@ class XMLTestJVM {
     }
   }
 
+  /** Default SAXParserFactory */
+  val defaultParserFactory = javax.xml.parsers.SAXParserFactory.newInstance
+
+  @throws(classOf[org.xml.sax.SAXNotRecognizedException])
+  def issue17UnrecognizedFeature: Unit = {
+    assertTrue(defaultParserFactory.getFeature("foobar"))
+  }
+
+  @UnitTest
+  def issue17SecureProcessing: Unit = {
+    assertTrue(defaultParserFactory.getFeature("http://javax.xml.XMLConstants/feature/secure-processing"))
+  }
+
+  @UnitTest
+  def issue17ExternalGeneralEntities: Unit = {
+    assertFalse(defaultParserFactory.getFeature("http://xml.org/sax/features/external-general-entities"))
+  }
+
+  @UnitTest
+  def issue17LoadExternalDtd: Unit = {
+    assertFalse(defaultParserFactory.getFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd"))
+  }
+
+  @UnitTest
+  def issue17DisallowDoctypeDecl: Unit = {
+    assertTrue(defaultParserFactory.getFeature("http://apache.org/xml/features/disallow-doctype-decl"))
+  }
+
+  @UnitTest
+  def issue17ExternalParameterEntities: Unit = {
+    assertFalse(defaultParserFactory.getFeature("http://xml.org/sax/features/external-parameter-entities"))
+  }
+
+  @UnitTest
+  def issue17ResolveDtdUris: Unit = {
+    assertFalse(defaultParserFactory.getFeature("http://xml.org/sax/features/resolve-dtd-uris"))
+  }
+
+  @UnitTest
+  def issue17isXIncludeAware: Unit = {
+    assertFalse(XML.parser.isXIncludeAware)
+  }
+
+  @UnitTest
+  def issue17isNamespaceAware: Unit = {
+    assertFalse(XML.parser.isNamespaceAware)
+  }
+
   @UnitTest
   def issue28: Unit = {
     val x = <x:foo xmlns:x="gaga"/>


### PR DESCRIPTION
With respect to #177, it appears that 3 of the 8 security features in JAXP/SAX/Xerces are already enabled by default all the way back to JDK 6.  They are:

- `http://javax.xml.XMLConstants/feature/secure-processing` is already enabled
- `isXIncludeAware` is already disabled
- `isNamespaceAware` is already disabled

These 5 are not enabled:

```
http://xml.org/sax/features/external-general-entities
http://apache.org/xml/features/nonvalidating/load-external-dtd
http://apache.org/xml/features/disallow-doctype-decl
http://xml.org/sax/features/external-parameter-entities
http://xml.org/sax/features/resolve-dtd-uris
```