### PR TITLE
Small compiler and scala-library deprecations

### DIFF
--- a/jvm/src/test/scala/scala/xml/ReuseNodesTest.scala
+++ b/jvm/src/test/scala/scala/xml/ReuseNodesTest.scala
@@ -32,7 +32,7 @@ object ReuseNodesTest {
     override def transform(ns: Seq[Node]): Seq[Node] = {
       val changed = ns flatMap transform
       
-      if (changed.length != ns.length || (changed, ns).zipped.exists(_ != _)) changed
+      if (changed.length != ns.length || changed.zip(ns).exists(p => p._1 != p._2)) changed
       else ns
     }
     override def transform(n:Node): Seq[Node] = super.transform(n)

--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -820,55 +820,55 @@ class XMLTestJVM {
   }
 
   @UnitTest
-  def xTokenTest {
+  def xTokenTest: Unit = {
     val x = xml.parsing.ConstructingParser.fromSource(toSource("a"), false)
     assertEquals((): Unit, x.xToken('b'))
   }
 
   @UnitTest(expected = classOf[FatalError])
-  def xCharDataFailure {
+  def xCharDataFailure: Unit = {
     val x = xml.parsing.ConstructingParser.fromSource(toSource(""), false)
 
     x.xCharData
   }
 
   @UnitTest(expected = classOf[FatalError])
-  def xCommentFailure {
+  def xCommentFailure: Unit = {
     val x = xml.parsing.ConstructingParser.fromSource(toSource(""), false)
 
     x.xComment
   }
 
   @UnitTest
-  def xmlProcInstrTest {
+  def xmlProcInstrTest: Unit = {
     val x = xml.parsing.ConstructingParser.fromSource(toSource("aa"), false)
 
     assertEquals(new UnprefixedAttribute("aa", Text(""), Null), x.xmlProcInstr)
   }
 
   @UnitTest(expected = classOf[FatalError])
-  def notationDeclFailure {
+  def notationDeclFailure: Unit = {
     val x = xml.parsing.ConstructingParser.fromSource(toSource(""), false)
 
     x.notationDecl
   }
 
   @UnitTest
-  def pubidLiteralTest {
+  def pubidLiteralTest: Unit = {
     val x = xml.parsing.ConstructingParser.fromSource(toSource(""), false)
 
     assertEquals("", x.pubidLiteral)
   }
 
   @UnitTest
-  def xAttributeValueTest {
+  def xAttributeValueTest: Unit = {
     val x = xml.parsing.ConstructingParser.fromSource(toSource("'"), false)
 
     assertEquals("", x.xAttributeValue)
   }
 
   @UnitTest
-  def xEntityValueTest {
+  def xEntityValueTest: Unit = {
     val x = xml.parsing.ConstructingParser.fromSource(toSource(""), false)
 
     assertEquals("", x.xEntityValue)

--- a/shared/src/main/scala/scala/xml/dtd/ExternalID.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ExternalID.scala
@@ -18,7 +18,7 @@ package dtd
 sealed abstract class ExternalID extends parsing.TokenTests {
   def quoted(s: String) = {
     val c = if (s contains '"') '\'' else '"'
-    c + s + c
+    c.toString + s + c
   }
 
   // public != null: PUBLIC " " publicLiteral " " [systemLiteral]

--- a/shared/src/main/scala/scala/xml/dtd/impl/DetWordAutom.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/DetWordAutom.scala
@@ -34,7 +34,7 @@ private[dtd] abstract class DetWordAutom[T <: AnyRef] {
     val sb = new StringBuilder("[DetWordAutom  nstates=")
     sb.append(nstates)
     sb.append(" finals=")
-    val map = Map(finals.zipWithIndex map (_.swap): _*)
+    val map = finals.zipWithIndex.map(_.swap).toMap
     sb.append(map.toString())
     sb.append(" delta=\n")
 

--- a/shared/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
@@ -144,7 +144,7 @@ private[dtd] abstract class WordBerrySethi extends BaseBerrySethi {
         if (x.isNullable) // initial state is final
           finals = finals.updated(0, finalTag)
 
-        val delta1 = immutable.Map(deltaq.zipWithIndex map (_.swap): _*)
+        val delta1 = deltaq.zipWithIndex.map(_.swap).toMap
         val finalsArr = (0 until pos map (k => finals.getOrElse(k, 0))).toArray // 0 == not final
 
         val deltaArr: Array[mutable.Map[_labelT, immutable.BitSet]] =

--- a/shared/src/main/scala/scala/xml/transform/BasicTransformer.scala
+++ b/shared/src/main/scala/scala/xml/transform/BasicTransformer.scala
@@ -34,7 +34,7 @@ abstract class BasicTransformer extends Function1[Node, Node] {
    */
   def transform(ns: Seq[Node]): Seq[Node] = {
     val changed = ns flatMap transform
-    if (changed.length != ns.length || (changed, ns).zipped.exists(_ != _)) changed
+    if (changed.length != ns.length || changed.zip(ns).exists(p => p._1 != p._2)) changed
     else ns
 }
 

--- a/shared/src/test/scala/scala/xml/PatternMatchingTest.scala
+++ b/shared/src/test/scala/scala/xml/PatternMatchingTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
 
-class PatternMatching extends {
+class PatternMatchingTest extends {
   @Test
   def unprefixedAttribute: Unit = {
     val li = List("1", "2", "3", "4")

--- a/shared/src/test/scala/scala/xml/TransformersTest.scala
+++ b/shared/src/test/scala/scala/xml/TransformersTest.scala
@@ -6,7 +6,7 @@ import scala.xml.transform._
 import org.junit.Test
 import org.junit.Assert.assertEquals
 
-class Transformers {
+class TransformersTest {
 
 
   def transformer = new RuleTransformer(new RewriteRule {


### PR DESCRIPTION
- The procedure syntax is deprecated
- Method + in class Char is deprecated
- Passing array to a varargs method is deprecated
- Predef.tuple2ToZippedOps is deprecated
