### PR TITLE
Remove deprecated methods from Elem

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,8 @@ lazy val xml = crossProject(JSPlatform, JVMPlatform)
         exclude[MissingTypesProblem]("scala.xml.SpecialNode"),
         exclude[MissingTypesProblem]("scala.xml.Text"),
         exclude[MissingTypesProblem]("scala.xml.Unparsed"),
+        exclude[DirectMissingMethodProblem]("scala.xml.Elem.this"),
+        exclude[DirectMissingMethodProblem]("scala.xml.Elem.apply"),
         // Scala 2.12 deprecated mutable.Stack, so we broke
         // binary compatibility for 2.0.0 in the following way:
         exclude[IncompatibleMethTypeProblem]("scala.xml.parsing.FactoryAdapter.scopeStack_="),

--- a/shared/src/main/scala/scala/xml/Elem.scala
+++ b/shared/src/main/scala/scala/xml/Elem.scala
@@ -20,16 +20,6 @@ import scala.collection.Seq
  *  syntax `case Elem(prefix, label, attribs, scope, child @ _*) => ...`
  */
 object Elem {
-  /**
-   * Build an Elem, setting its minimizeEmpty property to `true` if it has no children.  Note that this
-   *  default may not be exactly what you want, as some XML dialects don't permit some elements to be minimized.
-   *
-   * @deprecated This factory method is retained for backward compatibility; please use the other one, with which you
-   *             can specify your own preference for minimizeEmpty.
-   */
-  @deprecated("Use the other apply method in this object", "2.10.0")
-  def apply(prefix: String, label: String, attributes: MetaData, scope: NamespaceBinding, child: Node*): Elem =
-    apply(prefix, label, attributes, scope, child.isEmpty, child: _*)
 
   def apply(prefix: String, label: String, attributes: MetaData, scope: NamespaceBinding, minimizeEmpty: Boolean, child: Node*): Elem =
     new Elem(prefix, label, attributes, scope, minimizeEmpty, child: _*)
@@ -91,12 +81,8 @@ class Elem(
   attributes1: MetaData,
   override val scope: NamespaceBinding,
   val minimizeEmpty: Boolean,
-  val child: Node*)
-  extends Node with Serializable {
-  @deprecated("This constructor is retained for backward compatibility. Please use the primary constructor, which lets you specify your own preference for `minimizeEmpty`.", "2.10.0")
-  def this(prefix: String, label: String, attributes: MetaData, scope: NamespaceBinding, child: Node*) = {
-    this(prefix, label, attributes, scope, child.isEmpty, child: _*)
-  }
+  val child: Node*
+) extends Node with Serializable {
 
   final override def doCollectNamespaces = true
   final override def doTransform = true

--- a/shared/src/test/scala/scala/xml/AttributeTest.scala
+++ b/shared/src/test/scala/scala/xml/AttributeTest.scala
@@ -95,7 +95,7 @@ class AttributeTest {
   def attributePathDuplicateAttribute: Unit = {
     val xml = Elem(null, "foo",
       Attribute("bar", Text("apple"),
-        Attribute("bar", Text("orange"), Null)), TopScope)
+        Attribute("bar", Text("orange"), Null)), TopScope, true)
     assertEquals(Group(Text("apple")), xml \ "@bar")
   }
 

--- a/shared/src/test/scala/scala/xml/ShouldCompile.scala
+++ b/shared/src/test/scala/scala/xml/ShouldCompile.scala
@@ -58,7 +58,7 @@ class t2281B {
 
 // SI-5858
 object SI_5858 {
-  new Elem(null, null, Null, TopScope, Nil: _*) // was ambiguous
+  new Elem(null, null, Null, TopScope, true, Nil: _*) // was ambiguous
 }
 
 class Floozy {


### PR DESCRIPTION
Next release of scala-xml with be 2.0.  These have been marked deprecated for 6 years.