### PR TITLE
Make RuleTransformer fully recursive [#257]

### DIFF
--- a/shared/src/main/scala/scala/xml/transform/NestingTransformer.scala
+++ b/shared/src/main/scala/scala/xml/transform/NestingTransformer.scala
@@ -12,10 +12,8 @@ package transform
 
 import scala.collection.Seq
 
-class RuleTransformer(rules: RewriteRule*) extends BasicTransformer {
-  private val transformers = rules.map(new NestingTransformer(_))
+class NestingTransformer(rule: RewriteRule) extends BasicTransformer {
   override def transform(n: Node): Seq[Node] = {
-    if (transformers.isEmpty) n
-    else transformers.tail.foldLeft(transformers.head.transform(n)) { (res, transformer) => transformer.transform(res) }
+    rule.transform(super.transform(n))
   }
 }

--- a/shared/src/test/scala-2.x/scala/xml/TransformersTest.scala
+++ b/shared/src/test/scala-2.x/scala/xml/TransformersTest.scala
@@ -60,7 +60,7 @@ class TransformersTest {
   @Test
   def preserveReferentialComplexityInLinearComplexity = { // SI-4528
     var i = 0
- 
+
     val xmlNode = <a><b><c><h1>Hello Example</h1></c></b></a>
 
     new RuleTransformer(new RewriteRule {
@@ -77,4 +77,19 @@ class TransformersTest {
 
     assertEquals(1, i)
   }
+
+  @Test
+  def appliesRulesRecursivelyOnPreviousChanges = { // #257
+    def add(outer: Elem, inner: Node) = new RewriteRule {
+      override def transform(n: Node): Seq[Node] = n match {
+        case e: Elem if e.label == outer.label => e.copy(child = e.child ++ inner)
+        case other => other
+      }
+    }
+
+    def transformer = new RuleTransformer(add(<element/>, <new/>), add(<new/>, <thing/>))
+
+    assertEquals(<element><new><thing/></new></element>, transformer(<element/>))
+  }
 }
+


### PR DESCRIPTION
RuleTransformer for the past eleven years or more has first recursed,
then applied the rewrite rules as it backed out of the recursion.

That prevented rewrite rules from acting on changes of previous rules
unless they recursed themselves.

The workaround has always been chain rule transformers instead of
calling one rule transformer with all the rules. This change basically
re-implements RuleTransformer as that workaround, and introduces
a NestingTransformer which does the nesting.

Clearly, if you have N rules you'll now recurse N times instead of
once, though each rule is still only applied once for each element.

On the other hand, a RewriteRule that recursed would incur in
exponential times, and now they don't need to.

The original behavior has no reason to be. It didn't prevent
rules from seeing each other changes, nor was it particularly
concerned with performance.  With API changes coming on 2.0, I
believe this is the right time to introduce this change.