### PR TITLE
Remove exclude rule from scala-compiler test dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,7 +113,7 @@ lazy val xml = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       case Some((3, _)) =>
         Seq()
       case _ =>
-        Seq(("org.scala-lang" % "scala-compiler" % scalaVersion.value % Test).exclude("org.scala-lang.modules", s"scala-xml_${scalaBinaryVersion.value}"))
+        Seq("org.scala-lang" % "scala-compiler" % scalaVersion.value % Test)
     }),
   )
   .jsSettings(


### PR DESCRIPTION
Fixes #346.

I believe this was the last artifact in the build to deal with the dreaded classpath issue scala-xml suffered for years.  We could have probably fixed it back when sbt 1.1 was released, but I forgot about it.  It's only a test dependency, so it wouldn't affect downstream users.  I'm pretty sure it doesn't break testing.  In particular, it doesn't run the tests against the scala-xml dependency of scala-compiler rather than the compiled class files.