### PR TITLE
upgrade 1.x branch to sbt 0.13.18

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18


### PR DESCRIPTION
master is already on a newer version, but we are still
releasing from 1.x so it's safest to be on the latest 0.13.x