### PR TITLE
Do not ignore XML comments when parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,15 @@ lazy val xml = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         // we compare classes built on JDK 16 (which we only do on CI, not at release time)
         // to previous-version artifacts that were built on 8.  see scala/scala-xml#501
         exclude[DirectMissingMethodProblem]("scala.xml.include.sax.XIncluder.declaration"),
+
+        // caused by the switch from DefaultHandler to DefaultHandler2:
+        exclude[MissingTypesProblem]("scala.xml.parsing.FactoryAdapter"),
+        exclude[MissingTypesProblem]("scala.xml.parsing.NoBindingFactoryAdapter"),
+
+        exclude[DirectMissingMethodProblem]("scala.xml.parsing.FactoryAdapter.comment"),
+        exclude[ReversedMissingMethodProblem]("scala.xml.parsing.FactoryAdapter.createComment"),
+        exclude[DirectMissingMethodProblem]("scala.xml.parsing.FactoryAdapter.createComment"),
+        exclude[DirectMissingMethodProblem]("scala.xml.parsing.NoBindingFactoryAdapter.createComment")
       )
     },
 

--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -6,7 +6,6 @@ import org.junit.{Test => UnitTest}
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
-import scala.xml.parsing.ConstructingParser
 import java.io.StringWriter
 import java.io.ByteArrayOutputStream
 import java.io.StringReader
@@ -582,6 +581,21 @@ class XMLTestJVM {
   }
 
   @UnitTest
+  def issue508: Unit = {
+    def check(xml: String): Unit = assertEquals(xml, XML.loadString(xml).toString)
+
+    check("<a><!-- comment --> suffix</a>")
+    check("<a>prefix <!-- comment --> suffix</a>")
+    check("<a>prefix <b><!-- comment --></b> suffix</a>")
+
+    // TODO since XMLLoader retrieves FactoryAdapter.rootNode,
+    // capturing comments before and after the root element is not currently possible
+    // (by the way, the same applies to processing instructions).
+    //check("<!-- prologue --><a>text</a>")
+    //check("<a>text</a><!-- epilogue -->")
+  }
+
+  @UnitTest
   def nodeSeqNs: Unit = {
     val x = {
       <x:foo xmlns:x="abc"/><y:bar xmlns:y="def"/>
@@ -746,5 +760,4 @@ class XMLTestJVM {
 
     assertEquals("", x.xEntityValue())
   }
-
 }

--- a/shared/src/main/scala/scala/xml/factory/NodeFactory.scala
+++ b/shared/src/main/scala/scala/xml/factory/NodeFactory.scala
@@ -34,7 +34,7 @@ trait NodeFactory[A <: Node] {
   def eqElements(ch1: Seq[Node], ch2: Seq[Node]): Boolean =
     ch1.view.zipAll(ch2.view, null, null) forall { case (x, y) => x eq y }
 
-  def nodeEquals(n: Node, pre: String, name: String, attrSeq: MetaData, scope: NamespaceBinding, children: Seq[Node]) =
+  def nodeEquals(n: Node, pre: String, name: String, attrSeq: MetaData, scope: NamespaceBinding, children: Seq[Node]): Boolean =
     n.prefix == pre &&
       n.label == name &&
       n.attributes == attrSeq &&
@@ -55,7 +55,7 @@ trait NodeFactory[A <: Node] {
     }
   }
 
-  def makeText(s: String) = Text(s)
+  def makeText(s: String): Text = Text(s)
   def makeComment(s: String): Seq[Comment] =
     if (ignoreComments) Nil else List(Comment(s))
   def makeProcInstr(t: String, s: String): Seq[ProcInstr] =

--- a/shared/src/main/scala/scala/xml/parsing/NoBindingFactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/NoBindingFactoryAdapter.scala
@@ -23,20 +23,23 @@ import factory.NodeFactory
  */
 class NoBindingFactoryAdapter extends FactoryAdapter with NodeFactory[Elem] {
   /** True.  Every XML node may contain text that the application needs */
-  def nodeContainsText(label: String) = true
+  override def nodeContainsText(label: String) = true
 
   /** From NodeFactory.  Constructs an instance of scala.xml.Elem -- TODO: deprecate as in Elem */
-  protected def create(pre: String, label: String, attrs: MetaData, scope: NamespaceBinding, children: Seq[Node]): Elem =
+  override protected def create(pre: String, label: String, attrs: MetaData, scope: NamespaceBinding, children: Seq[Node]): Elem =
     Elem(pre, label, attrs, scope, children.isEmpty, children: _*)
 
   /** From FactoryAdapter.  Creates a node. never creates the same node twice, using hash-consing.
      TODO: deprecate as in Elem, or forward to create?? */
-  def createNode(pre: String, label: String, attrs: MetaData, scope: NamespaceBinding, children: List[Node]): Elem =
+  override def createNode(pre: String, label: String, attrs: MetaData, scope: NamespaceBinding, children: List[Node]): Elem =
     Elem(pre, label, attrs, scope, children.isEmpty, children: _*)
 
   /** Creates a text node. */
-  def createText(text: String) = Text(text)
+  override def createText(text: String): Text = makeText(text)
 
   /** Creates a processing instruction. */
-  def createProcInstr(target: String, data: String) = makeProcInstr(target, data)
+  override def createProcInstr(target: String, data: String): Seq[ProcInstr] = makeProcInstr(target, data)
+
+  /** Creates a comment. */
+  override def createComment(characters: String): Seq[Comment] = makeComment(characters)
 }


### PR DESCRIPTION
fixes #508

- set `org.xml.sax.ext.LexicalHandler` on the `SAXParser` that `XMLLoader` uses;
- override `LexicalHandler.comment()` in `FactoryAdapter` so that comments are added to the element content;
- add unit tests;
- add excludes for the binary compatibility checks.