### PR TITLE
docs: remove hardcoded stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ API documentation is available [here](https://javadoc.io/doc/org.scala-lang.modu
 
 How to documentation is available in the [wiki](https://github.com/scala/scala-xml/wiki)
 
-The latest stable release of Scala XML is 2.0.1.
-
 ## Maintenance status
 
 This library is community-maintained. The lead maintainer is [@aaron_s_hawley](https://github.com/ashawley).


### PR DESCRIPTION
Typically hardcoded versions like this always lag behind or get forgotten. I'm assuming the vast majority of users can instead rely on the badge in the readme, the GitHub releases, or manually doing `cs complete-dep org.scala-lang.modules:scala-xml_3:` to get the latest stable version.

Closes #629