### PR TITLE
use latest sbt-scala-module

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.12")
+addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.14")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")


### PR DESCRIPTION
the release notes promise more JDK9 friendliness, which
interests me in case it helps in the 2.12.x/JDK9 community build.

but also just generally good to have all the modules on the
latest.