### PR TITLE
use openjdk11 not oraclejdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ sudo: required
 jdk:
   - openjdk6
   - oraclejdk8
-  - oraclejdk11
+  - openjdk11
 
 scala:
   - 2.11.12


### PR DESCRIPTION
historically the Oracle one was the most standard one, but with the
new licensing model for 11, it's really OpenJDK that's the standard
one now, and the Oracle one is a commercial-use thing

sequel to #262