### PR TITLE
Fix Decl.toString

### DIFF
--- a/shared/src/main/scala/scala/xml/dtd/Decl.scala
+++ b/shared/src/main/scala/scala/xml/dtd/Decl.scala
@@ -26,6 +26,7 @@ import Utility.sbToString
 sealed abstract class Decl
 
 sealed abstract class MarkupDecl extends Decl {
+  override def toString(): String = sbToString(buildString)
   def buildString(sb: StringBuilder): StringBuilder
 }
 

--- a/shared/src/test/scala/scala/xml/dtd/DeclTest.scala
+++ b/shared/src/test/scala/scala/xml/dtd/DeclTest.scala
@@ -1,0 +1,42 @@
+package scala.xml
+package dtd
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class DeclTest {
+
+  @Test
+  def elemDeclToString: Unit = {
+    assertEquals(
+      "<!ELEMENT x (#PCDATA)>",
+      ElemDecl("x", PCDATA).toString
+    )
+  }
+
+  @Test
+  def attListDeclToString: Unit = {
+
+    val expected =
+      """|<!ATTLIST x
+         |  y CDATA #REQUIRED
+         |  z CDATA #REQUIRED>""".stripMargin
+
+    val actual = AttListDecl("x",
+      List(
+        AttrDecl("y", "CDATA", REQUIRED),
+        AttrDecl("z", "CDATA", REQUIRED)
+      )
+    ).toString
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  def parsedEntityDeclToString: Unit = {
+    assertEquals(
+      """<!ENTITY foo SYSTEM "bar">""",
+      ParsedEntityDecl("foo", ExtDef(SystemID("bar"))).toString
+    )
+  }
+}


### PR DESCRIPTION
These type classes exist, but can't be serialized.   Fifteen years later, it's time to fix them.