### PR TITLE
Fix native build in Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,6 @@ executors:
   scala_jdk16_executor:
     docker:
       - image: circleci/openjdk:16-buster
-  scala_native_executor:
-    machine:
-      image: ubuntu-1604:202004-01
 
 commands:
   sbt_cmd:
@@ -77,7 +74,7 @@ jobs:
           scala_version: << parameters.scala_version >>
           sbt_tasks: xmlJS/update xmlJS/compile xmlJS/Test/compile xmlJS/test xmlJS/doc xmlJS/package
   scalanative_job:
-    executor: scala_native_executor
+    executor: scala_jdk8_executor
     parameters:
       scala_version:
         description: "Scala version"
@@ -94,12 +91,10 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
-            curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
             sudo apt-get update
-            sudo apt-get install -y sbt clang-8 openjdk-8-jdk
-            sudo ln -s /usr/lib/llvm-8/bin/clang /usr/bin/clang
-            sudo ln -s /usr/lib/llvm-8/bin/clang++ /usr/bin/clang++
+            sudo apt-get install -y clang-7
+            sudo ln -s /usr/lib/llvm-7/bin/clang /usr/local/bin/clang
+            sudo ln -s /usr/lib/llvm-7/bin/clang++ /usr/local/bin/clang++
       - sbt_cmd:
           scala_version: << parameters.scala_version >>
           sbt_tasks: xmlNative/update xmlNative/compile xmlNative/test:compile xmlNative/test xmlNative/doc xmlNative/package


### PR DESCRIPTION
The sbt 1.5.1 update in #514 failed because of the bintray brownout.

This removes the Ubuntu container, drops the manual sbt install, but downgrades to LLVM/Clang 7.