### PR TITLE
choose an sbt-osgi version according to JVM version

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,10 @@
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.14")
 
+if (System.getProperty("java.version").startsWith("1."))
+  Seq()
+else
+  // override to version that works on Java 9,
+  // see https://github.com/scala/sbt-scala-module/issues/35
+  Seq(addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.3"))
+
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")


### PR DESCRIPTION
since no single version works on both Java 6 and 9

references: https://github.com/scala/sbt-scala-module/issues/35
context: https://github.com/scala/community-builds/issues/609