### PR TITLE
Update Sonatype environment variable names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ env:
   global:
     # PGP_PASSPHRASE
     - secure: "BYC1kEnHjNrINrHYWPGEuTTJ2V340/0ByzqeihLecjoZ75yrjWdsh6MI1JEUWgv5kb+58vLzib21JfnjsPK6Yb2bSXuCFCsEtJNh6RJKgxkWlCOzfTSh5I2wl7PCjRClRL6gseX2uTSvFjL4Z//pmxwxeXlLp7voQe4QAUq1+sE="
-    # SONA_USER
+    # SONATYPE_USERNAME
     - secure: "OpBwPc1GNvauageYOH3RscAa7wpZxgpmqDz15aigIKLNWzAhAtVUx0MleZ8rQeoqml6nrAvlnzuVHjKL2lVcjMPpjUis7bcQ5UAGK7tZK8x+qZNQxXmpXu8+pENwQA2yFaqt/xy7K5jFOrHJHTRxcPnyVG1yKakPWz53PPYUwbc="
-    # SONA_PASS
+    # SONATYPE_PASSWORD
     - secure: "Xw7rI/qlML1nD2e2XwlakkhKAWNGZKqqE+Q3ntTvFpfHryl7KLCvVzJ4LIavnL6kGJaWOgy9vlSoEWn5g9nqHSfE31C/k5pY5nTMAKiwiJzfAS+r0asKXW2gmKhwtcTBkqyLVOZLCJSPVlFRQyfBJHY+Fs0L3KWcnMQgtBlyDhU="
   matrix:
     # The empty SCALAJS_VERSION will only compile for the JVM

--- a/admin/README.md
+++ b/admin/README.md
@@ -34,9 +34,9 @@ env:
   global:
     # PGP_PASSPHRASE
     - secure: "XXXXXX"
-    # SONA_USER
+    # SONATYPE_USERNAME
     - secure: "XXXXXX"
-    # SONA_PASS
+    # SONATYPE_PASSWORD
     - secure: "XXXXXX"
 
 script: admin/build.sh

--- a/admin/encryptEnvVars.sh
+++ b/admin/encryptEnvVars.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-read -s -p 'SONA_USER: ' SONA_USER
-travis encrypt SONA_USER="$SONA_USER"
-read -s -p 'SONA_PASS: ' SONA_PASS
-travis encrypt SONA_PASS="$SONA_PASS"
+read -s -p 'SONATYPE_USERNAME: ' SONATYPE_USERNAME
+travis encrypt SONATYPE_USERNAME="$SONATYPE_USERNAME"
+read -s -p 'SONATYPE_PASSWORD: ' SONATYPE_PASSWORD
+travis encrypt SONATYPE_PASSWORD="$SONATYPE_PASSWORD"

--- a/admin/publish-settings.sbt
+++ b/admin/publish-settings.sbt
@@ -4,5 +4,5 @@ inThisBuild(Seq(
   pgpPassphrase := Some(env("PGP_PASSPHRASE").toArray),
   pgpPublicRing := file("admin/pubring.asc"),
   pgpSecretRing := file("admin/secring.asc"),
-  credentials += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", env("SONA_USER"), env("SONA_PASS"))
+  credentials += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", env("SONATYPE_USERNAME"), env("SONATYPE_PASSWORD"))
 ))


### PR DESCRIPTION
Looks like these got changed when sbt-ci-release was added to the build in #356.