### PR TITLE
Link to contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+Contributing
+============
+
+Please see the wiki for the scala-xml contributor guide:
+
+https://github.com/scala/scala-xml/wiki/Contributor-guide
+
+Thank you,
+
+The Scala XML maintainers

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ If you are cross-building a project that uses scala-xml with both Scala 2.10 and
 
 This library is community-maintained. The lead maintainer is [@aaron_s_hawley](https://github.com/ashawley).
 
+Contributors are welcome, and should read the [contributor guide](https://github.com/scala/scala-xml/wiki/Contributor-guide) on the wiki.
+
 ## Issues
 
 Many old issues from the Scala JIRA issue tracker have been migrated


### PR DESCRIPTION
Fixes #234.

As suggested, we started using the "good first issue" label for issues.  I've mentioned that in the [contributor guide](https://github.com/scala/scala-xml/wiki/Contributor-guide) on the wiki.  It was also suggested to mention something about contributing in the README, so I've done that and added a bare-bones `CONTRIBUTING.md` that also refers people to the wiki.