### PR TITLE
Fix OOM for ConstructingParser

### DIFF
--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -767,47 +767,46 @@ class XMLTestJVM {
   }
 
   @UnitTest(expected = classOf[FatalError])
-  def shouldThrowFatalErrorWhenCantFindRequestedXToken {
-    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
-
-    x.xToken('b')
+  def xTokenFailure {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("a"), false)
+    assertEquals((): Unit, x.xToken('b'))
   }
 
   @UnitTest(expected = classOf[FatalError])
-  def shouldThrowFatalErrorWhenCantFindRequestedXCharData {
-    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+  def xCharDataFailure {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString(""), false)
 
     x.xCharData
   }
 
   @UnitTest(expected = classOf[FatalError])
-  def shouldThrowFatalErrorWhenCantFindRequestedXComment {
-    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+  def xCommentFailure {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString(""), false)
 
     x.xComment
   }
 
   @UnitTest(expected = classOf[FatalError])
-  def shouldThrowFatalErrorWhenCantFindRequestedXmlProcInstr {
-    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+  def xmlProcInstrFailure {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("aa"), false)
 
-    x.xmlProcInstr()
+    assertEquals(new UnprefixedAttribute("aa", Text(""), Null), x.xmlProcInstr)
   }
 
   @Ignore("Ignored for future fix, currently throw OOE because of infinity MarkupParserCommon:66")
   @UnitTest(expected = classOf[FatalError])
-  def shouldThrowFatalErrorWhenCantFindRequestedXAttributeValue {
-    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+  def xAttributeValueFailure {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString(""), false)
 
-    x.xAttributeValue()
+    x.xAttributeValue
   }
 
   @Ignore("Ignored for future fix, currently return unexpected result")
   @UnitTest(expected = classOf[FatalError])
-  def shouldThrowFatalErrorWhenCantFindRequestedXEntityValue {
-    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+  def xEntityValueFailure {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString(""), false)
 
-    assertEquals("a/>", x.xEntityValue())
+    x.xEntityValue
   }
 
 }

--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -633,7 +633,7 @@ class XMLTestJVM {
   import scala.xml.parsing._
   @UnitTest
   def dontLoop: Unit = {
-    val xml = "<!DOCTYPE xmeml SYSTEM> <xmeml> <sequence> </sequence> </xmeml> "
+    val xml = "<!DOCTYPE xmeml SYSTEM 'uri'> <xmeml> <sequence> </sequence> </xmeml> "
     val sink = new PrintStream(new ByteArrayOutputStream())
     (Console withOut sink) {
       (Console withErr sink) {
@@ -765,4 +765,49 @@ class XMLTestJVM {
     val formatted = pp.format(x)
     assertEquals(x, XML.loadString(formatted))
   }
+
+  @UnitTest(expected = classOf[FatalError])
+  def shouldThrowFatalErrorWhenCantFindRequestedXToken {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+
+    x.xToken('b')
+  }
+
+  @UnitTest(expected = classOf[FatalError])
+  def shouldThrowFatalErrorWhenCantFindRequestedXCharData {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+
+    x.xCharData
+  }
+
+  @UnitTest(expected = classOf[FatalError])
+  def shouldThrowFatalErrorWhenCantFindRequestedXComment {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+
+    x.xComment
+  }
+
+  @UnitTest(expected = classOf[FatalError])
+  def shouldThrowFatalErrorWhenCantFindRequestedXmlProcInstr {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+
+    x.xmlProcInstr()
+  }
+
+  @Ignore("Ignored for future fix, currently throw OOE because of infinity MarkupParserCommon:66")
+  @UnitTest(expected = classOf[FatalError])
+  def shouldThrowFatalErrorWhenCantFindRequestedXAttributeValue {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+
+    x.xAttributeValue()
+  }
+
+  @Ignore("Ignored for future fix, currently return unexpected result")
+  @UnitTest(expected = classOf[FatalError])
+  def shouldThrowFatalErrorWhenCantFindRequestedXEntityValue {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("<a/>"), false)
+
+    assertEquals("a/>", x.xEntityValue())
+  }
+
 }

--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -766,57 +766,62 @@ class XMLTestJVM {
     assertEquals(x, XML.loadString(formatted))
   }
 
+  def toSource(s: String) = new scala.io.Source {
+    val iter = s.iterator
+    override def reportError(pos: Int, msg: String, out: java.io.PrintStream = Console.err): Unit = {}
+  }
+
   @UnitTest
   def xTokenTest {
-    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("a"), false)
+    val x = xml.parsing.ConstructingParser.fromSource(toSource("a"), false)
     assertEquals((): Unit, x.xToken('b'))
   }
 
   @UnitTest(expected = classOf[FatalError])
   def xCharDataFailure {
-    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString(""), false)
+    val x = xml.parsing.ConstructingParser.fromSource(toSource(""), false)
 
     x.xCharData
   }
 
   @UnitTest(expected = classOf[FatalError])
   def xCommentFailure {
-    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString(""), false)
+    val x = xml.parsing.ConstructingParser.fromSource(toSource(""), false)
 
     x.xComment
   }
 
   @UnitTest
   def xmlProcInstrTest {
-    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("aa"), false)
+    val x = xml.parsing.ConstructingParser.fromSource(toSource("aa"), false)
 
     assertEquals(new UnprefixedAttribute("aa", Text(""), Null), x.xmlProcInstr)
   }
 
   @UnitTest(expected = classOf[FatalError])
   def notationDeclFailure {
-    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString(""), false)
+    val x = xml.parsing.ConstructingParser.fromSource(toSource(""), false)
 
     x.notationDecl
   }
 
   @UnitTest
   def pubidLiteralTest {
-    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString(""), false)
+    val x = xml.parsing.ConstructingParser.fromSource(toSource(""), false)
 
     assertEquals("", x.pubidLiteral)
   }
 
   @UnitTest
   def xAttributeValueTest {
-    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("'"), false)
+    val x = xml.parsing.ConstructingParser.fromSource(toSource("'"), false)
 
     assertEquals("", x.xAttributeValue)
   }
 
   @UnitTest
   def xEntityValueTest {
-    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString(""), false)
+    val x = xml.parsing.ConstructingParser.fromSource(toSource(""), false)
 
     assertEquals("", x.xEntityValue)
   }

--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -766,8 +766,8 @@ class XMLTestJVM {
     assertEquals(x, XML.loadString(formatted))
   }
 
-  @UnitTest(expected = classOf[FatalError])
-  def xTokenFailure {
+  @UnitTest
+  def xTokenTest {
     val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("a"), false)
     assertEquals((): Unit, x.xToken('b'))
   }
@@ -786,27 +786,39 @@ class XMLTestJVM {
     x.xComment
   }
 
-  @UnitTest(expected = classOf[FatalError])
-  def xmlProcInstrFailure {
+  @UnitTest
+  def xmlProcInstrTest {
     val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("aa"), false)
 
     assertEquals(new UnprefixedAttribute("aa", Text(""), Null), x.xmlProcInstr)
   }
 
-  @Ignore("Ignored for future fix, currently throw OOE because of infinity MarkupParserCommon:66")
   @UnitTest(expected = classOf[FatalError])
-  def xAttributeValueFailure {
+  def notationDeclFailure {
     val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString(""), false)
 
-    x.xAttributeValue
+    x.notationDecl
   }
 
-  @Ignore("Ignored for future fix, currently return unexpected result")
-  @UnitTest(expected = classOf[FatalError])
-  def xEntityValueFailure {
+  @UnitTest
+  def pubidLiteralTest {
     val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString(""), false)
 
-    x.xEntityValue
+    assertEquals("", x.pubidLiteral)
+  }
+
+  @UnitTest
+  def xAttributeValueTest {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString("'"), false)
+
+    assertEquals("", x.xAttributeValue)
+  }
+
+  @UnitTest
+  def xEntityValueTest {
+    val x = xml.parsing.ConstructingParser.fromSource(io.Source.fromString(""), false)
+
+    assertEquals("", x.xEntityValue)
   }
 
 }

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
@@ -397,7 +397,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
       } else sb.append(ch)
       nextch()
     }
-    throw truncatedError("broken comment")
+    truncatedError("broken comment")
   }
 
   /* todo: move this into the NodeBuilder class */
@@ -928,7 +928,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
       new PublicID(pubID, sysID)
     } else {
       reportSyntaxError("PUBLIC or SYSTEM expected")
-      scala.sys.error("died parsing notationdecl")
+      truncatedError("died parsing notationdecl")
     }
     xSpaceOpt()
     xToken('>')

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
@@ -19,7 +19,7 @@ import Utility.SU
  *  All members should be accessed through those.
  */
 private[scala] trait MarkupParserCommon extends TokenTests {
-  protected def unreachable = scala.sys.error("Cannot be reached.")
+  protected def unreachable = truncatedError("Cannot be reached.")
 
   // type HandleType       // MarkupHandler, SymbolicXMLBuilder
   type InputType // Source, CharArrayReader
@@ -62,7 +62,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
     val buf = new StringBuilder
     while (ch != endCh && !eof) {
       // well-formedness constraint
-      if (ch == '<') return errorAndResult("'<' not allowed in attrib value", "")
+      if (ch == '<') reportSyntaxError("'<' not allowed in attrib value")
       else if (ch == SU) truncatedError("")
       else buf append ch_returning_nextch
     }
@@ -241,11 +241,11 @@ private[scala] trait MarkupParserCommon extends TokenTests {
       val head = until.head
       val rest = until.tail
 
-      while (true) {
+      while (!eof) {
         if (ch == head && peek(rest))
           return handler(positioner(), sb.toString)
         else if (ch == SU || eof)
-          truncatedError("") // throws TruncatedXMLControl in compiler
+          truncatedError(s"died parsing until $until") // throws TruncatedXMLControl in compiler
 
         sb append ch
         nextch()


### PR DESCRIPTION
This tries to fix the long-standing defects in `ConstructingParser` that were shown to cause out of memory exceptions.   The original tests contributed by Artem Stasiuk in #32 presumed fixing the methods would make them throw exceptions.   I made a more minimal fix:  I followed the suggestions of A.P. Marki that not every syntax error is fatal, and that it is better to address the infinite loops in various method than actually terminate processing with an exception.  Admittedly, this code is pretty inconsistent with respect to termination.  I suggest we take that on later.

To be honest, making further improvements would have consequences in the behavior of `XMLEventReader`.  I decided to not go there.  There is a plan to drop `XMLEventReader` in #200.  Given, my most recent experience here, I'd say that's still a good idea.