### PR TITLE
Drop the scala.xml.Properties

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,7 @@ lazy val xml = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       Seq(
         // because we reverted #279
         exclude[DirectMissingMethodProblem]("scala.xml.Utility.escapeText"),
+        exclude[MissingClassProblem]("scala.xml.Properties*"),
         // New MiMa checks for generic signature changes
         exclude[IncompatibleSignatureProblem]("*"),
         // afaict this is just a JDK 8 vs 16 difference, producing a false positive when

--- a/jvm/src/test/scala-2.x/scala/xml/CompilerErrors.scala
+++ b/jvm/src/test/scala-2.x/scala/xml/CompilerErrors.scala
@@ -8,7 +8,7 @@ class CompilerErrors extends CompilerTesting {
     // the error message here differs a bit by Scala version
     import util.Properties.versionNumberString
     val thing =
-      if (versionNumberString.startsWith("2.11") || versionNumberString.startsWith("2.12")) "method value"
+      if (versionNumberString.startsWith("2.12")) "method value"
       else "method"
     expectXmlError(s"""|overloaded $thing apply with alternatives:
                        |  (f: scala.xml.Node => Boolean)scala.xml.NodeSeq <and>

--- a/shared/src/main/scala/scala/xml/XML.scala
+++ b/shared/src/main/scala/scala/xml/XML.scala
@@ -118,8 +118,3 @@ object XML extends XMLLoader[Elem] {
     w.write(Utility.serialize(node, minimizeTags = minimizeTags).toString)
   }
 }
-
-object Properties extends scala.util.PropertiesTrait {
-  protected def propCategory    = "scala-xml"
-  protected def pickJarBasedOn  = classOf[scala.xml.Node]
-}

--- a/shared/src/test/scala/scala/xml/Properties.scala
+++ b/shared/src/test/scala/scala/xml/Properties.scala
@@ -1,0 +1,19 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package xml
+
+object Properties extends util.PropertiesTrait {
+  protected def propCategory    = "scala-xml"
+  protected def pickJarBasedOn  = classOf[scala.xml.Node]
+}


### PR DESCRIPTION
The PropertiesTrait is a compiler internal of some sort that might have served a purpose at one time, but it's probably no longer necessary save for a test in the test suite that uses it for some scala-reflect tests.  I don't believe it needs to be shipped in the library.