### PR TITLE
Rework Utility.trim

### DIFF
--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -46,11 +46,11 @@ object Utility extends AnyRef with parsing.TokenTests {
    */
   def trim(x: Node): Node = x match {
     case Elem(pre, lab, md, scp, child@_*) =>
-      val children = combineAdjacentTextNodes(child:_*) flatMap trimProper
+      val children = combineAdjacentTextNodes(child) flatMap trimProper
       Elem(pre, lab, md, scp, children.isEmpty, children: _*)
   }
 
-  private def combineAdjacentTextNodes(children: Node*): Seq[Node] = {
+  private def combineAdjacentTextNodes(children: Seq[Node]): Seq[Node] = {
     children.foldRight(Seq.empty[Node]) {
       case (Text(left), Text(right) +: nodes) => Text(left + right) +: nodes
       case (n, nodes) => n +: nodes
@@ -63,7 +63,7 @@ object Utility extends AnyRef with parsing.TokenTests {
    */
   def trimProper(x: Node): Seq[Node] = x match {
     case Elem(pre, lab, md, scp, child@_*) =>
-      val children = combineAdjacentTextNodes(child:_*) flatMap trimProper
+      val children = combineAdjacentTextNodes(child) flatMap trimProper
       Elem(pre, lab, md, scp, children.isEmpty, children: _*)
     case Text(s) =>
       new TextBuffer().append(s).toText

--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -52,8 +52,8 @@ object Utility extends AnyRef with parsing.TokenTests {
 
   private def combineAdjacentTextNodes(children: Node*): Seq[Node] = {
     children.foldRight(Seq.empty[Node]) {
-      case (Text(left), Text(right) +: accMinusLast) => Text(left + right) +: accMinusLast
-      case (n, acc) => n +: acc 
+      case (Text(left), Text(right) +: nodes) => Text(left + right) +: nodes
+      case (n, nodes) => n +: nodes
     }
   }
 


### PR DESCRIPTION
Follow-up to #113.

- Drop varargs from `Utility.combineAdjacentTextNodes`
- Rename some variables