### PR TITLE
Fix 2.13 collections methods for NodeSeq

### DIFF
--- a/shared/src/main/scala-2.13/scala/xml/ScalaVersionSpecific.scala
+++ b/shared/src/main/scala-2.13/scala/xml/ScalaVersionSpecific.scala
@@ -1,7 +1,7 @@
 package scala.xml
 
 import scala.collection.immutable.StrictOptimizedSeqOps
-import scala.collection.{SeqOps, IterableOnce, immutable, mutable}
+import scala.collection.{View, SeqOps, IterableOnce, immutable, mutable}
 import scala.collection.BuildFrom
 import scala.collection.mutable.Builder
 
@@ -20,6 +20,21 @@ private[xml] trait ScalaVersionSpecificNodeSeq
   override def fromSpecific(coll: IterableOnce[Node]): NodeSeq = (NodeSeq.newBuilder ++= coll).result()
   override def newSpecificBuilder: mutable.Builder[Node, NodeSeq] = NodeSeq.newBuilder
   override def empty: NodeSeq = NodeSeq.Empty
+  def concat(suffix: IterableOnce[Node]): NodeSeq =
+    fromSpecific(iterator ++ suffix.iterator)
+  @inline final def ++ (suffix: Seq[Node]): NodeSeq = concat(suffix)
+  def appended(base: Node): NodeSeq =
+    fromSpecific(new View.Appended(this, base))
+  def appendedAll(suffix: IterableOnce[Node]): NodeSeq =
+    concat(suffix)
+  def prepended(base: Node): NodeSeq =
+    fromSpecific(new View.Prepended(base, this))
+  def prependedAll(prefix: IterableOnce[Node]): NodeSeq =
+    fromSpecific(prefix.iterator ++ iterator)
+  def map(f: Node => Node): NodeSeq =
+    fromSpecific(new View.Map(this, f))
+  def flatMap(f: Node => IterableOnce[Node]): NodeSeq =
+    fromSpecific(new View.FlatMap(this, f))
 }
 
 private[xml] trait ScalaVersionSpecificNodeBuffer { self: NodeBuffer =>

--- a/shared/src/test/scala/scala/xml/NodeSeqTest.scala
+++ b/shared/src/test/scala/scala/xml/NodeSeqTest.scala
@@ -1,0 +1,23 @@
+package scala.xml
+
+import scala.xml.NodeSeq.seqToNodeSeq
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+
+class NodeSeqTest {
+
+  @Test
+  def testAppend: Unit = { // Bug #392.
+    val a: NodeSeq = <a>Hello</a>
+    val b = <b>Hi</b>
+    a ++ <b>Hi</b> match {
+      case res: NodeSeq => assertEquals(2, res.size)
+      case res: Seq[Node] => fail("Should be NodeSeq") // Unreachable code?
+    }
+    val res: NodeSeq = a ++ b
+    val exp = NodeSeq.fromSeq(Seq(<a>Hello</a>, <b>Hi</b>))
+    assertEquals(exp, res)
+  }
+}

--- a/shared/src/test/scala/scala/xml/NodeSeqTest.scala
+++ b/shared/src/test/scala/scala/xml/NodeSeqTest.scala
@@ -20,4 +20,84 @@ class NodeSeqTest {
     val exp = NodeSeq.fromSeq(Seq(<a>Hello</a>, <b>Hi</b>))
     assertEquals(exp, res)
   }
+
+  @Test
+  def testAppendedAll: Unit = { // Bug #392.
+    val a: NodeSeq = <a>Hello</a>
+    val b = <b>Hi</b>
+    a :+ <b>Hi</b> match {
+      case res: Seq[Node] => assertEquals(2, res.size)
+      case res: NodeSeq => fail("Should be Seq[Node]") // Unreachable code?
+    }
+    val res: NodeSeq = a :+ b
+    val exp = NodeSeq.fromSeq(Seq(<a>Hello</a>, <b>Hi</b>))
+    assertEquals(exp, res)
+  }
+
+  @Test
+  def testPrepended: Unit = {
+    val a: NodeSeq = <a>Hello</a>
+    val b = <b>Hi</b>
+    a +: <b>Hi</b> match {
+      case res: Seq[NodeSeq] => assertEquals(2, res.size)
+      case res: NodeSeq => fail("Should be NodeSeq was Seq[Node]") // Unreachable code?
+    }
+    val res: Seq[NodeSeq] = a +: b
+    val exp = <a>Hello</a><b>Hi</b>
+    assertEquals(exp, res)
+  }
+
+  @Test
+  def testPrependedAll: Unit = {
+    val a: NodeSeq = <a>Hello</a>
+    val b = <b>Hi</b>
+    val c = <c>Hey</c>
+    a ++: <b>Hi</b> ++: <c>Hey</c> match {
+      case res: Seq[Node] => assertEquals(3, res.size)
+      case res: NodeSeq => fail("Should be Seq[Node]") // Unreachable code?
+    }
+    val res: NodeSeq = a ++: b ++: c
+    val exp = NodeSeq.fromSeq(Seq(<a>Hello</a>, <b>Hi</b>, <c>Hey</c>))
+    assertEquals(exp, res)
+  }
+
+  @Test
+  def testMap: Unit = {
+    val a: NodeSeq = <a>Hello</a>
+    val exp: NodeSeq = Seq(<b>Hi</b>)
+    assertEquals(exp, a.map(_ => <b>Hi</b>))
+    assertEquals(exp, for { _ <- a } yield { <b>Hi</b> })
+  }
+
+  @Test
+  def testFlatMap: Unit = {
+    val a: NodeSeq = <a>Hello</a>
+    val exp: NodeSeq = Seq(<b>Hi</b>)
+    assertEquals(exp, a.flatMap(_ => Seq(<b>Hi</b>)))
+    assertEquals(exp, for { b <- a; _ <- b } yield { <b>Hi</b> })
+    assertEquals(exp, for { b <- a; c <- b; _ <- c } yield { <b>Hi</b> })
+  }
+
+  @Test
+  def testStringProjection: Unit = {
+    val a =
+      <a>
+        <b>b</b>
+        <b>
+          <c d="d">
+            <e>e</e>
+            <e>e</e>
+          </c>
+          <c>c</c>
+        </b>
+      </a>
+    val res = for {
+      b <- a \ "b"
+      c <- b.child
+      e <- (c \ "e").headOption
+    } yield {
+      e.text.trim
+    }
+    assertEquals(Seq("e"), res)
+  }
 }


### PR DESCRIPTION
Add boilerplate from [Implementing Custom Collections (Scala 2.13)](https://docs.scala-lang.org/overviews/core/custom-collections.html).

Fix #392. 