### PR TITLE
Add config for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,115 @@
+version: 2.1
+
+executors:
+  scala_jdk8_executor:
+    docker:
+      - image: circleci/openjdk:8-jdk-node
+  scala_jdk11_executor:
+    docker:
+      - image: circleci/openjdk:11-jdk
+
+commands:
+  sbt_cmd:
+    description: "Build with sbt"
+    parameters:
+      scala_version:
+        type: string
+        default: 2.12.8
+      sbt_tasks:
+        type: string
+        default: update compile test:compile test doc package
+    steps:
+      - restore_cache:
+          keys:
+            - sbt-deps-v1-{{ checksum "build.sbt" }}
+            - sbt-deps-v1-
+      - run: sbt ++<< parameters.scala_version >> << parameters.sbt_tasks >>
+      - save_cache:
+          key: sbt-deps-v1-{{ checksum "build.sbt" }}
+          paths:
+            - "~/.ivy2/cache"
+            - "~/.sbt"
+            - "~/.m2"
+
+jobs:
+  scala_job:
+    executor: scala_<<parameters.java_version>>_executor
+    parameters:
+      scala_version:
+        description: "Scala version"
+        default: 2.12.8
+        type: string
+      java_version:
+        description: "Java version"
+        default: jdk8
+        type: string
+    steps:
+      - checkout
+      - run: java -version
+      - sbt_cmd:
+          scala_version: << parameters.scala_version >>
+          sbt_tasks: xml/update xml/compile xml/test:compile xml/test xml/doc xml/package
+  scalajs_job:
+    executor: scala_jdk8_executor
+    parameters:
+      scala_version:
+        description: "Scala version"
+        default: 2.12.8
+        type: string
+      scalajs_version:
+        description: "ScalaJS version"
+        default: 0.6.28
+        type: string
+    environment:
+      SCALAJS_VERSION: << parameters.scalajs_version >>
+    steps:
+      - checkout
+      - run: java -version
+      - run: node -v
+      - sbt_cmd:
+          scala_version: << parameters.scala_version >>
+          sbt_tasks: xmlJS/update xmlJS/compile xmlJS/test:compile xmlJS/test xmlJS/doc xmlJS/package
+
+workflows:
+  build:
+    jobs:
+      - scala_job:
+          name: 2.12.8
+          java_version: jdk8
+          scala_version: 2.12.8
+      - scala_job:
+          name: 2.13.0
+          java_version: jdk8
+          scala_version: 2.13.0
+      - scala_job:
+          name: dotty_0.16
+          java_version: jdk8
+          scala_version: 0.16.0-RC3
+      - scala_job:
+          name: jdk11_2.12.8
+          java_version: jdk11
+          scala_version: 2.12.8
+      - scala_job:
+          name: jdk11_2.13.0
+          java_version: jdk11
+          scala_version: 2.13.0
+      - scala_job:
+          name: dotty_0.16
+          java_version: jdk11
+          scala_version: 0.16.0-RC3
+      - scalajs_job:
+          name: sjs0.6_2.12
+          scala_version: 2.12.8
+          scalajs_version: 0.6.28
+      - scalajs_job:
+          name: sjs0.6_2.13
+          scala_version: 2.13.0
+          scalajs_version: 0.6.28
+      - scalajs_job:
+          name: sjs1.0.0-M8_2.12
+          scala_version: 2.12.8
+          scalajs_version: 1.0.0-M8
+      - scalajs_job:
+          name: sjs1.0.0-M8_2.13
+          scala_version: 2.13.0
+          scalajs_version: 1.0.0-M8


### PR DESCRIPTION
For some personal projects, I've found that Circle build times are fast (compared to Travis).  It might be nice to experiment with it, and have a backup build service.

I didn't bother reusing the shell script at `admin/build.sh`, which is release focused, anyway.  I decided to keep it plain YAML for now, since Circle is tricky.

This will need to be setup for this repo at Circle:

https://circleci.com/add-projects/gh/scala

It would at most maybe setup an SSH key and a webhook.

