### PR TITLE
Relax versionPolicyIntention to BinaryCompatible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,8 +56,9 @@ lazy val xml = crossProject(JSPlatform, JVMPlatform, NativePlatform)
           |additional information regarding copyright ownership.
           |""".stripMargin)),
 
+    // Note: Change back to BinaryAndSourceCompatible after 2.1.0 release
+    versionPolicyIntention := Compatibility.BinaryCompatible,
     // Note: See discussion on non-JVM Mima in https://github.com/scala/scala-xml/pull/517
-    versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
     mimaReportSignatureProblems := true,
     mimaBinaryIssueFilters ++= {
       import com.typesafe.tools.mima.core._


### PR DESCRIPTION
Fixes #551 and prepares for minor release after Scala.js minor release.