### PR TITLE
Use openjdk8 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 
 scala:

--- a/admin/README.md
+++ b/admin/README.md
@@ -23,8 +23,7 @@ After these steps, your `.travis.yml` should contain config of the form:
 language: scala
 
 jdk:
-  - openjdk6
-  - oraclejdk8
+  - openjdk8
 
 scala:
   - 2.11.12

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -16,7 +16,7 @@ set -e
 # of the existing tag. Then a new tag can be created for that commit, e.g., `v1.2.3#2.13.0-M5`.
 # Everything after the `#` in the tag name is ignored.
 
-if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8" && "$TRAVIS_SCALA_VERSION" =~ 2\.1[23]\..* ]]; then
+if [[ "$TRAVIS_JDK_VERSION" == "openjdk8" && "$TRAVIS_SCALA_VERSION" =~ 2\.1[23]\..* ]]; then
   RELEASE_COMBO=true;
 fi
 


### PR DESCRIPTION
Travis is failing for `oraclejdk8`, maybe now is a good excuse to switch to OpenJDK? ¯\\\_(ツ)\_/¯