### PR TITLE
Fix openjdk6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,15 @@ matrix:
     - scala: 2.13.0-M5
       jdk: openjdk6
 
+before_script:
+  - nvm install 8
+  - nvm use 8
+
 script: 
   # work around https://github.com/travis-ci/travis-ci/issues/9713
   - if [[ $JAVA_HOME = *java-6* ]]; then jdk_switcher use openjdk6; fi
   - java -version
+  - node -v
   - admin/build.sh
 
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: scala
 
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
-
 # Needed for openjdk6
+dist: precise
 sudo: required
+addons:
+  hosts:
+    - localhost
+  hostname: localhost.local
 
 jdk:
   - openjdk6


### PR DESCRIPTION
The build started failing:

```
$ ~/bin/install-jdk.sh --target "/home/travis/openjdk6" --workspace "/home/travis/.cache/install-jdk" --feature "6" --license "GPL" --cacerts
install-jdk.sh 2019-01-18 II
Expected feature release number in range of 9 to 13, but got: 6
The command "~/bin/install-jdk.sh --target "/home/travis/openjdk6" --workspace "/home/travis/.cache/install-jdk" --feature "6" --license "GPL" --cacerts" failed and exited with 3 during .
```

Downgrading from [Trusty](https://docs.travis-ci.com/user/reference/trusty/) back to [Precise](https://docs.travis-ci.com/user/reference/precise/) gives:

```
$ admin/build.sh
Downloading sbt launcher for 0.13.17:
  From  http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.17/sbt-launch.jar
    To  /home/travis/.sbt/launchers/0.13.17/sbt-launch.jar
*** buffer overflow detected ***: java terminated
```

This can be fixed with a [hostname setting](https://docs.travis-ci.com/user/hostname).