### PR TITLE
Allow overriding XMLReader used in parsing

### DIFF
--- a/shared/src/main/scala/scala/xml/XML.scala
+++ b/shared/src/main/scala/scala/xml/XML.scala
@@ -14,8 +14,8 @@ package scala
 package xml
 
 import factory.XMLLoader
-import java.io.{ File, FileDescriptor, FileInputStream, FileOutputStream }
-import java.io.{ InputStream, Reader, StringReader }
+import java.io.{File, FileDescriptor, FileInputStream, FileOutputStream}
+import java.io.{InputStream, Reader, StringReader}
 import java.nio.channels.Channels
 import scala.util.control.Exception.ultimately
 
@@ -71,6 +71,10 @@ object XML extends XMLLoader[Elem] {
   /** Returns an XMLLoader whose load* methods will use the supplied SAXParser. */
   def withSAXParser(p: SAXParser): XMLLoader[Elem] =
     new XMLLoader[Elem] { override val parser: SAXParser = p }
+
+  /** Returns an XMLLoader whose load* methods will use the supplied XMLReader. */
+  def withXMLReader(r: XMLReader): XMLLoader[Elem] =
+    new XMLLoader[Elem] { override val reader: XMLReader = r }
 
   /**
    * Saves a node to a file with given filename using given encoding

--- a/shared/src/main/scala/scala/xml/package.scala
+++ b/shared/src/main/scala/scala/xml/package.scala
@@ -80,5 +80,6 @@ package object xml {
   type SAXParseException = org.xml.sax.SAXParseException
   type EntityResolver = org.xml.sax.EntityResolver
   type InputSource = org.xml.sax.InputSource
+  type XMLReader = org.xml.sax.XMLReader
   type SAXParser = javax.xml.parsers.SAXParser
 }

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
@@ -98,8 +98,9 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
   var extIndex = -1
 
   /** holds temporary values of pos */
-  // Note: this is clearly an override, but if marked as such it causes a "...cannot override a mutable variable"
-  // error with Scala 3; does it work with Scala 3 if not explicitly marked as an override remains to be seen...
+  // Note: if marked as an override, this causes a "...cannot override a mutable variable" error with Scala 3;
+  // SethTisue noted on Oct 14, 2021 that lampepfl/dotty#13744 should fix it - and it probably did,
+  // but Scala XML still builds against Scala 3 version that has this bug, so this still can not be marked as an override :(
   var tmppos: Int = _
 
   /** holds the next character */


### PR DESCRIPTION
`scala.xml.XML` allows overriding the SAXParser used via the `withSAXParser()` method. Some XML parsing customizations require changing the XMLReader contained inside every SAXParser (e.g., adding an XMLFilter). This pull request introduces an additional extension point `XMLLoader.reader` and a method `XML.withXMLReader()` for such a purpose.

Also, ErrorHandler and EntityResolver configured externally are no longer wiped out before parsing the XML.