### PR TITLE
Move build from JDK6 to JDK7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 language: scala
 
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
-
 jdk:
-  - openjdk6
+  - openjdk7
   - oraclejdk8
   - oraclejdk10
 
@@ -40,9 +35,9 @@ matrix:
     - scala: 2.11.12
       jdk: oraclejdk10
     - scala: 2.12.6
-      jdk: openjdk6
+      jdk: openjdk7
     - scala: 2.13.0-M3
-      jdk: openjdk6
+      jdk: openjdk7
 
 script: admin/build.sh
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The standard Scala XML library. Please file XML issues here, not at https://gith
 
 Since Scala 2.11, this library is a separate jar that can be omitted from Scala projects that do not use XML.
 
+Starting with version 1.1.1, the published jar of scala-xml will be built with Java 7 for Scala 2.11, rather than Java 6.  This change could introduce compatability issues for 2.11 users. More information at [sbt-scala-module#41](https://github.com/scala/sbt-scala-module/issues/41).
+
 The decoupling works because the compiler desugars XML literals in Scala source code into a set of method calls. Alternative implementations of these calls are welcome! (The calls are unfortunately only defined by the [implementation](https://github.com/scala/scala/blob/2.11.x/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala).)
 
 API documentation is available [here](http://www.scala-lang.org/api/current/scala-xml/scala/xml/index.html).

--- a/admin/README.md
+++ b/admin/README.md
@@ -23,7 +23,7 @@ After these steps, your `.travis.yml` should contain config of the form:
 language: scala
 
 jdk:
-  - openjdk6
+  - openjdk7
   - oraclejdk8
 
 scala:

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -16,7 +16,7 @@ set -e
 # of the existing tag. Then a new tag can be created for that commit, e.g., `v1.2.3#2.13.0-M5`.
 # Everything after the `#` in the tag name is ignored.
 
-if [[ "$TRAVIS_JDK_VERSION" == "openjdk6" && "$TRAVIS_SCALA_VERSION" =~ 2\.11\..* \
+if [[ "$TRAVIS_JDK_VERSION" == "openjdk7" && "$TRAVIS_SCALA_VERSION" =~ 2\.11\..* \
       || "$TRAVIS_JDK_VERSION" == "oraclejdk8" && "$TRAVIS_SCALA_VERSION" =~ 2\.1[23]\..* ]]; then
   RELEASE_COMBO=true;
 fi
@@ -52,4 +52,4 @@ if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
   fi
 fi
 
-sbt "++$TRAVIS_SCALA_VERSION" "$publishVersion" "$projectPrefix/clean" "$projectPrefix/test" "$projectPrefix/publishLocal" "$publishTask"
+sbt -Dhttps.protocols=TLSv1.2 "++$TRAVIS_SCALA_VERSION" "$publishVersion" "$projectPrefix/clean" "$projectPrefix/test" "$projectPrefix/publishLocal" "$publishTask"


### PR DESCRIPTION
Because Maven Central updated their servers to only support newer SSL/TLS protocols, a Java 6 build will be unable to publish.

Moving builds to Java 7 could have unintended consequences, since there may be changes in the Java class library between versions, but what else can be done?

More information at https://github.com/scala/sbt-scala-module/issues/41