### PR TITLE
Fix 1.x branch on Travis

### DIFF
--- a/.sbtrepos
+++ b/.sbtrepos
@@ -1,8 +1,0 @@
-[repositories]
-  local
-  local-preloaded-ivy: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
-  local-preloaded: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
-  maven-central:  http://repo1.maven.org/maven2/
-  sonatype-public: http://oss.sonatype.org/content/repositories/public
-  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
-  sbt-ivy-releases: http://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,7 @@
 language: scala
 
-# Needed for openjdk6
-dist: precise
-sudo: required
-addons:
-  hosts:
-    - localhost
-  hostname: localhost.local
-
 jdk:
-  - openjdk6
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 
 scala:
@@ -41,21 +32,9 @@ matrix:
     - scala: 2.11.12
       env: SCALAJS_VERSION=1.0.0-M8
     - scala: 2.11.12
-      jdk: oraclejdk8
-    - scala: 2.11.12
       jdk: openjdk11
-    - scala: 2.12.8
-      jdk: openjdk6
-    - scala: 2.13.0
-      jdk: openjdk6
-
-before_script:
-  - nvm install 8
-  - nvm use 8
 
 script:
-  # work around https://github.com/travis-ci/travis-ci/issues/9713
-  - if [[ $JAVA_HOME = *java-6* ]]; then jdk_switcher use openjdk6; fi
   - java -version
   - node -v
   - admin/build.sh

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -16,8 +16,7 @@ set -e
 # of the existing tag. Then a new tag can be created for that commit, e.g., `v1.2.3#2.13.0-M5`.
 # Everything after the `#` in the tag name is ignored.
 
-if [[ "$TRAVIS_JDK_VERSION" == "openjdk6" && "$TRAVIS_SCALA_VERSION" =~ 2\.11\..* \
-      || "$TRAVIS_JDK_VERSION" == "oraclejdk8" && "$TRAVIS_SCALA_VERSION" =~ 2\.1[23]\..* ]]; then
+if [[ "$TRAVIS_JDK_VERSION" == "openjdk8" && "$TRAVIS_SCALA_VERSION" =~ 2\.1[123]\..* ]]; then
   RELEASE_COMBO=true;
 fi
 
@@ -52,9 +51,4 @@ if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
   fi
 fi
 
-# Maven Central and Bintray are unreachable over HTTPS
-if [[ "$TRAVIS_JDK_VERSION" == "openjdk6" ]]; then
-  SBTOPTS="-Dsbt.override.build.repos=true -Dsbt.repository.config=./.sbtrepos"
-fi
-
-sbt $SBTOPTS "++$TRAVIS_SCALA_VERSION" "$publishVersion" "$projectPrefix/clean" "$projectPrefix/test" "$projectPrefix/publishLocal" "$publishTask"
+sbt "++$TRAVIS_SCALA_VERSION" "$publishVersion" "$projectPrefix/clean" "$projectPrefix/test" "$projectPrefix/publishLocal" "$publishTask"


### PR DESCRIPTION
Revert the JDK 6 hacks, and just use OpenJDK 8.  They probably weren't necessary.

PS. The work on using Travis shared builds and AdoptOpenJDK came after the 1.x branch was made from master.  Various versions updates to sbt, Scala.js, Dotty are also missing.  Circle build is also probably out of date.