### PR TITLE
accommodate non-cross-built modules in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,9 +26,9 @@ isReleaseJob() {
 }
 
 if [[ "$SCALAJS_VERSION" == "" ]]; then
-  projectPrefix="xml"
+  projectPrefix="xml/"
 else
-  projectPrefix="xmlJS"
+  projectPrefix="xmlJS/"
 fi
 
 verPat="[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)?"
@@ -43,12 +43,12 @@ if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
 fi
 
 # default is +publishSigned; we cross-build with travis jobs, not sbt's crossScalaVersions
-export CI_RELEASE="$projectPrefix/publishSigned"
-export CI_SNAPSHOT_RELEASE="$projectPrefix/publish"
+export CI_RELEASE="${projectPrefix}publishSigned"
+export CI_SNAPSHOT_RELEASE="${projectPrefix}publish"
 
 # default is sonatypeBundleRelease, which closes and releases the staging repo
 # see https://github.com/xerial/sbt-sonatype#commands
 # for now, until we're confident in the new release scripts, just close the staging repo.
 export CI_SONATYPE_RELEASE="; sonatypePrepare; sonatypeBundleUpload; sonatypeClose"
 
-sbt clean $projectPrefix/test $projectPrefix/publishLocal $releaseTask
+sbt clean ${projectPrefix}test ${projectPrefix}publishLocal $releaseTask


### PR DESCRIPTION
here in this repo there's no need for `projectPrefix` ever to be empty,
but when I first set up scala-library-next (before any crossbuilding
was added), I wanted it to be. scala-xml is the de facto master copy
of this script, so I'd like to make the change here

the change has already been tested in scala-library-next