### PR TITLE
Set the Circle instance size to small

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,15 @@ executors:
   scala_jdk8_executor:
     docker:
       - image: circleci/openjdk:8-jdk-node
+    resource_class: small
   scala_jdk11_executor:
     docker:
       - image: circleci/openjdk:11-jdk
+    resource_class: small
   scala_jdk17_executor:
     docker:
       - image: circleci/openjdk:17-buster
+    resource_class: small
 
 commands:
   sbt_cmd:


### PR DESCRIPTION
This would reduce the resources we're asking to use at Circle, but my experience suggests it shouldn't cause the build to run much slower.