### PR TITLE
Do not ignore XML CDATA sections when parsing:

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,14 +69,12 @@ lazy val xml = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         // to previous-version artifacts that were built on 8.  see scala/scala-xml#501
         exclude[DirectMissingMethodProblem]("scala.xml.include.sax.XIncluder.declaration"),
 
-        // caused by the switch from DefaultHandler to DefaultHandler2:
-        exclude[MissingTypesProblem]("scala.xml.parsing.FactoryAdapter"),
-        exclude[MissingTypesProblem]("scala.xml.parsing.NoBindingFactoryAdapter"),
+        // necessitated by the switch from DefaultHandler to DefaultHandler2 in FactoryAdapter:
+        exclude[MissingTypesProblem]("scala.xml.parsing.FactoryAdapter"),                         // see #549
 
-        exclude[DirectMissingMethodProblem]("scala.xml.parsing.FactoryAdapter.comment"),
-        exclude[ReversedMissingMethodProblem]("scala.xml.parsing.FactoryAdapter.createComment"),
-        exclude[DirectMissingMethodProblem]("scala.xml.parsing.FactoryAdapter.createComment"),
-        exclude[DirectMissingMethodProblem]("scala.xml.parsing.NoBindingFactoryAdapter.createComment")
+        // necessitated by the introduction of new abstract methods in FactoryAdapter:
+        exclude[ReversedMissingMethodProblem]("scala.xml.parsing.FactoryAdapter.createComment"),  // see #549
+        exclude[ReversedMissingMethodProblem]("scala.xml.parsing.FactoryAdapter.createPCData")    // see #558
       )
     },
 

--- a/shared/src/main/scala/scala/xml/factory/NodeFactory.scala
+++ b/shared/src/main/scala/scala/xml/factory/NodeFactory.scala
@@ -56,6 +56,8 @@ trait NodeFactory[A <: Node] {
   }
 
   def makeText(s: String): Text = Text(s)
+  def makePCData(s: String): PCData =
+    PCData(s)
   def makeComment(s: String): Seq[Comment] =
     if (ignoreComments) Nil else List(Comment(s))
   def makeProcInstr(t: String, s: String): Seq[ProcInstr] =

--- a/shared/src/main/scala/scala/xml/parsing/NoBindingFactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/NoBindingFactoryAdapter.scala
@@ -42,4 +42,7 @@ class NoBindingFactoryAdapter extends FactoryAdapter with NodeFactory[Elem] {
 
   /** Creates a comment. */
   override def createComment(characters: String): Seq[Comment] = makeComment(characters)
+
+  /** Creates a cdata. */
+  override def createPCData(characters: String): PCData = makePCData(characters)
 }

--- a/shared/src/test/scala/scala/xml/CommentTest.scala
+++ b/shared/src/test/scala/scala/xml/CommentTest.scala
@@ -1,7 +1,6 @@
 package scala.xml
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 final class CommentTest {


### PR DESCRIPTION
- handle startCDATA/endCDATA lexical events;
- keep track of the `inCDATA` state;
- capture text into appropriate Node subtype depending on that state;
- add createPCData()/makePCData() helpers;
- add unit tests.