### PR TITLE
Re-work 2.13 collections changes

### DIFF
--- a/jvm/src/test/scala/scala/xml/ReuseNodesTest.scala
+++ b/jvm/src/test/scala/scala/xml/ReuseNodesTest.scala
@@ -1,6 +1,7 @@
 package scala.xml
 
 import scala.xml.transform._
+import scala.collection.Seq
 import org.junit.Assert.assertSame
 import org.junit.experimental.theories.Theories
 import org.junit.experimental.theories.Theory

--- a/jvm/src/test/scala/scala/xml/SerializationTest.scala
+++ b/jvm/src/test/scala/scala/xml/SerializationTest.scala
@@ -1,5 +1,6 @@
 package scala.xml
 
+import scala.collection.Seq
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -11,6 +11,7 @@ import java.io.StringWriter
 import java.io.ByteArrayOutputStream
 import java.io.StringReader
 import scala.collection.Iterable
+import scala.collection.Seq
 import scala.xml.Utility.sort
 
 object XMLTestJVM {

--- a/shared/src/main/scala/scala/xml/Atom.scala
+++ b/shared/src/main/scala/scala/xml/Atom.scala
@@ -9,6 +9,8 @@
 package scala
 package xml
 
+import scala.collection.Seq
+
 /**
  * The class `Atom` provides an XML node for text (`PCDATA`).
  *  It is used in both non-bound and bound XML representations.

--- a/shared/src/main/scala/scala/xml/Attribute.scala
+++ b/shared/src/main/scala/scala/xml/Attribute.scala
@@ -9,6 +9,8 @@
 package scala
 package xml
 
+import scala.collection.Seq
+
 /**
  * This singleton object contains the `apply` and `unapply` methods for
  *  convenient construction and deconstruction.

--- a/shared/src/main/scala/scala/xml/Document.scala
+++ b/shared/src/main/scala/scala/xml/Document.scala
@@ -9,6 +9,8 @@
 package scala
 package xml
 
+import scala.collection.Seq
+
 /**
  * A document information item (according to InfoSet spec). The comments
  *  are copied from the Infoset spec, only augmented with some information

--- a/shared/src/main/scala/scala/xml/Elem.scala
+++ b/shared/src/main/scala/scala/xml/Elem.scala
@@ -11,6 +11,8 @@
 package scala
 package xml
 
+import scala.collection.Seq
+
 /**
  * This singleton object contains the `apply` and `unapplySeq` methods for
  *  convenient construction and deconstruction. It is possible to deconstruct

--- a/shared/src/main/scala/scala/xml/Equality.scala
+++ b/shared/src/main/scala/scala/xml/Equality.scala
@@ -9,6 +9,8 @@
 package scala
 package xml
 
+import scala.collection.Seq
+
 /**
  * In an attempt to contain the damage being inflicted on consistency by the
  *  ad hoc `equals` methods spread around `xml`, the logic is centralized and

--- a/shared/src/main/scala/scala/xml/Group.scala
+++ b/shared/src/main/scala/scala/xml/Group.scala
@@ -9,6 +9,8 @@
 package scala
 package xml
 
+import scala.collection.Seq
+
 /**
  * A hack to group XML nodes in one node for output.
  *

--- a/shared/src/main/scala/scala/xml/MetaData.scala
+++ b/shared/src/main/scala/scala/xml/MetaData.scala
@@ -14,6 +14,7 @@ package xml
 import Utility.sbToString
 import scala.annotation.tailrec
 import scala.collection.AbstractIterable
+import scala.collection.Seq
 
 object MetaData {
   /**

--- a/shared/src/main/scala/scala/xml/NamespaceBinding.scala
+++ b/shared/src/main/scala/scala/xml/NamespaceBinding.scala
@@ -9,6 +9,7 @@
 package scala
 package xml
 
+import scala.collection.Seq
 import Utility.sbToString
 
 /**

--- a/shared/src/main/scala/scala/xml/Node.scala
+++ b/shared/src/main/scala/scala/xml/Node.scala
@@ -9,6 +9,8 @@
 package scala
 package xml
 
+import scala.collection.Seq
+
 /**
  * This singleton object contains the `unapplySeq` method for
  *  convenient deconstruction.

--- a/shared/src/main/scala/scala/xml/NodeSeq.scala
+++ b/shared/src/main/scala/scala/xml/NodeSeq.scala
@@ -13,6 +13,7 @@ import scala.collection.{ mutable, immutable, generic, SeqLike, AbstractSeq }
 import mutable.{ Builder, ListBuffer }
 import generic.{ CanBuildFrom }
 import scala.language.implicitConversions
+import scala.collection.Seq
 
 /**
  * This object ...

--- a/shared/src/main/scala/scala/xml/Null.scala
+++ b/shared/src/main/scala/scala/xml/Null.scala
@@ -11,6 +11,7 @@ package xml
 
 import Utility.isNameStart
 import scala.collection.Iterator
+import scala.collection.Seq
 
 /**
  * Essentially, every method in here is a dummy, returning Zero[T].

--- a/shared/src/main/scala/scala/xml/PrefixedAttribute.scala
+++ b/shared/src/main/scala/scala/xml/PrefixedAttribute.scala
@@ -9,6 +9,8 @@
 package scala
 package xml
 
+import scala.collection.Seq
+
 /**
  * prefixed attributes always have a non-null namespace.
  *

--- a/shared/src/main/scala/scala/xml/PrettyPrinter.scala
+++ b/shared/src/main/scala/scala/xml/PrettyPrinter.scala
@@ -9,6 +9,7 @@
 package scala
 package xml
 
+import scala.collection.Seq
 import Utility.sbToString
 
 /**

--- a/shared/src/main/scala/scala/xml/TextBuffer.scala
+++ b/shared/src/main/scala/scala/xml/TextBuffer.scala
@@ -9,6 +9,7 @@
 package scala
 package xml
 
+import scala.collection.Seq
 import Utility.isSpace
 
 object TextBuffer {

--- a/shared/src/main/scala/scala/xml/UnprefixedAttribute.scala
+++ b/shared/src/main/scala/scala/xml/UnprefixedAttribute.scala
@@ -9,6 +9,8 @@
 package scala
 package xml
 
+import scala.collection.Seq
+
 /**
  * Unprefixed attributes have the null namespace, and no prefix field
  *

--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -11,6 +11,7 @@ package xml
 
 import scala.collection.mutable
 import scala.language.implicitConversions
+import scala.collection.Seq
 
 /**
  * The `Utility` object provides utility functions for processing instances

--- a/shared/src/main/scala/scala/xml/Xhtml.scala
+++ b/shared/src/main/scala/scala/xml/Xhtml.scala
@@ -4,6 +4,7 @@ package xml
 
 import parsing.XhtmlEntities
 import Utility.{ sbToString, isAtomAndNotText }
+import scala.collection.Seq
 
 /* (c) David Pollak  2007 WorldWide Conferencing, LLC */
 

--- a/shared/src/main/scala/scala/xml/dtd/ContentModel.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ContentModel.scala
@@ -10,6 +10,7 @@ package scala
 package xml
 package dtd
 
+import scala.collection.Seq
 import scala.xml.dtd.impl._
 import scala.xml.Utility.sbToString
 import PartialFunction._

--- a/shared/src/main/scala/scala/xml/dtd/DTD.scala
+++ b/shared/src/main/scala/scala/xml/dtd/DTD.scala
@@ -11,6 +11,7 @@ package xml
 package dtd
 
 import scala.collection.mutable
+import scala.collection.Seq
 
 /**
  * A document type declaration.

--- a/shared/src/main/scala/scala/xml/dtd/DocType.scala
+++ b/shared/src/main/scala/scala/xml/dtd/DocType.scala
@@ -10,6 +10,8 @@ package scala
 package xml
 package dtd
 
+import scala.collection.Seq
+
 /**
  * An XML node for document type declaration.
  *

--- a/shared/src/main/scala/scala/xml/dtd/ElementValidator.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ElementValidator.scala
@@ -12,6 +12,7 @@ package dtd
 
 import PartialFunction._
 import scala.collection.mutable
+import scala.collection.Seq
 
 import ContentModel.ElemName
 import MakeValidationException._ // @todo other exceptions

--- a/shared/src/main/scala/scala/xml/dtd/Scanner.scala
+++ b/shared/src/main/scala/scala/xml/dtd/Scanner.scala
@@ -10,6 +10,8 @@ package scala
 package xml
 package dtd
 
+import scala.collection.Seq
+
 /**
  * Scanner for regexps (content models in DTD element declarations)
  *  todo: cleanup

--- a/shared/src/main/scala/scala/xml/dtd/impl/BaseBerrySethi.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/BaseBerrySethi.scala
@@ -10,6 +10,7 @@ package scala
 package xml.dtd.impl
 
 import scala.collection.{ mutable, immutable }
+import scala.collection.Seq
 
 // todo: replace global variable pos with acc
 

--- a/shared/src/main/scala/scala/xml/dtd/impl/Inclusion.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/Inclusion.scala
@@ -9,6 +9,8 @@
 package scala
 package xml.dtd.impl
 
+import scala.collection.Seq
+
 /**
  * A fast test of language inclusion between minimal automata.
  *  inspired by the ''AMoRE automata library''.

--- a/shared/src/main/scala/scala/xml/dtd/impl/NondetWordAutom.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/NondetWordAutom.scala
@@ -48,7 +48,7 @@ private[dtd] abstract class NondetWordAutom[T <: AnyRef] {
   def nextDefault(Q: immutable.BitSet): immutable.BitSet = next(Q, default)
 
   private def next(Q: immutable.BitSet, f: (Int) => immutable.BitSet): immutable.BitSet =
-    (Q map f).foldLeft(immutable.BitSet.empty)(_ ++ _)
+    Q.toSet.map(f).foldLeft(immutable.BitSet.empty)(_ ++ _)
 
   private def finalStates = 0 until nstates filter isFinal
   override def toString = {

--- a/shared/src/main/scala/scala/xml/dtd/impl/NondetWordAutom.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/NondetWordAutom.scala
@@ -10,6 +10,7 @@ package scala
 package xml.dtd.impl
 
 import scala.collection.{ immutable, mutable }
+import scala.collection.Seq
 
 /**
  * A nondeterministic automaton. States are integers, where

--- a/shared/src/main/scala/scala/xml/dtd/impl/SubsetConstruction.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/SubsetConstruction.scala
@@ -20,8 +20,8 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
 
   def determinize: DetWordAutom[T] = {
     // for assigning numbers to bitsets
-    var indexMap = scala.collection.Map[immutable.BitSet, Int]()
-    var invIndexMap = scala.collection.Map[Int, immutable.BitSet]()
+    val indexMap = mutable.Map[immutable.BitSet, Int]()
+    val invIndexMap = mutable.Map[Int, immutable.BitSet]()
     var ix = 0
 
     // we compute the dfa with states = bitsets
@@ -30,15 +30,15 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
 
     var states = Set(q0, sink) // initial set of sets
     val delta = new mutable.HashMap[immutable.BitSet, mutable.HashMap[T, immutable.BitSet]]
-    var deftrans = mutable.Map(q0 -> sink, sink -> sink) // initial transitions
-    var finals: mutable.Map[immutable.BitSet, Int] = mutable.Map()
+    val deftrans = mutable.Map(q0 -> sink, sink -> sink) // initial transitions
+    val finals: mutable.Map[immutable.BitSet, Int] = mutable.Map()
     val rest = new mutable.Stack[immutable.BitSet]
 
     rest.push(sink, q0)
 
     def addFinal(q: immutable.BitSet): Unit = {
       if (nfa containsFinal q)
-        finals = finals.updated(q, selectTag(q, nfa.finals))
+        finals(q) = selectTag(q, nfa.finals)
     }
     def add(Q: immutable.BitSet): Unit = {
       if (!states(Q)) {
@@ -53,8 +53,8 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
     while (!rest.isEmpty) {
       val P = rest.pop()
       // assign a number to this bitset
-      indexMap = indexMap.updated(P, ix)
-      invIndexMap = invIndexMap.updated(ix, P)
+      indexMap(P) = ix
+      invIndexMap(ix) = P
       ix += 1
 
       // make transition map
@@ -69,7 +69,7 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
 
       // collect default transitions
       val Pdef = nfa nextDefault P
-      deftrans = deftrans.updated(P, Pdef)
+      deftrans(P) = Pdef
       add(Pdef)
     }
 

--- a/shared/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
@@ -10,6 +10,7 @@ package scala
 package xml.dtd.impl
 
 import scala.collection.{ immutable, mutable }
+import scala.collection.Seq
 
 /**
  * This class turns a regular expression into a [[scala.util.automata.NondetWordAutom]]

--- a/shared/src/main/scala/scala/xml/factory/LoggedNodeFactory.scala
+++ b/shared/src/main/scala/scala/xml/factory/LoggedNodeFactory.scala
@@ -10,6 +10,8 @@ package scala
 package xml
 package factory
 
+import scala.collection.Seq
+
 /**
  * This class logs what the nodefactory is actually doing.
  *  If you want to see what happens during loading, use it like this:

--- a/shared/src/main/scala/scala/xml/factory/NodeFactory.scala
+++ b/shared/src/main/scala/scala/xml/factory/NodeFactory.scala
@@ -10,6 +10,8 @@ package scala
 package xml
 package factory
 
+import scala.collection.Seq
+
 trait NodeFactory[A <: Node] {
   val ignoreComments = false
   val ignoreProcInstr = false

--- a/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
@@ -11,6 +11,7 @@ package xml
 package parsing
 
 import scala.collection.{ mutable, Iterator }
+import scala.collection.Seq
 import org.xml.sax.Attributes
 import org.xml.sax.helpers.DefaultHandler
 

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
@@ -358,7 +358,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     }
     nextch()
     val str = cbuf.toString()
-    cbuf.length = 0
+    cbuf.setLength(0)
     str
   }
 
@@ -390,7 +390,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     xToken("--")
     while (!eof) {
       if (ch == '-' && { sb.append(ch); nextch(); ch == '-' }) {
-        sb.length = sb.length - 1
+        sb.setLength(sb.length - 1)
         nextch()
         xToken('>')
         return handle.comment(pos, sb.toString())
@@ -608,7 +608,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
       exit = eof || (ch == '<') || (ch == '&')
     }
     val str = cbuf.toString
-    cbuf.length = 0
+    cbuf.setLength(0)
     str
   }
 
@@ -630,7 +630,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     }
     nextch()
     val str = cbuf.toString()
-    cbuf.length = 0
+    cbuf.setLength(0)
     str
   }
 
@@ -653,7 +653,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     }
     nextch()
     val str = cbuf.toString
-    cbuf.length = 0
+    cbuf.setLength(0)
     str
   }
 
@@ -799,7 +799,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     //Console.println("END["+ch+"]")
     nextch()
     val cmstr = cbuf.toString()
-    cbuf.length = 0
+    cbuf.setLength(0)
     handle.elemDecl(n, cmstr)
   }
 
@@ -826,7 +826,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
         nextch()
       }
       val atpe = cbuf.toString
-      cbuf.length = 0
+      cbuf.setLength(0)
 
       val defdecl: DefaultDecl = ch match {
         case '\'' | '"' =>
@@ -846,7 +846,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
       xSpaceOpt()
 
       attList ::= AttrDecl(aname, atpe, defdecl)
-      cbuf.length = 0
+      cbuf.setLength(0)
     }
     nextch()
     handle.attListDecl(n, attList.reverse)

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
@@ -10,6 +10,7 @@ package scala
 package xml
 package parsing
 
+import scala.collection.Seq
 import Utility.SU
 
 /**

--- a/shared/src/main/scala/scala/xml/parsing/NoBindingFactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/NoBindingFactoryAdapter.scala
@@ -10,6 +10,7 @@ package scala
 package xml
 package parsing
 
+import scala.collection.Seq
 import factory.NodeFactory
 
 /**

--- a/shared/src/main/scala/scala/xml/parsing/TokenTests.scala
+++ b/shared/src/main/scala/scala/xml/parsing/TokenTests.scala
@@ -10,6 +10,8 @@ package scala
 package xml
 package parsing
 
+import scala.collection.Seq
+
 /**
  * Helper functions for parsing XML fragments
  */

--- a/shared/src/main/scala/scala/xml/transform/BasicTransformer.scala
+++ b/shared/src/main/scala/scala/xml/transform/BasicTransformer.scala
@@ -10,6 +10,8 @@ package scala
 package xml
 package transform
 
+import scala.collection.Seq
+
 /**
  * A class for XML transformations.
  *

--- a/shared/src/main/scala/scala/xml/transform/RewriteRule.scala
+++ b/shared/src/main/scala/scala/xml/transform/RewriteRule.scala
@@ -10,6 +10,8 @@ package scala
 package xml
 package transform
 
+import scala.collection.Seq
+
 /**
  * A RewriteRule, when applied to a term, yields either
  *  the result of rewriting the term or the term itself if the rule

--- a/shared/src/main/scala/scala/xml/transform/RuleTransformer.scala
+++ b/shared/src/main/scala/scala/xml/transform/RuleTransformer.scala
@@ -10,6 +10,8 @@ package scala
 package xml
 package transform
 
+import scala.collection.Seq
+
 class RuleTransformer(rules: RewriteRule*) extends BasicTransformer {
   override def transform(n: Node): Seq[Node] =
     rules.foldLeft(super.transform(n)) { (res, rule) => rule transform res }

--- a/shared/src/test/scala/scala/xml/AttributeTest.scala
+++ b/shared/src/test/scala/scala/xml/AttributeTest.scala
@@ -1,5 +1,6 @@
 package scala.xml
 
+import scala.collection.Seq
 import org.junit.Test
 import org.junit.Assert.assertEquals
 

--- a/shared/src/test/scala/scala/xml/PatternMatching.scala
+++ b/shared/src/test/scala/scala/xml/PatternMatching.scala
@@ -1,5 +1,6 @@
 package scala.xml
 
+import scala.collection.Seq
 import org.junit.Test
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals

--- a/shared/src/test/scala/scala/xml/Transformers.scala
+++ b/shared/src/test/scala/scala/xml/Transformers.scala
@@ -1,5 +1,6 @@
 package scala.xml
 
+import scala.collection.Seq
 import scala.xml.transform._
 
 import org.junit.Test

--- a/shared/src/test/scala/scala/xml/UtilityTest.scala
+++ b/shared/src/test/scala/scala/xml/UtilityTest.scala
@@ -1,5 +1,6 @@
 package scala.xml
 
+import scala.collection.Seq
 import org.junit.Test
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals

--- a/shared/src/test/scala/scala/xml/XMLSyntaxTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLSyntaxTest.scala
@@ -1,5 +1,6 @@
 package scala.xml
 
+import scala.collection.Seq
 import org.junit.Test
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse

--- a/shared/src/test/scala/scala/xml/XMLTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLTest.scala
@@ -9,6 +9,7 @@ import org.junit.Assert.assertEquals
 // import scala.xml.parsing.ConstructingParser
 import java.io.StringWriter
 import scala.collection.Iterable
+import scala.collection.Seq
 import scala.xml.Utility.sort
 
 object XMLTest {


### PR DESCRIPTION
While verifying the #202 changes were binary compatible, I went and rebased and then re-worked the first changes from Lukas for the latest 2.13.x collections.  The result is a more minimal changeset, fwiw.

1. Use import statements for `scala.collection.Seq` instead of search-and-replace, 
1. preserve `mutable.Map`,
1. use `StringBuilder.setLength` instead of `StringBuilder.clear`