### PR TITLE
Fix deprecation doc of Stack in FactoryAdapter

### DIFF
--- a/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
@@ -43,28 +43,28 @@ abstract class FactoryAdapter extends DefaultHandler with factory.XMLLoader[Node
     * 
     * Previously was a mutable [[scala.collection.mutable.Stack Stack]], but is now a mutable reference to an immutable [[scala.collection.immutable.List List]].
     * 
-    * @since 1.1.0 
+    * @since 2.0.0 
     */
   var attribStack = List.empty[MetaData]
   /** List of elements
     * 
     * Previously was a mutable [[scala.collection.mutable.Stack Stack]], but is now a mutable reference to an immutable [[scala.collection.immutable.List List]].
     * 
-    * @since 1.1.0 
+    * @since 2.0.0 
     */
   var hStack = List.empty[Node] // [ element ] contains siblings
   /** List of element names
     * 
     * Previously was a mutable [[scala.collection.mutable.Stack Stack]], but is now a mutable reference to an immutable [[scala.collection.immutable.List List]].
     * 
-    * @since 1.1.0 
+    * @since 2.0.0 
     */
   var tagStack = List.empty[String]
   /** List of namespaces
     * 
     * Previously was a mutable [[scala.collection.mutable.Stack Stack]], but is now a mutable reference to an immutable [[scala.collection.immutable.List List]].
     * 
-    * @since 1.1.0 
+    * @since 2.0.0 
     */
   var scopeStack = List.empty[NamespaceBinding]
 


### PR DESCRIPTION
Version numbers in `since` annotation were wrong.