### PR TITLE
Move to Scala 2.13.0-M4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jdk:
 scala:
   - 2.11.12
   - 2.12.6
-  - 2.13.0-M3
+  - 2.13.0-M4
 
 env:
   global:
@@ -30,13 +30,13 @@ env:
 
 matrix:
   exclude:
-    - scala: 2.13.0-M3
+    - scala: 2.13.0-M4
       env: SCALAJS_VERSION=1.0.0-M3
     - jdk: oraclejdk9
       env: SCALAJS_VERSION=1.0.0-M3
     - scala: 2.12.6
       jdk: openjdk6
-    - scala: 2.13.0-M3
+    - scala: 2.13.0-M4
       jdk: openjdk6
 
 script: admin/build.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ scala-xml
 [![Travis](https://img.shields.io/travis/scala/scala-xml.svg)](https://travis-ci.org/scala/scala-xml)
 [![latest release for 2.11](https://img.shields.io/maven-central/v/org.scala-lang.modules/scala-xml_2.11.svg?label=scala+2.11)](http://mvnrepository.com/artifact/org.scala-lang.modules/scala-xml_2.11)
 [![latest release for 2.12](https://img.shields.io/maven-central/v/org.scala-lang.modules/scala-xml_2.12.svg?label=scala+2.12)](http://mvnrepository.com/artifact/org.scala-lang.modules/scala-xml_2.12)
-[![latest release for 2.13.0-M3](https://img.shields.io/maven-central/v/org.scala-lang.modules/scala-xml_2.13.0-M3.svg?label=scala+2.13.0-M3)](http://mvnrepository.com/artifact/org.scala-lang.modules/scala-xml_2.13.0-M3)
+[![latest release for 2.13.0-M4](https://img.shields.io/maven-central/v/org.scala-lang.modules/scala-xml_2.13.0-M4.svg?label=scala+2.13.0-M4)](http://mvnrepository.com/artifact/org.scala-lang.modules/scala-xml_2.13.0-M4)
 [![Gitter](https://badges.gitter.im/Join+Chat.svg)](https://gitter.im/scala/scala-xml)
 =========
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,16 @@ lazy val xml = crossProject(JSPlatform, JVMPlatform)
       else Some("1.1.0")
     },
 
+    unmanagedSourceDirectories in Compile ++= {
+      (unmanagedSourceDirectories in Compile).value.map { dir =>
+        val sv = scalaVersion.value
+        CrossVersion.partialVersion(sv) match {
+          case Some((2, 13)) if !sv.startsWith("2.13.0-M3") => file(dir.getPath ++ "-2.13") // TODO: remove M3 guard once M4 is out.
+          case _             => file(dir.getPath ++ "-2.11-2.12")
+        }
+      }
+    },
+
     apiMappings ++= Map(
       scalaInstance.value.libraryJar
         -> url(s"http://www.scala-lang.org/api/${scalaVersion.value}/")

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtcrossproject.{crossProject, CrossType}
 import ScalaModulePlugin._
 
-crossScalaVersions in ThisBuild := List("2.12.6", "2.11.12", "2.13.0-M3")
+crossScalaVersions in ThisBuild := List("2.12.6", "2.11.12", "2.13.0-M4")
 
 lazy val xml = crossProject(JSPlatform, JVMPlatform)
   .withoutSuffixFor(JVMPlatform)
@@ -27,7 +27,7 @@ lazy val xml = crossProject(JSPlatform, JVMPlatform)
       (unmanagedSourceDirectories in Compile).value.map { dir =>
         val sv = scalaVersion.value
         CrossVersion.partialVersion(sv) match {
-          case Some((2, 13)) if !sv.startsWith("2.13.0-M3") => file(dir.getPath ++ "-2.13") // TODO: remove M3 guard once M4 is out.
+          case Some((2, 13)) => file(dir.getPath ++ "-2.13")
           case _             => file(dir.getPath ++ "-2.11-2.12")
         }
       }

--- a/shared/src/main/scala-2.11-2.12/scala/xml/ScalaVersionSpecific.scala
+++ b/shared/src/main/scala-2.11-2.12/scala/xml/ScalaVersionSpecific.scala
@@ -1,0 +1,22 @@
+package scala.xml
+
+import scala.collection.SeqLike
+import scala.collection.generic.CanBuildFrom
+
+object ScalaVersionSpecific {
+  import NodeSeq.Coll
+  type CBF[-From, -A, +C] = CanBuildFrom[From, A, C]
+  object NodeSeqCBF extends CanBuildFrom[Coll, Node, NodeSeq] {
+    def apply(from: Coll) = NodeSeq.newBuilder
+    def apply() = NodeSeq.newBuilder
+  }
+}
+
+trait ScalaVersionSpecificNodeSeq extends SeqLike[Node, NodeSeq] { self: NodeSeq =>
+  /** Creates a list buffer as builder for this class */
+  override protected[this] def newBuilder = NodeSeq.newBuilder
+}
+
+trait ScalaVersionSpecificNodeBuffer { self: NodeBuffer =>
+  override def stringPrefix: String = "NodeBuffer"
+}

--- a/shared/src/main/scala-2.11-2.12/scala/xml/ScalaVersionSpecific.scala
+++ b/shared/src/main/scala-2.11-2.12/scala/xml/ScalaVersionSpecific.scala
@@ -3,7 +3,7 @@ package scala.xml
 import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
 
-object ScalaVersionSpecific {
+private[xml] object ScalaVersionSpecific {
   import NodeSeq.Coll
   type CBF[-From, -A, +C] = CanBuildFrom[From, A, C]
   object NodeSeqCBF extends CanBuildFrom[Coll, Node, NodeSeq] {
@@ -12,11 +12,11 @@ object ScalaVersionSpecific {
   }
 }
 
-trait ScalaVersionSpecificNodeSeq extends SeqLike[Node, NodeSeq] { self: NodeSeq =>
+private[xml] trait ScalaVersionSpecificNodeSeq extends SeqLike[Node, NodeSeq] { self: NodeSeq =>
   /** Creates a list buffer as builder for this class */
   override protected[this] def newBuilder = NodeSeq.newBuilder
 }
 
-trait ScalaVersionSpecificNodeBuffer { self: NodeBuffer =>
+private[xml] trait ScalaVersionSpecificNodeBuffer { self: NodeBuffer =>
   override def stringPrefix: String = "NodeBuffer"
 }

--- a/shared/src/main/scala-2.13/scala/xml/ScalaVersionSpecific.scala
+++ b/shared/src/main/scala-2.13/scala/xml/ScalaVersionSpecific.scala
@@ -1,0 +1,27 @@
+package scala.xml
+
+import scala.collection.immutable.StrictOptimizedSeqOps
+import scala.collection.{SeqOps, immutable, mutable}
+import scala.collection.BuildFrom
+import scala.collection.mutable.Builder
+
+object ScalaVersionSpecific {
+  import NodeSeq.Coll
+  type CBF[-From, -A, +C] = BuildFrom[From, A, C]
+  object NodeSeqCBF extends BuildFrom[Coll, Node, NodeSeq] {
+    def newBuilder(from: Coll): Builder[Node, NodeSeq] = NodeSeq.newBuilder
+    def fromSpecificIterable(from: Coll)(it: Iterable[Node]): NodeSeq = (NodeSeq.newBuilder ++= from).result()
+  }
+}
+
+trait ScalaVersionSpecificNodeSeq
+  extends SeqOps[Node, immutable.Seq, NodeSeq]
+    with StrictOptimizedSeqOps[Node, immutable.Seq, NodeSeq] { self: NodeSeq =>
+  override def fromSpecificIterable(coll: Iterable[Node]): NodeSeq = (NodeSeq.newBuilder ++= coll).result()
+
+  override def newSpecificBuilder(): mutable.Builder[Node, NodeSeq] = NodeSeq.newBuilder
+}
+
+trait ScalaVersionSpecificNodeBuffer { self: NodeBuffer =>
+  override def className: String = "NodeBuffer"
+}

--- a/shared/src/main/scala-2.13/scala/xml/ScalaVersionSpecific.scala
+++ b/shared/src/main/scala-2.13/scala/xml/ScalaVersionSpecific.scala
@@ -5,7 +5,7 @@ import scala.collection.{SeqOps, immutable, mutable}
 import scala.collection.BuildFrom
 import scala.collection.mutable.Builder
 
-object ScalaVersionSpecific {
+private[xml] object ScalaVersionSpecific {
   import NodeSeq.Coll
   type CBF[-From, -A, +C] = BuildFrom[From, A, C]
   object NodeSeqCBF extends BuildFrom[Coll, Node, NodeSeq] {
@@ -14,14 +14,13 @@ object ScalaVersionSpecific {
   }
 }
 
-trait ScalaVersionSpecificNodeSeq
+private[xml] trait ScalaVersionSpecificNodeSeq
   extends SeqOps[Node, immutable.Seq, NodeSeq]
     with StrictOptimizedSeqOps[Node, immutable.Seq, NodeSeq] { self: NodeSeq =>
   override def fromSpecificIterable(coll: Iterable[Node]): NodeSeq = (NodeSeq.newBuilder ++= coll).result()
-
-  override def newSpecificBuilder(): mutable.Builder[Node, NodeSeq] = NodeSeq.newBuilder
+  override def newSpecificBuilder: mutable.Builder[Node, NodeSeq] = NodeSeq.newBuilder
 }
 
-trait ScalaVersionSpecificNodeBuffer { self: NodeBuffer =>
+private[xml] trait ScalaVersionSpecificNodeBuffer { self: NodeBuffer =>
   override def className: String = "NodeBuffer"
 }

--- a/shared/src/main/scala/scala/xml/NodeBuffer.scala
+++ b/shared/src/main/scala/scala/xml/NodeBuffer.scala
@@ -19,10 +19,7 @@ package xml
  *
  * @author  Burak Emir
  */
-class NodeBuffer extends scala.collection.mutable.ArrayBuffer[Node] {
-
-  override def stringPrefix: String = "NodeBuffer"
-
+class NodeBuffer extends scala.collection.mutable.ArrayBuffer[Node] with ScalaVersionSpecificNodeBuffer {
   /**
    * Append given object to this buffer, returns reference on this
    * `NodeBuffer` for convenience. Some rules apply:


### PR DESCRIPTION
Rebased the `newCollectionsRebase` branch on current master. This can go in now, no?