### PR TITLE
drop references to Scala 2.10 from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,11 @@ scala-xml
 
 The standard Scala XML library. Please file XML issues here, not at https://github.com/scala/bug/issues.
 
-Since Scala 2.11, this library is a separate jar that can be omitted from Scala projects that do not use XML.
-
-The decoupling works because the compiler desugars XML literals in Scala source code into a set of method calls. Alternative implementations of these calls are welcome! (The calls are unfortunately only defined by the [implementation](https://github.com/scala/scala/blob/2.11.x/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala).)
+The decoupling of scala-xml from the Scala compiler and standard library is possible because the compiler desugars XML literals in Scala source code into a set of method calls. Alternative implementations of these calls are welcome! (The calls are unfortunately only defined by the [implementation](https://github.com/scala/scala/blob/2.11.x/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala).)
 
 API documentation is available [here](https://scala.github.io/scala-xml/api/1.2.0/scala/xml/).
 
 How to documentation is available in the [wiki](https://github.com/scala/scala-xml/wiki)
-
-## Cross-building with 2.10
-
-If you are cross-building a project that uses scala-xml with both Scala 2.10 and later Scala versions, take a look at [this example](https://github.com/scala/scala-module-dependency-sample).
 
 ## Maintenance status
 


### PR DESCRIPTION
context: https://github.com/scala/scala-module-dependency-sample/issues/21