### PR TITLE
Fix null pointer exception in XhtmlParser

### DIFF
--- a/jvm/src/test/scala/scala/xml/parsing/ConstructingParserTest.scala
+++ b/jvm/src/test/scala/scala/xml/parsing/ConstructingParserTest.scala
@@ -4,6 +4,7 @@ package parsing
 import scala.io.Source
 import org.junit.Test
 import scala.xml.JUnitAssertsForXML.{ assertEquals => assertXml }
+import org.junit.Assert.assertEquals
 
 class ConstructingParserTest {
 
@@ -19,4 +20,55 @@ class ConstructingParserTest {
 
   }
 
+  /* Example of using SYSTEM in DOCTYPE */
+  @Test
+  def docbookTest = {
+    val xml =
+      """|<!DOCTYPE docbook SYSTEM 'docbook.dtd'>
+         |<book>
+         |  <title>Book</title>
+         |  <chapter>
+         |    <title>Chapter</title>
+         |    <para>Text</para>
+         |  </chapter>
+         |</book>""".stripMargin
+
+    val expected = <book>
+  <title>Book</title>
+  <chapter>
+    <title>Chapter</title>
+    <para>Text</para>
+  </chapter>
+</book>
+
+    val source = new Source {
+      val iter = xml.iterator
+      override def reportError(pos: Int, msg: String, out: java.io.PrintStream = Console.err) = {}
+    }
+
+    val doc = ConstructingParser.fromSource(source, true).document
+
+    assertEquals(expected, doc.theSeq)
+  }
+
+  /* Unsupported use of lowercase DOCTYPE and SYSTEM */
+  @Test(expected = classOf[scala.xml.parsing.FatalError])
+  def docbookFail: Unit = {
+    val xml =
+      """|<!doctype docbook system 'docbook.dtd'>
+         |<book>
+         |<title>Book</title>
+         |<chapter>
+         |<title>Chapter</title>
+         |<para>Text</para>
+         |</chapter>
+         |</book>""".stripMargin
+
+    val source = new Source {
+      val iter = xml.iterator
+      override def reportError(pos: Int, msg: String, out: java.io.PrintStream = Console.err) = {}
+    }
+
+    ConstructingParser.fromSource(source, true).content(TopScope)
+  }
 }

--- a/jvm/src/test/scala/scala/xml/parsing/XhtmlParserTest.scala
+++ b/jvm/src/test/scala/scala/xml/parsing/XhtmlParserTest.scala
@@ -1,0 +1,61 @@
+package scala.xml
+package parsing
+
+import scala.io.Source
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class XhtmlParserTest {
+
+  @Test
+  def issue259: Unit = {
+    val xml =
+      """|<!DOCTYPE html>
+         |<html xmlns="http://www.w3.org/1999/xhtml">
+         |  <head>
+         |    <meta charset="utf-8"/>
+         |  </head>
+         |  <body>
+         |    <p>Text</p>
+         |  </body>
+         |</html>""".stripMargin
+
+    val expected = <html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8"/>
+  </head>
+  <body>
+    <p>Text</p>
+  </body>
+</html>
+
+    assertEquals(expected, XhtmlParser(Source.fromString(xml)).theSeq)
+  }
+
+  @Test
+  def html4Strict: Unit = {
+    val xml =
+      """|<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+         |    "http://www.w3.org/TR/html4/strict.dtd">
+         |<html>
+         |  <head>
+         |    <title>Title</title>
+         |  </head>
+         |  <body>
+         |    <p>Text</p>
+         |  </body>
+         |</html>""".stripMargin
+
+    val expected = <html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Title</title>
+  </head>
+  <body>
+    <p>Text</p>
+  </body>
+</html>
+
+    assertEquals(expected, XhtmlParser(Source.fromString(xml)).theSeq)
+  }
+}

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
@@ -518,7 +518,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     xToken("DOCTYPE")
     xSpace()
     val n = xName
-    xSpace()
+    xSpaceOpt()
     //external ID
     if ('S' == ch || 'P' == ch) {
       extID = externalID()


### PR DESCRIPTION
Fixes #259.

This one-line change seems low enough risk that it could be included in the next bug-fix release.
