### PR TITLE
Change test of error message for 2.13.2

### DIFF
--- a/jvm/src/test/scala-2.x/scala/xml/CompilerErrors.scala
+++ b/jvm/src/test/scala-2.x/scala/xml/CompilerErrors.scala
@@ -4,14 +4,30 @@ import org.junit.Test
 
 class CompilerErrors extends CompilerTesting {
   @Test
-  def t7185() =
-    expectXmlError("""|overloaded method value apply with alternatives:
+  def t7185() = {
+    // Error message 2.13.1 and earlier:
+    // expectXmlError("""|overloaded method value apply with alternatives:
+    //                   |  (f: scala.xml.Node => Boolean)scala.xml.NodeSeq <and>
+    //                   |  (i: Int)scala.xml.Node
+    //                   | cannot be applied to ()""".stripMargin,
+    //  """|object Test {
+    //     |  <e></e>()
+    //     |}""")
+
+    // Error message changed in Scala 2.13.2
+    // https://github.com/scala/scala/pull/8592
+    expectXmlError("overloaded method", // " apply "
+     """|object Test {
+        |  <e></e>()
+        |}""")
+    expectXmlError("""|with alternatives:
                       |  (f: scala.xml.Node => Boolean)scala.xml.NodeSeq <and>
                       |  (i: Int)scala.xml.Node
                       | cannot be applied to ()""".stripMargin,
      """|object Test {
         |  <e></e>()
         |}""")
+  }
 
   @Test
   def t1878_typer() =


### PR DESCRIPTION
This was uncovered in https://github.com/scala/community-build/pull/1025

This is a hacky work-around.  It may be possible to move the test upstream, but the compiler likely complains about missing the scala-xml dependency, first.  Prior efforts at moving tests upstream was in https://github.com/scala/scala/pull/8138.  
