### PR TITLE
Fix Java 11 API mappings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,12 +90,12 @@ lazy val xml = crossProject(JSPlatform, JVMPlatform)
             -> url("http://docs.oracle.com/javase/8/docs/api")
         )
       } getOrElse {
-        // If everything fails, jam in the Java 9 base module.
+        // If everything fails, jam in Java 11 modules.
         Map(
           file("/modules/java.base")
-            -> url("http://docs.oracle.com/javase/9/docs/api"),
+            -> url("https://docs.oracle.com/en/java/javase/11/docs/api/java.base"),
           file("/modules/java.xml")
-            -> url("http://docs.oracle.com/javase/9/docs/api")
+            -> url("https://docs.oracle.com/en/java/javase/11/docs/api/java.xml")
         )
       }
     }

--- a/shared/src/main/scala/scala/xml/package.scala
+++ b/shared/src/main/scala/scala/xml/package.scala
@@ -56,9 +56,6 @@ package scala
  * [[http://xerces.apache.org/ Xerces]] parser and is provided in Java
  * by [[javax.xml.parsers.SAXParser]].
  *
- * A less greedy XML reader can return data as a sequential collection
- * of events, see [[scala.xml.pull.XMLEventReader]].
- *
  * For more control of the input, use the parser written in Scala that
  * is provided, [[scala.xml.parsing.ConstructingParser]].
  *


### PR DESCRIPTION
Updating for Java LTS.  

We don't need or use this, but we may down the road.