### PR TITLE
Move to Scala 2.13.0-M5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jdk:
 scala:
   - 2.11.12
   - 2.12.6
-  - 2.13.0-M4
+  - 2.13.0-M5
 
 env:
   global:
@@ -46,7 +46,7 @@ matrix:
       jdk: openjdk11
     - scala: 2.12.6
       jdk: openjdk6
-    - scala: 2.13.0-M4
+    - scala: 2.13.0-M5
       jdk: openjdk6
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,16 @@ env:
     # The empty SCALAJS_VERSION will only compile for the JVM
     - SCALAJS_VERSION=
     - SCALAJS_VERSION=0.6.25
-    - SCALAJS_VERSION=1.0.0-M5
+    - SCALAJS_VERSION=1.0.0-M6
 
 matrix:
   exclude:
     - jdk: openjdk11
       env: SCALAJS_VERSION=0.6.25
     - jdk: openjdk11
-      env: SCALAJS_VERSION=1.0.0-M5
+      env: SCALAJS_VERSION=1.0.0-M6
     - scala: 2.11.12
-      env: SCALAJS_VERSION=1.0.0-M5
+      env: SCALAJS_VERSION=1.0.0-M6
     - scala: 2.11.12
       jdk: oraclejdk8
     - scala: 2.11.12

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val xml = crossProject(JSPlatform, JVMPlatform)
     scalacOptions in Test  += "-Xxml:coalescing",
 
     mimaPreviousVersion := {
-      if (System.getenv("SCALAJS_VERSION") == "1.0.0-M5") None // No such release yet
+      if (System.getenv("SCALAJS_VERSION") == "1.0.0-M6") None // No such release yet
       else Some("1.1.1")
     },
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtcrossproject.{crossProject, CrossType}
 import ScalaModulePlugin._
 
-crossScalaVersions in ThisBuild := List("2.12.6", "2.11.12", "2.13.0-M4")
+crossScalaVersions in ThisBuild := List("2.12.6", "2.11.12", "2.13.0-M5")
 
 lazy val xml = crossProject(JSPlatform, JVMPlatform)
   .withoutSuffixFor(JVMPlatform)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,5 +9,5 @@ val scalaJSVersion =
   Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("0.6.25")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.14")

--- a/shared/src/main/scala-2.11-2.12/scala/xml/ScalaVersionSpecific.scala
+++ b/shared/src/main/scala-2.11-2.12/scala/xml/ScalaVersionSpecific.scala
@@ -20,3 +20,7 @@ private[xml] trait ScalaVersionSpecificNodeSeq extends SeqLike[Node, NodeSeq] { 
 private[xml] trait ScalaVersionSpecificNodeBuffer { self: NodeBuffer =>
   override def stringPrefix: String = "NodeBuffer"
 }
+
+private[xml] trait ScalaVersionSpecificIterableSerializable[+A] { // extends Iterable[A] {
+  // protected[this] override def writeReplace(): AnyRef = this
+}

--- a/shared/src/main/scala-2.13/scala/xml/ScalaVersionSpecific.scala
+++ b/shared/src/main/scala-2.13/scala/xml/ScalaVersionSpecific.scala
@@ -24,3 +24,7 @@ private[xml] trait ScalaVersionSpecificNodeSeq
 private[xml] trait ScalaVersionSpecificNodeBuffer { self: NodeBuffer =>
   override def className: String = "NodeBuffer"
 }
+
+private[xml] trait ScalaVersionSpecificIterableSerializable[+A] extends Iterable[A] {
+  protected[this] override def writeReplace(): AnyRef = this
+}

--- a/shared/src/main/scala-2.13/scala/xml/ScalaVersionSpecific.scala
+++ b/shared/src/main/scala-2.13/scala/xml/ScalaVersionSpecific.scala
@@ -1,7 +1,7 @@
 package scala.xml
 
 import scala.collection.immutable.StrictOptimizedSeqOps
-import scala.collection.{SeqOps, immutable, mutable}
+import scala.collection.{SeqOps, IterableOnce, immutable, mutable}
 import scala.collection.BuildFrom
 import scala.collection.mutable.Builder
 
@@ -10,14 +10,14 @@ private[xml] object ScalaVersionSpecific {
   type CBF[-From, -A, +C] = BuildFrom[From, A, C]
   object NodeSeqCBF extends BuildFrom[Coll, Node, NodeSeq] {
     def newBuilder(from: Coll): Builder[Node, NodeSeq] = NodeSeq.newBuilder
-    def fromSpecificIterable(from: Coll)(it: Iterable[Node]): NodeSeq = (NodeSeq.newBuilder ++= from).result()
+    def fromSpecific(from: Coll)(it: IterableOnce[Node]): NodeSeq = (NodeSeq.newBuilder ++= from).result()
   }
 }
 
 private[xml] trait ScalaVersionSpecificNodeSeq
   extends SeqOps[Node, immutable.Seq, NodeSeq]
     with StrictOptimizedSeqOps[Node, immutable.Seq, NodeSeq] { self: NodeSeq =>
-  override def fromSpecificIterable(coll: Iterable[Node]): NodeSeq = (NodeSeq.newBuilder ++= coll).result()
+  override def fromSpecific(coll: IterableOnce[Node]): NodeSeq = (NodeSeq.newBuilder ++= coll).result()
   override def newSpecificBuilder: mutable.Builder[Node, NodeSeq] = NodeSeq.newBuilder
 }
 

--- a/shared/src/main/scala/scala/xml/Elem.scala
+++ b/shared/src/main/scala/scala/xml/Elem.scala
@@ -36,7 +36,7 @@ object Elem {
 
   def unapplySeq(n: Node) = n match {
     case _: SpecialNode | _: Group => None
-    case _                         => Some((n.prefix, n.label, n.attributes, n.scope, n.child))
+    case _                         => Some((n.prefix, n.label, n.attributes, n.scope, n.child.toSeq))
   }
 
   import scala.sys.process._

--- a/shared/src/main/scala/scala/xml/MetaData.scala
+++ b/shared/src/main/scala/scala/xml/MetaData.scala
@@ -82,6 +82,7 @@ abstract class MetaData
   extends AbstractIterable[MetaData]
   with Iterable[MetaData]
   with Equality
+  with ScalaVersionSpecificIterableSerializable[MetaData]
   with Serializable {
 
   /**
@@ -225,6 +226,4 @@ abstract class MetaData
 
   final def remove(namespace: String, owner: Node, key: String): MetaData =
     remove(namespace, owner.scope, key)
-
-  protected[this] override def writeReplace(): AnyRef = this
 }

--- a/shared/src/main/scala/scala/xml/MetaData.scala
+++ b/shared/src/main/scala/scala/xml/MetaData.scala
@@ -225,4 +225,6 @@ abstract class MetaData
 
   final def remove(namespace: String, owner: Node, key: String): MetaData =
     remove(namespace, owner.scope, key)
+
+  protected[this] override def writeReplace(): AnyRef = this
 }

--- a/shared/src/main/scala/scala/xml/Node.scala
+++ b/shared/src/main/scala/scala/xml/Node.scala
@@ -24,7 +24,7 @@ object Node {
   /** the empty namespace */
   val EmptyNamespace = ""
 
-  def unapplySeq(n: Node) = Some((n.label, n.attributes, n.child))
+  def unapplySeq(n: Node) = Some((n.label, n.attributes, n.child.toSeq))
 }
 
 /**

--- a/shared/src/main/scala/scala/xml/NodeSeq.scala
+++ b/shared/src/main/scala/scala/xml/NodeSeq.scala
@@ -158,4 +158,6 @@ abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with S
   override def toString(): String = theSeq.mkString
 
   def text: String = (this map (_.text)).mkString
+
+  protected[this] override def writeReplace(): AnyRef = this
 }

--- a/shared/src/main/scala/scala/xml/NodeSeq.scala
+++ b/shared/src/main/scala/scala/xml/NodeSeq.scala
@@ -44,7 +44,7 @@ object NodeSeq {
  *
  *  @author  Burak Emir
  */
-abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with ScalaVersionSpecificNodeSeq with Equality with Serializable {
+abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with ScalaVersionSpecificNodeSeq with Equality with ScalaVersionSpecificIterableSerializable[Node] with Serializable {
   def theSeq: Seq[Node]
   def length = theSeq.length
   override def iterator = theSeq.iterator
@@ -158,6 +158,4 @@ abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with S
   override def toString(): String = theSeq.mkString
 
   def text: String = (this map (_.text)).mkString
-
-  protected[this] override def writeReplace(): AnyRef = this
 }

--- a/shared/src/main/scala/scala/xml/QNode.scala
+++ b/shared/src/main/scala/scala/xml/QNode.scala
@@ -16,5 +16,5 @@ package xml
  *  @author  Burak Emir
  */
 object QNode {
-  def unapplySeq(n: Node) = Some((n.scope.getURI(n.prefix), n.label, n.attributes, n.child))
+  def unapplySeq(n: Node) = Some((n.scope.getURI(n.prefix), n.label, n.attributes, n.child.toSeq))
 }

--- a/shared/src/test/scala/scala/xml/PatternMatching.scala
+++ b/shared/src/test/scala/scala/xml/PatternMatching.scala
@@ -58,9 +58,9 @@ class PatternMatching extends {
 
   object SafeNodeSeq {
     def unapplySeq(any: Any): Option[Seq[Node]] = any match {
-      case s: Seq[_] => Some(s flatMap (_ match {
+      case s: Seq[_] => Some((s flatMap (_ match {
         case n: Node => n case _ => NodeSeq.Empty
-      })) case _ => None
+      })).toSeq) case _ => None
     }
   }
 


### PR DESCRIPTION
Previously, #222.

Work from this branch has already been published from the 1.1.0 tag in #256.

- [x] Serialization problem, #254, affects only 2.13 builds
- [x] Scala.js 1.0.0-M5 not having a 2.13.0-M5 build