### PR TITLE
Parse nodes before and after the root element

### DIFF
--- a/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
@@ -98,6 +98,8 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
   var extIndex = -1
 
   /** holds temporary values of pos */
+  // Note: this is clearly an override, but if marked as such it causes a "...cannot override a mutable variable"
+  // error with Scala 3; does it work with Scala 3 if not explicitly marked as an override remains to be seen...
   var tmppos: Int = _
 
   /** holds the next character */


### PR DESCRIPTION
@ashawley @SethTisue yet another bit of the lexical stuff

XML allows for comments and processing instructions to be present before the start and after the end of the root element. Currently,  `FactoryAdapter` does not capture those nodes, and `XMLLoader.loadXML` does not provide access to anything other than the root element anyway. This pull request addresses the issue.

Note: at least with the JDK's Xerces, whitespace in the prolog and epilogue gets lost in parsing: the parser does not fire any white-space related events.

(Travis builds for JDK 17 fail with "no matching JDK found: 17" as noted in #559.)