### PR TITLE
Fix SI-5645 Don't escape quotes in PCDATA

### DIFF
--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -315,7 +315,10 @@ class XMLTestJVM {
     val inputStream = new java.io.ByteArrayInputStream(outputStream.toByteArray)
     val streamReader = new java.io.InputStreamReader(inputStream, XML.encoding)
 
-    assertEquals(xml.toString, XML.load(streamReader).toString)
+    def unescapeQuotes(str: String) = 
+      "&quot;".r.replaceFirstIn(str, "\"")
+    val xmlFixed = unescapeQuotes(xml.toString)
+    assertEquals(xmlFixed, XML.load(streamReader).toString)
   }
 
   @UnitTest

--- a/shared/src/main/scala/scala/xml/Text.scala
+++ b/shared/src/main/scala/scala/xml/Text.scala
@@ -23,7 +23,7 @@ class Text(data: String) extends Atom[String](data) {
    *  specification.
    */
   override def buildString(sb: StringBuilder): StringBuilder =
-    Utility.escape(data, sb)
+    Utility.escapeText(data, sb)
 }
 
 /**

--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -128,6 +128,20 @@ object Utility extends AnyRef with parsing.TokenTests {
   }
 
   /**
+   * Appends escaped string to `s`, but not &quot;.
+   */
+  final def escapeText(text: String, s: StringBuilder): StringBuilder = {
+    val escTextMap = escMap - '"' // Remove quotes from escMap
+    text.iterator.foldLeft(s) { (s, c) =>
+      escTextMap.get(c) match {
+        case Some(str)                             => s ++= str
+        case _ if c >= ' ' || "\n\r\t".contains(c) => s += c
+        case _ => s // noop
+      }
+    }
+  }
+
+  /**
    * Appends unescaped string to `s`, `amp` becomes `&amp;`,
    * `lt` becomes `&lt;` etc..
    *

--- a/shared/src/test/scala/scala/xml/XMLTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLTest.scala
@@ -307,10 +307,10 @@ class XMLTest {
   @UnitTest
   def escape =
     assertEquals("""
- &quot;Come, come again, whoever you are, come!
+ "Come, come again, whoever you are, come!
 Heathen, fire worshipper or idolatrous, come!
 Come even if you broke your penitence a hundred times,
-Ours is the portal of hope, come as you are.&quot;
+Ours is the portal of hope, come as you are."
                               Mevlana Celaleddin Rumi""", <![CDATA[
  "Come, come again, whoever you are, come!
 Heathen, fire worshipper or idolatrous, come!
@@ -471,6 +471,22 @@ Ours is the portal of hope, come as you are."
     assertHonorsIterableContract(<a y={ null: String }/>.attributes)
     assertHonorsIterableContract(<a y={ null: String } x=""/>.attributes)
     assertHonorsIterableContract(<a a="" y={ null: String }/>.attributes)
+  }
+
+  @UnitTest
+  def t5645: Unit = {
+
+    val bar = "baz"
+    val script = <script type="text/javascript">
+      foo("{bar}");
+    </script>
+
+    val expected =
+      """|<script type="text/javascript">
+         |      foo("baz");
+         |    </script>""".stripMargin
+
+    assertEquals(expected, script.toString)
   }
 
   @UnitTest


### PR DESCRIPTION
Produces different output for `PCDATA` and `CDATA`.

Fixes #57.