### PR TITLE
Re-enable Coursier in sbt 1.3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ commands:
       - save_cache:
           key: sbt-deps-v1-{{ checksum "build.sbt" }}
           paths:
-            - "~/.coursier"
+            - "~/.cache/coursier"
             - "~/.ivy2/cache"
             - "~/.sbt"
             - "~/.m2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.sbt
     - $HOME/.sdkman
-    - $HOME/.coursier
+    - $HOME/.cache/coursier

--- a/build.sbt
+++ b/build.sbt
@@ -29,10 +29,6 @@ lazy val xml = crossProject(JSPlatform, JVMPlatform)
   .settings(
     name    := "scala-xml",
 
-    // See https://github.com/sbt/sbt/issues/4995
-    // doc task broken in sbt 1.3.0-RC4 and Scala 2.12.9
-    useCoursier := false,
-
     scalacOptions ++= {
       val opts =
         if (isDotty.value)


### PR DESCRIPTION
While upgrading to sbt 1.3.0, we needed to disable the Coursier feature.  It should be fixed in 1.3.2, which see https://github.com/sbt/sbt/issues/4995