### PR TITLE
Add type annotations

### DIFF
--- a/jvm/src/test/scala-2.x/scala/xml/CompilerErrors.scala
+++ b/jvm/src/test/scala-2.x/scala/xml/CompilerErrors.scala
@@ -4,10 +4,10 @@ import org.junit.Test
 
 class CompilerErrors extends CompilerTesting {
   @Test
-  def t7185() = {
+  def t7185(): Unit = {
     // the error message here differs a bit by Scala version
     import util.Properties.versionNumberString
-    val thing =
+    val thing: String =
       if (versionNumberString.startsWith("2.12")) "method value"
       else "method"
     expectXmlError(s"""|overloaded $thing apply with alternatives:
@@ -20,7 +20,7 @@ class CompilerErrors extends CompilerTesting {
   }
 
   @Test
-  def t1878_typer() =
+  def t1878_typer(): Unit =
     expectXmlError("_* may only come last",
      """|object Test extends App {
         |  // illegal - bug #1764
@@ -31,14 +31,14 @@ class CompilerErrors extends CompilerTesting {
 
 
   @Test
-  def t1017() =
+  def t1017(): Unit =
     expectXmlErrors(1, "not found: value foo",
      """|object Test {
         |  <x><x><x><x><x><x><x><x><x><x><x><x><x><x><x><x><x><x>{ foo }</x></x></x></x></x></x></x></x></x></x></x></x></x></x></x></x></x></x>
         |}""")
 
   @Test
-  def t1011() =
+  def t1011(): Unit =
     expectXmlErrors(69, "not found: value entity",
      """|import scala.xml._;
         |
@@ -177,9 +177,9 @@ class CompilerTesting {
 
   def errorMessages(errorSnippet: String, compileOptions: String = "")(code: String): List[String] = {
     import scala.tools.reflect._
-    val m  = scala.reflect.runtime.currentMirror
-    val tb = m.mkToolBox(options = compileOptions) //: ToolBox[m.universe.type]
-    val fe = tb.frontEnd
+    val m: scala.reflect.runtime.universe.Mirror  = scala.reflect.runtime.currentMirror
+    val tb: ToolBox[scala.reflect.runtime.universe.type] = m.mkToolBox(options = compileOptions) //: ToolBox[m.universe.type]
+    val fe: FrontEnd = tb.frontEnd
 
     try {
       tb.eval(tb.parse(code))
@@ -192,17 +192,17 @@ class CompilerTesting {
 
   // note: `code` should have a | margin
   // the import's needed because toolbox compiler does not accumulate imports like the real one (TODO: verify hypothesis)
-  def xmlErrorMessages(msg: String, code: String) =
+  def xmlErrorMessages(msg: String, code: String): List[String] =
     errorMessages(msg)("import scala.xml.{TopScope => $scope}\n"+ code.stripMargin)
 
-  def expectXmlError(msg: String, code: String) = {
-    val errors = xmlErrorMessages(msg, code)
+  def expectXmlError(msg: String, code: String): Unit = {
+    val errors: List[String] = xmlErrorMessages(msg, code)
     assert(errors exists (_ contains msg), errors mkString "\n")
   }
 
-  def expectXmlErrors(msgCount: Int, msg: String, code: String) = {
-    val errors = xmlErrorMessages(msg, code)
-    val errorCount = errors.count(_ contains msg)
+  def expectXmlErrors(msgCount: Int, msg: String, code: String): Unit = {
+    val errors: List[String] = xmlErrorMessages(msg, code)
+    val errorCount: Int = errors.count(_ contains msg)
     assert(errorCount == msgCount, s"$errorCount occurrences of \'$msg\' found -- expected $msgCount in:\n${errors mkString "\n"}")
   }
 }

--- a/jvm/src/test/scala-2.x/scala/xml/XMLTestJVM2x.scala
+++ b/jvm/src/test/scala-2.x/scala/xml/XMLTestJVM2x.scala
@@ -6,25 +6,25 @@ import scala.xml.parsing.ConstructingParser
 
 class XMLTestJVM2x {
   @UnitTest
-  def t2354: Unit = {
-    val xml_good = "<title><![CDATA[Hello [tag]]]></title>"
-    val xml_bad = "<title><![CDATA[Hello [tag] ]]></title>"
+  def t2354(): Unit = {
+    val xml_good: String = "<title><![CDATA[Hello [tag]]]></title>"
+    val xml_bad: String = "<title><![CDATA[Hello [tag] ]]></title>"
 
-    val parser1 = ConstructingParser.fromSource(io.Source.fromString(xml_good), false)
-    val parser2 = ConstructingParser.fromSource(io.Source.fromString(xml_bad), false)
+    val parser1: ConstructingParser = ConstructingParser.fromSource(io.Source.fromString(xml_good), preserveWS = false)
+    val parser2: ConstructingParser = ConstructingParser.fromSource(io.Source.fromString(xml_bad), preserveWS = false)
 
     parser1.document()
     parser2.document()
   }
 
   @UnitTest
-  def t8253: Unit = {
+  def t8253(): Unit = {
     // `identity(foo)` used to match the overly permissive match in SymbolXMLBuilder
     // which was intended to more specifically match `_root_.scala.xml.Text(...)`
 
     import reflect.runtime.universe._ // not using the XML library in compiler tests
 
-    val ns1 = "ns1"
+    val ns1: String = "ns1"
     assertEquals(reify(ns1).tree.toString, q"ns1".toString)
     assertEquals("<sample xmlns='ns1'/>",
       """|{
@@ -69,10 +69,10 @@ class XMLTestJVM2x {
   }
 
   @UnitTest
-  def t8466lift: Unit = {
+  def t8466lift(): Unit = {
     import scala.reflect.runtime.universe._
 
-    implicit val liftXmlComment = Liftable[Comment] { comment =>
+    implicit val liftXmlComment: Liftable[Comment] = Liftable[Comment] { comment =>
       q"new _root_.scala.xml.Comment(${comment.commentText})"
     }
     liftXmlComment(Comment("foo"))
@@ -80,10 +80,10 @@ class XMLTestJVM2x {
   }
 
   @UnitTest
-  def t8466unlift: Unit = {
+  def t8466unlift(): Unit = {
     import scala.reflect.runtime.universe._
 
-    implicit val unliftXmlComment = Unliftable[Comment] {
+    implicit val unliftXmlComment: Unliftable[Comment] = Unliftable[Comment] {
       case q"new _root_.scala.xml.Comment(${value: String})" => Comment(value)
     }
     unliftXmlComment.unapply(q"<!--foo-->")
@@ -92,7 +92,7 @@ class XMLTestJVM2x {
   }
 
   @UnitTest
-  def t9027: Unit = {
+  def t9027(): Unit = {
     // used to be parsed as .println
 
     import reflect.runtime._, universe._

--- a/jvm/src/test/scala/scala/xml/AttributeTest.scala
+++ b/jvm/src/test/scala/scala/xml/AttributeTest.scala
@@ -7,31 +7,31 @@ import org.junit.Assert.assertNotEquals
 class AttributeTestJVM {
 
   @Test
-  def attributeOrder: Unit = {
-    val x = <x y="1" z="2"/>
+  def attributeOrder(): Unit = {
+    val x: Elem = <x y="1" z="2"/>
     assertEquals("""<x y="1" z="2"/>""", x.toString)
   }
 
   @Test
-  def attributesFromString: Unit = {
-    val str = """<x y="1" z="2"/>"""
-    val doc = XML.loadString(str)
+  def attributesFromString(): Unit = {
+    val str: String = """<x y="1" z="2"/>"""
+    val doc: Elem = XML.loadString(str)
     assertEquals(str, doc.toString)
   }
 
   @Test
-  def attributesAndNamespaceFromString: Unit = {
-    val str = """<x xmlns:w="w" y="1" z="2"/>"""
-    val doc = XML.loadString(str)
+  def attributesAndNamespaceFromString(): Unit = {
+    val str: String = """<x xmlns:w="w" y="1" z="2"/>"""
+    val doc: Elem = XML.loadString(str)
     assertNotEquals(str, doc.toString)
-    val str2 = """<x y="1" z="2" xmlns:w="w"/>"""
-    val doc2 = XML.loadString(str2)
+    val str2: String = """<x y="1" z="2" xmlns:w="w"/>"""
+    val doc2: Elem = XML.loadString(str2)
     assertEquals(str2, doc2.toString)
   }
 
   @Test(expected=classOf[SAXParseException])
-  def attributesFromStringWithDuplicate: Unit = {
-    val str = """<elem one="test" one="test1" two="test2" three="test3"></elem>"""
+  def attributesFromStringWithDuplicate(): Unit = {
+    val str: String = """<elem one="test" one="test1" two="test2" three="test3"></elem>"""
     XML.loadString(str)
   }
 }

--- a/jvm/src/test/scala/scala/xml/BillionLaughsAttackTest.scala
+++ b/jvm/src/test/scala/scala/xml/BillionLaughsAttackTest.scala
@@ -10,12 +10,12 @@ class BillionLaughsAttackTest {
    * this is the limit imposed by the JDK.
    */
   @Test(expected=classOf[org.xml.sax.SAXParseException])
-  def lolzTest: Unit = {
+  def lolzTest(): Unit = {
     XML.loadString(lolz)
   }
 
   // Copied from https://msdn.microsoft.com/en-us/magazine/ee335713.aspx
-  val lolz =
+  val lolz: String =
     """<?xml version="1.0"?>
       |<!DOCTYPE lolz [
       | <!ENTITY lol "lol">
@@ -32,5 +32,4 @@ class BillionLaughsAttackTest {
       |]>
       |<lolz>&lol9;</lolz>
       |""".stripMargin
-
 }

--- a/jvm/src/test/scala/scala/xml/ReuseNodesTest.scala
+++ b/jvm/src/test/scala/scala/xml/ReuseNodesTest.scala
@@ -19,8 +19,8 @@ object ReuseNodesTest {
  
   class OriginalTranformr(rules: RewriteRule*) extends RuleTransformer(rules:_*) {
     override def transform(ns: Seq[Node]): Seq[Node] = {
-      val xs = ns.toStream map transform
-      val (xs1, xs2) = xs.zip(ns).span { case (x, n) => unchanged(n, x) }
+      val xs: Seq[Seq[Node]] = ns.toStream map transform
+      val (xs1: Seq[(Seq[Node], Node)], xs2: Seq[(Seq[Node], Node)]) = xs.zip(ns).span { case (x, n) => unchanged(n, x) }
        
       if (xs2.isEmpty) ns
       else xs1.map(_._2) ++ xs2.head._1 ++ transform(ns.drop(xs1.length + 1))
@@ -30,7 +30,7 @@ object ReuseNodesTest {
 
   class ModifiedTranformr(rules: RewriteRule*) extends RuleTransformer(rules:_*) {
     override def transform(ns: Seq[Node]): Seq[Node] = {
-      val changed = ns flatMap transform
+      val changed: Seq[Node] = ns flatMap transform
       
       if (changed.length != ns.length || changed.zip(ns).exists(p => p._1 != p._2)) changed
       else ns
@@ -40,8 +40,8 @@ object ReuseNodesTest {
 
   class AlternateTranformr(rules: RewriteRule*) extends RuleTransformer(rules:_*) {
     override def transform(ns: Seq[Node]): Seq[Node] = {
-      val xs = ns.toStream.map(transform)
-      val (xs1, xs2) = xs.zip(ns).span { case (x, n) => unchanged(n, x) }
+      val xs: Seq[Seq[Node]] = ns.toStream.map(transform)
+      val (xs1: Seq[(Seq[Node], Node)], xs2: Seq[(Seq[Node], Node)]) = xs.zip(ns).span { case (x, n) => unchanged(n, x) }
        
       if (xs2.isEmpty) ns
       else xs1.map(_._2) ++ xs2.head._1 ++ transform(ns.drop(xs1.length + 1))
@@ -49,7 +49,7 @@ object ReuseNodesTest {
     override def transform(n: Node): Seq[Node] = super.transform(n)
   }
    
-  def rewriteRule = new RewriteRule {
+  def rewriteRule: RewriteRule = new RewriteRule {
     override def transform(n: Node): NodeSeq = n match {
       case n if n.label == "change" => Elem(
            n.prefix, "changed", n.attributes, n.scope, n.child.isEmpty, n.child : _*)
@@ -58,7 +58,7 @@ object ReuseNodesTest {
   }
 
   @DataPoints 
-  def tranformers() = Array(
+  def tranformers(): Array[RuleTransformer] = Array(
       new OriginalTranformr(rewriteRule),
       new ModifiedTranformr(rewriteRule),
       new AlternateTranformr(rewriteRule))
@@ -68,16 +68,16 @@ object ReuseNodesTest {
 class ReuseNodesTest {
    
   @Theory
-  def transformReferentialEquality(rt: RuleTransformer) = {
-    val original = <p><lost/></p>
-    val tranformed = rt.transform(original)
+  def transformReferentialEquality(rt: RuleTransformer): Unit = {
+    val original: Elem = <p><lost/></p>
+    val tranformed: Seq[Node] = rt.transform(original)
     assertSame(original, tranformed)
   }
       
   @Theory
-  def transformReferentialEqualityOnly(rt: RuleTransformer) = {
-    val original = <changed><change><lost/><a><b><c/></b></a></change><a><b><c/></b></a></changed>
-    val transformed = rt.transform(original)
+  def transformReferentialEqualityOnly(rt: RuleTransformer): Unit = {
+    val original: Elem = <changed><change><lost/><a><b><c/></b></a></change><a><b><c/></b></a></changed>
+    val transformed: Seq[Node] = rt.transform(original)
     recursiveAssert(original,transformed)
   }
   

--- a/jvm/src/test/scala/scala/xml/SerializationTest.scala
+++ b/jvm/src/test/scala/scala/xml/SerializationTest.scala
@@ -6,24 +6,24 @@ import org.junit.Test
 
 class SerializationTest {
   @Test
-  def xmlLiteral: Unit = {
-    val n = <node/>
+  def xmlLiteral(): Unit = {
+    val n: Elem = <node/>
     assertEquals(n, JavaByteSerialization.roundTrip(n))
   }
 
   @Test
-  def empty: Unit = {
+  def empty(): Unit = {
     assertEquals(NodeSeq.Empty, JavaByteSerialization.roundTrip(NodeSeq.Empty))
   }
 
   @Test
-  def unmatched: Unit = {
+  def unmatched(): Unit = {
     assertEquals(NodeSeq.Empty, JavaByteSerialization.roundTrip(<xml/> \ "HTML"))
   }
 
   @Test
-  def implicitConversion: Unit = {
-    val parent = <parent><child></child><child/></parent>
+  def implicitConversion(): Unit = {
+    val parent: Elem = <parent><child></child><child/></parent>
     val children: Seq[Node] = parent.child
     val asNodeSeq: NodeSeq = children
     assertEquals(asNodeSeq, JavaByteSerialization.roundTrip(asNodeSeq))

--- a/jvm/src/test/scala/scala/xml/XMLSyntaxTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLSyntaxTest.scala
@@ -8,8 +8,8 @@ class XMLSyntaxTestJVM {
   @Test
   def test3(): Unit = {
     // this demonstrates how to handle entities
-    val s = io.Source.fromString("<a>&nbsp;</a>")
-    object parser extends xml.parsing.ConstructingParser(s, false /*ignore ws*/) {
+    val s: io.Source = io.Source.fromString("<a>&nbsp;</a>")
+    object parser extends xml.parsing.ConstructingParser(s, preserveWS = false /*ignore ws*/) {
       override def replacementText(entityName: String): io.Source = {
         entityName match {
           case "nbsp" => io.Source.fromString("\u0160")
@@ -18,9 +18,8 @@ class XMLSyntaxTestJVM {
       }
       nextch() // !!important, to initialize the parser
     }
-    val parsed = parser.element(TopScope) // parse the source as element
+    val parsed: NodeSeq = parser.element(TopScope) // parse the source as element
     // alternatively, we could call document()
     assertEquals("<a>Š</a>", parsed.toString)
   }
-
 }

--- a/jvm/src/test/scala/scala/xml/parsing/ConstructingParserTest.scala
+++ b/jvm/src/test/scala/scala/xml/parsing/ConstructingParserTest.scala
@@ -9,21 +9,20 @@ import org.junit.Assert.assertEquals
 class ConstructingParserTest {
 
   @Test
-  def t9060 = {
-    val a = """<a xmlns:b·="http://example.com"/>"""
-    val source = new Source {
-      override val iter = a.iterator
-      override def reportError(pos: Int, msg: String, out: java.io.PrintStream = Console.err) = {}
+  def t9060(): Unit = {
+    val a: String = """<a xmlns:b·="http://example.com"/>"""
+    val source: Source = new Source {
+      override val iter: Iterator[Char] = a.iterator
+      override def reportError(pos: Int, msg: String, out: java.io.PrintStream = Console.err): Unit = ()
     }
-    val doc = ConstructingParser.fromSource(source, false).content(TopScope)
+    val doc: NodeSeq = ConstructingParser.fromSource(source, preserveWS = false).content(TopScope)
     assertXml(a, doc)
-
   }
 
   /* Example of using SYSTEM in DOCTYPE */
   @Test
-  def docbookTest = {
-    val xml =
+  def docbookTest(): Unit = {
+    val xml: String =
       """|<!DOCTYPE docbook SYSTEM 'docbook.dtd'>
          |<book>
          |  <title>Book</title>
@@ -33,7 +32,7 @@ class ConstructingParserTest {
          |  </chapter>
          |</book>""".stripMargin
 
-    val expected = <book>
+    val expected: Elem = <book>
   <title>Book</title>
   <chapter>
     <title>Chapter</title>
@@ -41,20 +40,20 @@ class ConstructingParserTest {
   </chapter>
 </book>
 
-    val source = new Source {
-      override val iter = xml.iterator
-      override def reportError(pos: Int, msg: String, out: java.io.PrintStream = Console.err) = {}
+    val source: Source = new Source {
+      override val iter: Iterator[Char] = xml.iterator
+      override def reportError(pos: Int, msg: String, out: java.io.PrintStream = Console.err): Unit = ()
     }
 
-    val doc = ConstructingParser.fromSource(source, true).document()
+    val doc: Document = ConstructingParser.fromSource(source, preserveWS = true).document()
 
     assertEquals(expected, doc.theSeq)
   }
 
   /* Unsupported use of lowercase DOCTYPE and SYSTEM */
   @Test(expected = classOf[scala.xml.parsing.FatalError])
-  def docbookFail: Unit = {
-    val xml =
+  def docbookFail(): Unit = {
+    val xml: String =
       """|<!doctype docbook system 'docbook.dtd'>
          |<book>
          |<title>Book</title>
@@ -64,33 +63,32 @@ class ConstructingParserTest {
          |</chapter>
          |</book>""".stripMargin
 
-    val source = new Source {
-      override val iter = xml.iterator
-      override def reportError(pos: Int, msg: String, out: java.io.PrintStream = Console.err) = {}
+    val source: Source = new Source {
+      override val iter: Iterator[Char] = xml.iterator
+      override def reportError(pos: Int, msg: String, out: java.io.PrintStream = Console.err): Unit = ()
     }
 
-    ConstructingParser.fromSource(source, true).content(TopScope)
+    ConstructingParser.fromSource(source, preserveWS = true).content(TopScope)
   }
 
   @Test
-  def SI6341issue65: Unit = {
-    val str = """<elem one="test" two="test2" three="test3"/>"""
-    val cpa = ConstructingParser.fromSource(Source.fromString(str), preserveWS = true)
-    val cpadoc = cpa.document()
-    val ppr = new PrettyPrinter(80,5)
-    val out = ppr.format(cpadoc.docElem)
+  def SI6341issue65(): Unit = {
+    val str: String = """<elem one="test" two="test2" three="test3"/>"""
+    val cpa: ConstructingParser = ConstructingParser.fromSource(Source.fromString(str), preserveWS = true)
+    val cpadoc: Document = cpa.document()
+    val ppr: PrettyPrinter = new PrettyPrinter(80,5)
+    val out: String = ppr.format(cpadoc.docElem)
     assertEquals(str, out)
   }
 
   // https://github.com/scala/scala-xml/issues/541
   @Test
-  def issue541: Unit = {
-    val xml =
+  def issue541(): Unit = {
+    val xml: String =
       """|<script>// <![CDATA[
          |[]; // ]]>
          |</script>""".stripMargin
-    val parser = ConstructingParser.fromSource(Source.fromString(xml), preserveWS = true)
+    val parser: ConstructingParser = ConstructingParser.fromSource(Source.fromString(xml), preserveWS = true)
     parser.document().docElem  // shouldn't crash
   }
-
 }

--- a/jvm/src/test/scala/scala/xml/parsing/PiParsingTest.scala
+++ b/jvm/src/test/scala/scala/xml/parsing/PiParsingTest.scala
@@ -2,38 +2,37 @@ package scala.xml.parsing
 
 import org.junit.Test
 import scala.xml.JUnitAssertsForXML.assertEquals
+import scala.xml.NodeSeq
 
 class PiParsingTestJVM {
-
 
   import scala.io.Source.fromString
   import scala.xml.parsing.ConstructingParser.fromSource
   import scala.xml.TopScope
-  private def parse(s:String) = fromSource(fromString(s), preserveWS = true).element(TopScope)
-  private def parseNoWS(s:String) = fromSource(fromString(s), preserveWS = false).element(TopScope)
+  private def parse(s: String): NodeSeq = fromSource(fromString(s), preserveWS = true).element(TopScope)
+  private def parseNoWS(s: String): NodeSeq = fromSource(fromString(s), preserveWS = false).element(TopScope)
 
   @Test
-  def piNoWSparse: Unit = {
-    val expected = "<foo>a<?pi?>b</foo>"
+  def piNoWSparse(): Unit = {
+    val expected: String = "<foo>a<?pi?>b</foo>"
     assertEquals(expected, parseNoWS("<foo>a<?pi?>b</foo>"))
   }
 
   @Test
-  def piNoWSloadString: Unit = {
-    val expected = "<foo>a<?pi?>b</foo>"
+  def piNoWSloadString(): Unit = {
+    val expected: String = "<foo>a<?pi?>b</foo>"
     assertEquals(expected, xml.XML.loadString("<foo>a<?pi?>b</foo>"))
   }
 
   @Test
-  def piParse: Unit = {
-    val expected = "<foo> a <?pi?> b </foo>"
+  def piParse(): Unit = {
+    val expected: String = "<foo> a <?pi?> b </foo>"
     assertEquals(expected, parse("<foo> a <?pi?> b </foo>"))
   }
 
   @Test
-  def piLoadString: Unit = {
-    val expected = "<foo> a <?pi?> b </foo>"
+  def piLoadString(): Unit = {
+    val expected: String = "<foo> a <?pi?> b </foo>"
     assertEquals(expected, xml.XML.loadString("<foo> a <?pi?> b </foo>"))
   }
-
 }

--- a/jvm/src/test/scala/scala/xml/parsing/Ticket0632Test.scala
+++ b/jvm/src/test/scala/scala/xml/parsing/Ticket0632Test.scala
@@ -2,33 +2,33 @@ package scala.xml.parsing
 
 import org.junit.Test
 import scala.xml.JUnitAssertsForXML.assertEquals
+import scala.xml.NodeSeq
 
 class Ticket0632TestJVM {
 
   import scala.io.Source.fromString
   import scala.xml.parsing.ConstructingParser.fromSource
   import scala.xml.TopScope
-  private def parse(s:String) = fromSource(fromString(s), false).element(TopScope)
+  private def parse(s:String): NodeSeq = fromSource(fromString(s), preserveWS = false).element(TopScope)
 
   @Test
-  def singleAmp: Unit = {
-    val expected = "<foo x=\"&amp;\"/>"
+  def singleAmp(): Unit = {
+    val expected: String = "<foo x=\"&amp;\"/>"
     assertEquals(expected, parse("<foo x='&amp;'/>"))
     assertEquals(expected, xml.XML.loadString("<foo x='&amp;'/>"))
   }
 
   @Test
-  def oneAndHalfAmp: Unit = {
-    val expected = "<foo x=\"&amp;amp;\"/>"
+  def oneAndHalfAmp(): Unit = {
+    val expected: String = "<foo x=\"&amp;amp;\"/>"
     assertEquals(expected, xml.XML.loadString("<foo x='&amp;amp;'/>"))
     assertEquals(expected, parse("<foo x='&amp;amp;'/>"))
   }
 
   @Test
-  def doubleAmp: Unit = {
-    val expected = "<foo x=\"&amp;&amp;\"/>"
+  def doubleAmp(): Unit = {
+    val expected: String = "<foo x=\"&amp;&amp;\"/>"
     assertEquals(expected, xml.XML.loadString("<foo x='&amp;&amp;'/>"))
     assertEquals(expected, parse("<foo x='&amp;&amp;'/>"))
   }
-
 }

--- a/jvm/src/test/scala/scala/xml/parsing/XhtmlParserTest.scala
+++ b/jvm/src/test/scala/scala/xml/parsing/XhtmlParserTest.scala
@@ -9,8 +9,8 @@ import org.junit.Assert.assertEquals
 class XhtmlParserTest {
 
   @Test
-  def issue259: Unit = {
-    val xml =
+  def issue259(): Unit = {
+    val xml: String =
       """|<!DOCTYPE html>
          |<html xmlns="http://www.w3.org/1999/xhtml">
          |  <head>
@@ -21,7 +21,7 @@ class XhtmlParserTest {
          |  </body>
          |</html>""".stripMargin
 
-    val expected = <html xmlns="http://www.w3.org/1999/xhtml">
+    val expected: Elem = <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta charset="utf-8"/>
   </head>
@@ -34,8 +34,8 @@ class XhtmlParserTest {
   }
 
   @Test
-  def html4Strict: Unit = {
-    val xml =
+  def html4Strict(): Unit = {
+    val xml: String =
       """|<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
          |    "http://www.w3.org/TR/html4/strict.dtd">
          |<html>
@@ -47,7 +47,7 @@ class XhtmlParserTest {
          |  </body>
          |</html>""".stripMargin
 
-    val expected = <html xmlns="http://www.w3.org/1999/xhtml">
+    val expected: Elem = <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>Title</title>
   </head>

--- a/shared/src/main/scala-2.13-/scala/xml/ScalaVersionSpecific.scala
+++ b/shared/src/main/scala-2.13-/scala/xml/ScalaVersionSpecific.scala
@@ -19,14 +19,14 @@ private[xml] object ScalaVersionSpecific {
   import NodeSeq.Coll
   type CBF[-From, -A, +C] = CanBuildFrom[From, A, C]
   object NodeSeqCBF extends CanBuildFrom[Coll, Node, NodeSeq] {
-    override def apply(from: Coll) = NodeSeq.newBuilder
-    override def apply() = NodeSeq.newBuilder
+    override def apply(from: Coll) /* TODO type annotation */ = NodeSeq.newBuilder
+    override def apply() /* TODO type annotation */ = NodeSeq.newBuilder
   }
 }
 
 private[xml] trait ScalaVersionSpecificNodeSeq extends SeqLike[Node, NodeSeq] { self: NodeSeq =>
   /** Creates a list buffer as builder for this class */
-  override protected[this] def newBuilder = NodeSeq.newBuilder
+  override protected[this] def newBuilder /* TODO type annotation */ = NodeSeq.newBuilder
 }
 
 private[xml] trait ScalaVersionSpecificNodeBuffer { self: NodeBuffer =>

--- a/shared/src/main/scala/scala/xml/Atom.scala
+++ b/shared/src/main/scala/scala/xml/Atom.scala
@@ -28,20 +28,20 @@ class Atom[+A](val data: A) extends SpecialNode with Serializable {
 
   override protected def basisForHashCode: Seq[Any] = Seq(data)
 
-  override def strict_==(other: Equality) = other match {
+  override def strict_==(other: Equality): Boolean = other match {
     case x: Atom[_] => data == x.data
     case _          => false
   }
 
-  override def canEqual(other: Any) = other match {
+  override def canEqual(other: Any): Boolean = other match {
     case _: Atom[_] => true
     case _          => false
   }
 
-  final override def doCollectNamespaces = false
-  final override def doTransform = false
+  final override def doCollectNamespaces: Boolean = false
+  final override def doTransform: Boolean = false
 
-  override def label = "#PCDATA"
+  override def label: String = "#PCDATA"
 
   /**
    * Returns text, with some characters escaped according to the XML
@@ -51,5 +51,4 @@ class Atom[+A](val data: A) extends SpecialNode with Serializable {
     Utility.escape(data.toString, sb)
 
   override def text: String = data.toString
-
 }

--- a/shared/src/main/scala/scala/xml/Attribute.scala
+++ b/shared/src/main/scala/scala/xml/Attribute.scala
@@ -22,7 +22,7 @@ import scala.collection.Seq
  *  @author  Burak Emir
  */
 object Attribute {
-  def unapply(x: Attribute) = x match {
+  def unapply(x: Attribute) /* TODO type annotation */ = x match {
     case PrefixedAttribute(_, key, value, next) => Some((key, value, next))
     case UnprefixedAttribute(key, value, next)  => Some((key, value, next))
     case _                                      => None
@@ -63,11 +63,11 @@ trait Attribute extends MetaData {
   override def apply(namespace: String, scope: NamespaceBinding, key: String): Seq[Node]
   override def copy(next: MetaData): Attribute
 
-  override def remove(key: String) =
+  override def remove(key: String): MetaData =
     if (!isPrefixed && this.key == key) next
     else copy(next remove key)
 
-  override def remove(namespace: String, scope: NamespaceBinding, key: String) =
+  override def remove(namespace: String, scope: NamespaceBinding, key: String): MetaData =
     if (this.key == key && (scope getURI pre) == namespace) next
     else copy(next.remove(namespace, scope, key))
 
@@ -76,7 +76,7 @@ trait Attribute extends MetaData {
   override def getNamespace(owner: Node): String
 
   override def wellformed(scope: NamespaceBinding): Boolean = {
-    val arg = if (isPrefixed) scope getURI pre else null
+    val arg: String = if (isPrefixed) scope getURI pre else null
     (next(arg, scope, key) == null) && (next wellformed scope)
   }
 
@@ -101,7 +101,7 @@ trait Attribute extends MetaData {
       sb append pre append ':'
 
     sb append key append '='
-    val sb2 = new StringBuilder()
+    val sb2: StringBuilder = new StringBuilder()
     Utility.sequenceToXML(value, TopScope, sb2, stripComments = true)
     Utility.appendQuoted(sb2.toString, sb)
   }

--- a/shared/src/main/scala/scala/xml/Comment.scala
+++ b/shared/src/main/scala/scala/xml/Comment.scala
@@ -23,10 +23,10 @@ package xml
  */
 case class Comment(commentText: String) extends SpecialNode {
 
-  override def label = "#REM"
-  override def text = ""
-  final override def doCollectNamespaces = false
-  final override def doTransform = false
+  override def label: String = "#REM"
+  override def text: String = ""
+  final override def doCollectNamespaces: Boolean = false
+  final override def doTransform: Boolean = false
 
   if (commentText.contains("--")) {
     throw new IllegalArgumentException("text contains \"--\"")
@@ -38,6 +38,6 @@ case class Comment(commentText: String) extends SpecialNode {
   /**
    * Appends &quot;<!-- text -->&quot; to this string buffer.
    */
-  override def buildString(sb: StringBuilder) =
+  override def buildString(sb: StringBuilder): StringBuilder =
     sb append "<!--" append commentText append "-->"
 }

--- a/shared/src/main/scala/scala/xml/Document.scala
+++ b/shared/src/main/scala/scala/xml/Document.scala
@@ -92,13 +92,13 @@ class Document extends NodeSeq with Serializable {
    *  then certain properties (indicated in their descriptions below) may
    *  be unknown. If it is true, those properties are never unknown.
    */
-  var allDeclarationsProcessed = false
+  var allDeclarationsProcessed: Boolean = false
 
   // methods for NodeSeq
 
   override def theSeq: Seq[Node] = this.docElem
 
-  override def canEqual(other: Any) = other match {
+  override def canEqual(other: Any): Boolean = other match {
     case _: Document => true
     case _           => false
   }

--- a/shared/src/main/scala/scala/xml/Elem.scala
+++ b/shared/src/main/scala/scala/xml/Elem.scala
@@ -26,7 +26,7 @@ object Elem {
   def apply(prefix: String, label: String, attributes: MetaData, scope: NamespaceBinding, minimizeEmpty: Boolean, child: Node*): Elem =
     new Elem(prefix, label, attributes, scope, minimizeEmpty, child: _*)
 
-  def unapplySeq(n: Node) = n match {
+  def unapplySeq(n: Node) /* TODO type annotation */ = n match {
     case _: SpecialNode | _: Group => None
     case _                         => Some((n.prefix, n.label, n.attributes, n.scope, n.child.toSeq))
   }
@@ -60,10 +60,10 @@ class Elem(
   override val child: Node*
 ) extends Node with Serializable {
 
-  final override def doCollectNamespaces = true
-  final override def doTransform = true
+  final override def doCollectNamespaces: Boolean = true
+  final override def doTransform: Boolean = true
 
-  override val attributes = MetaData.normalize(attributes1, scope)
+  override val attributes: MetaData = MetaData.normalize(attributes1, scope)
 
   if (prefix == "")
     throw new IllegalArgumentException("prefix of zero length, use null instead")
@@ -106,5 +106,5 @@ class Elem(
   /**
    * Returns concatenation of `text(n)` for each child `n`.
    */
-  override def text = (child map (_.text)).mkString
+  override def text: String = (child map (_.text)).mkString
 }

--- a/shared/src/main/scala/scala/xml/EntityRef.scala
+++ b/shared/src/main/scala/scala/xml/EntityRef.scala
@@ -20,11 +20,11 @@ package xml
  * @param   entityName the name of the entity reference, for example `amp`.
  */
 case class EntityRef(entityName: String) extends SpecialNode {
-  final override def doCollectNamespaces = false
-  final override def doTransform = false
-  override def label = "#ENTITY"
+  final override def doCollectNamespaces: Boolean = false
+  final override def doTransform: Boolean = false
+  override def label: String = "#ENTITY"
 
-  override def text = entityName match {
+  override def text: String = entityName match {
     case "lt"   => "<"
     case "gt"   => ">"
     case "amp"  => "&"
@@ -39,7 +39,6 @@ case class EntityRef(entityName: String) extends SpecialNode {
    *  @param  sb the string buffer.
    *  @return the modified string buffer `sb`.
    */
-  override def buildString(sb: StringBuilder) =
+  override def buildString(sb: StringBuilder): StringBuilder =
     sb.append("&").append(entityName).append(";")
-
 }

--- a/shared/src/main/scala/scala/xml/Equality.scala
+++ b/shared/src/main/scala/scala/xml/Equality.scala
@@ -63,7 +63,7 @@ object Equality {
   }
   def compareBlithely(x1: AnyRef, x2: AnyRef): Boolean = {
     if (x1 == null || x2 == null)
-      return (x1 eq x2)
+      return x1 eq x2
 
     x2 match {
       case s: String => compareBlithely(x1, s)
@@ -78,7 +78,7 @@ trait Equality extends scala.Equals {
   protected def basisForHashCode: Seq[Any]
 
   def strict_==(other: Equality): Boolean
-  def strict_!=(other: Equality) = !strict_==(other)
+  def strict_!=(other: Equality): Boolean = !strict_==(other)
 
   /**
    * We insist we're only equal to other `xml.Equality` implementors,
@@ -96,18 +96,18 @@ trait Equality extends scala.Equals {
    *  are final since clearly individual classes cannot be trusted
    *  to maintain a semblance of order.
    */
-  override def hashCode() = basisForHashCode.##
-  override def equals(other: Any) = doComparison(other, blithe = false)
-  final def xml_==(other: Any) = doComparison(other, blithe = true)
-  final def xml_!=(other: Any) = !xml_==(other)
+  override def hashCode(): Int = basisForHashCode.##
+  override def equals(other: Any): Boolean = doComparison(other, blithe = false)
+  final def xml_==(other: Any): Boolean = doComparison(other, blithe = true)
+  final def xml_!=(other: Any): Boolean = !xml_==(other)
 
   /**
    * The "blithe" parameter expresses the caller's unconcerned attitude
    *  regarding the usual constraints on equals.  The method is thereby
    *  given carte blanche to declare any two things equal.
    */
-  private def doComparison(other: Any, blithe: Boolean) = {
-    val strictlyEqual = other match {
+  private def doComparison(other: Any, blithe: Boolean): Boolean = {
+    val strictlyEqual: Boolean = other match {
       case x: AnyRef if this eq x => true
       case x: Equality            => (x canEqual this) && (this strict_== x)
       case _                      => false

--- a/shared/src/main/scala/scala/xml/Group.scala
+++ b/shared/src/main/scala/scala/xml/Group.scala
@@ -21,29 +21,29 @@ import scala.collection.Seq
  *  @author  Burak Emir
  */
 final case class Group(nodes: Seq[Node]) extends Node {
-  override def theSeq = nodes
+  override def theSeq: Seq[Node] = nodes
 
-  override def canEqual(other: Any) = other match {
+  override def canEqual(other: Any): Boolean = other match {
     case x: Group => true
     case _        => false
   }
 
-  override def strict_==(other: Equality) = other match {
+  override def strict_==(other: Equality): Boolean = other match {
     case Group(xs) => nodes sameElements xs
     case _         => false
   }
 
-  override protected def basisForHashCode = nodes
+  override protected def basisForHashCode: Seq[Node] = nodes
 
   /**
    * Since Group is very much a hack it throws an exception if you
    *  try to do anything with it.
    */
-  private def fail(msg: String) = throw new UnsupportedOperationException("class Group does not support method '%s'" format msg)
+  private def fail(msg: String): Nothing = throw new UnsupportedOperationException("class Group does not support method '%s'" format msg)
 
-  override def label = fail("label")
-  override def attributes = fail("attributes")
-  override def namespace = fail("namespace")
-  override def child = fail("child")
-  def buildString(sb: StringBuilder) = fail("toString(StringBuilder)")
+  override def label: Nothing = fail("label")
+  override def attributes: Nothing = fail("attributes")
+  override def namespace: Nothing = fail("namespace")
+  override def child /* TODO type annotation */ = fail("child")
+  def buildString(sb: StringBuilder): Nothing = fail("toString(StringBuilder)")
 }

--- a/shared/src/main/scala/scala/xml/MetaData.scala
+++ b/shared/src/main/scala/scala/xml/MetaData.scala
@@ -43,7 +43,7 @@ object MetaData {
       } else if (md.value eq null) {
         iterate(md.next, normalized_attribs, set)
       } else {
-        val key = getUniversalKey(md, scope)
+        val key: String = getUniversalKey(md, scope)
         if (set(key)) {
           iterate(md.next, normalized_attribs, set)
         } else {
@@ -57,7 +57,7 @@ object MetaData {
   /**
    * returns key if md is unprefixed, pre+key is md is prefixed
    */
-  def getUniversalKey(attrib: MetaData, scope: NamespaceBinding) = attrib match {
+  def getUniversalKey(attrib: MetaData, scope: NamespaceBinding): String = attrib match {
     case prefixed: PrefixedAttribute     => scope.getURI(prefixed.pre) + prefixed.key
     case unprefixed: UnprefixedAttribute => unprefixed.key
   }
@@ -134,7 +134,7 @@ abstract class MetaData
   /** if owner is the element of this metadata item, returns namespace */
   def getNamespace(owner: Node): String
 
-  def hasNext = Null != next
+  def hasNext: Boolean = Null != next
 
   def length: Int = length(0)
 
@@ -142,11 +142,11 @@ abstract class MetaData
 
   def isPrefixed: Boolean
 
-  override def canEqual(other: Any) = other match {
+  override def canEqual(other: Any): Boolean = other match {
     case _: MetaData => true
     case _           => false
   }
-  override def strict_==(other: Equality) = other match {
+  override def strict_==(other: Equality): Boolean = other match {
     case m: MetaData => this.asAttrMap == m.asAttrMap
     case _           => false
   }
@@ -172,7 +172,7 @@ abstract class MetaData
    * Returns a String containing "prefix:key" if the first key is
    *  prefixed, and "key" otherwise.
    */
-  def prefixedKey = this match {
+  def prefixedKey: String = this match {
     case x: Attribute if x.isPrefixed => x.pre + ":" + key
     case _                            => key
   }

--- a/shared/src/main/scala/scala/xml/NamespaceBinding.scala
+++ b/shared/src/main/scala/scala/xml/NamespaceBinding.scala
@@ -52,18 +52,18 @@ case class NamespaceBinding(prefix: String, uri: String, parent: NamespaceBindin
       case Nil     => stop
       case x :: xs => NamespaceBinding(x, this.getURI(x), fromPrefixList(xs))
     }
-    val ps0 = prefixList(this).reverse
-    val ps = ps0.distinct
+    val ps0: List[String] = prefixList(this).reverse
+    val ps: List[String] = ps0.distinct
     if (ps.size == ps0.size) this
     else fromPrefixList(ps)
   }
 
-  override def canEqual(other: Any) = other match {
+  override def canEqual(other: Any): Boolean = other match {
     case _: NamespaceBinding => true
     case _                   => false
   }
 
-  override def strict_==(other: Equality) = other match {
+  override def strict_==(other: Equality): Boolean = other match {
     case x: NamespaceBinding => (prefix == x.prefix) && (uri == x.uri) && (parent == x.parent)
     case _                   => false
   }
@@ -79,7 +79,7 @@ case class NamespaceBinding(prefix: String, uri: String, parent: NamespaceBindin
   private def doBuildString(sb: StringBuilder, stop: NamespaceBinding): Unit = {
     if (List(null, stop, TopScope).contains(this)) return
 
-    val s = " xmlns%s=\"%s\"".format(
+    val s: String = " xmlns%s=\"%s\"".format(
       if (prefix != null) ":" + prefix else "",
       if (uri != null) uri else ""
     )

--- a/shared/src/main/scala/scala/xml/Node.scala
+++ b/shared/src/main/scala/scala/xml/Node.scala
@@ -26,9 +26,9 @@ object Node {
   final def NoAttributes: MetaData = Null
 
   /** the empty namespace */
-  val EmptyNamespace = ""
+  val EmptyNamespace: String = ""
 
-  def unapplySeq(n: Node) = Some((n.label, n.attributes, n.child.toSeq))
+  def unapplySeq(n: Node) /* TODO type annotation */ = Some((n.label, n.attributes, n.child.toSeq))
 }
 
 /**
@@ -55,11 +55,11 @@ abstract class Node extends NodeSeq {
   /**
    * used internally. Atom/Molecule = -1 PI = -2 Comment = -3 EntityRef = -5
    */
-  def isAtom = this.isInstanceOf[Atom[_]]
+  def isAtom: Boolean = this.isInstanceOf[Atom[_]]
 
   /** The logic formerly found in typeTag$, as best I could infer it. */
-  def doCollectNamespaces = true // if (tag >= 0) DO collect namespaces
-  def doTransform = true // if (tag < 0) DO NOT transform
+  def doCollectNamespaces: Boolean = true // if (tag >= 0) DO collect namespaces
+  def doTransform: Boolean = true // if (tag < 0) DO NOT transform
 
   /**
    *  method returning the namespace bindings of this node. by default, this
@@ -71,7 +71,7 @@ abstract class Node extends NodeSeq {
   /**
    *  convenience, same as `getNamespace(this.prefix)`
    */
-  def namespace = getNamespace(this.prefix)
+  def namespace: String = getNamespace(this.prefix)
 
   /**
    * Convenience method, same as `scope.getURI(pre)` but additionally
@@ -139,7 +139,7 @@ abstract class Node extends NodeSeq {
    */
   def descendant_or_self: List[Node] = this :: descendant
 
-  override def canEqual(other: Any) = other match {
+  override def canEqual(other: Any): Boolean = other match {
     case x: Group => false
     case x: Node  => true
     case _        => false
@@ -148,7 +148,7 @@ abstract class Node extends NodeSeq {
   override protected def basisForHashCode: Seq[Any] =
     prefix :: label :: attributes :: nonEmptyChildren.toList
 
-  override def strict_==(other: Equality) = other match {
+  override def strict_==(other: Equality): Boolean = other match {
     case _: Group => false
     case x: Node =>
       (prefix == x.prefix) &&

--- a/shared/src/main/scala/scala/xml/NodeSeq.scala
+++ b/shared/src/main/scala/scala/xml/NodeSeq.scala
@@ -13,8 +13,7 @@
 package scala
 package xml
 
-import scala.collection.{ mutable, immutable, AbstractSeq }
-import mutable.{ Builder, ListBuffer }
+import scala.collection.{mutable, immutable, AbstractSeq}
 import ScalaVersionSpecific.CBF
 import scala.language.implicitConversions
 import scala.collection.Seq
@@ -25,9 +24,9 @@ import scala.collection.Seq
  *  @author  Burak Emir
  */
 object NodeSeq {
-  final val Empty = fromSeq(Nil)
+  final val Empty: NodeSeq = fromSeq(Nil)
   def fromSeq(s: Seq[Node]): NodeSeq = new NodeSeq {
-    override def theSeq = s
+    override def theSeq: Seq[Node] = s
   }
 
   // ---
@@ -38,7 +37,7 @@ object NodeSeq {
   implicit def canBuildFrom: CBF[Coll, Node, NodeSeq] = ScalaVersionSpecific.NodeSeqCBF
   // ---
 
-  def newBuilder: Builder[Node, NodeSeq] = new ListBuffer[Node] mapResult fromSeq
+  def newBuilder: mutable.Builder[Node, NodeSeq] = new mutable.ListBuffer[Node] mapResult fromSeq
   implicit def seqToNodeSeq(s: Seq[Node]): NodeSeq = fromSeq(s)
 }
 
@@ -50,15 +49,15 @@ object NodeSeq {
  */
 abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with ScalaVersionSpecificNodeSeq with Equality with Serializable {
   def theSeq: Seq[Node]
-  override def length = theSeq.length
-  override def iterator = theSeq.iterator
+  override def length: Int = theSeq.length
+  override def iterator: Iterator[Node] = theSeq.iterator
 
   override def apply(i: Int): Node = theSeq(i)
   def apply(f: Node => Boolean): NodeSeq = filter(f)
 
   def xml_sameElements[A](that: Iterable[A]): Boolean = {
-    val these = this.iterator
-    val those = that.iterator
+    val these: Iterator[Node] = this.iterator
+    val those: Iterator[A] = that.iterator
     while (these.hasNext && those.hasNext)
       if (these.next() xml_!= those.next())
         return false
@@ -68,12 +67,12 @@ abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with S
 
   override protected def basisForHashCode: Seq[Any] = theSeq
 
-  override def canEqual(other: Any) = other match {
+  override def canEqual(other: Any): Boolean = other match {
     case _: NodeSeq => true
     case _          => false
   }
 
-  override def strict_==(other: Equality) = other match {
+  override def strict_==(other: Equality): Boolean = other match {
     case x: NodeSeq => (length == x.length) && (theSeq sameElements x.theSeq)
     case _          => false
   }
@@ -95,15 +94,15 @@ abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with S
    *  The document order is preserved.
    */
   def \(that: String): NodeSeq = {
-    def fail = throw new IllegalArgumentException(that)
-    def atResult = {
-      lazy val y = this(0)
-      val attr =
+    def fail: Nothing = throw new IllegalArgumentException(that)
+    def atResult: NodeSeq = {
+      lazy val y: Node = this(0)
+      val attr: Option[Seq[Node]] =
         if (that.length == 1) fail
         else if (that(1) == '{') {
-          val i = that indexOf '}'
+          val i: Int = that indexOf '}'
           if (i == -1) fail
-          val (uri, key) = (that.substring(2, i), that.substring(i + 1, that.length()))
+          val (uri: String, key: String) = (that.substring(2, i), that.substring(i + 1, that.length()))
           if (uri == "" || key == "") fail
           else y.attribute(uri, key)
         } else y.attribute(that drop 1)
@@ -114,7 +113,7 @@ abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with S
       }
     }
 
-    def makeSeq(cond: (Node) => Boolean) =
+    def makeSeq(cond: Node => Boolean): NodeSeq =
       NodeSeq fromSeq (this flatMap (_.child) filter cond)
 
     that match {
@@ -144,8 +143,8 @@ abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with S
    *  The document order is preserved.
    */
   def \\(that: String): NodeSeq = {
-    def fail = throw new IllegalArgumentException(that)
-    def filt(cond: (Node) => Boolean) = this flatMap (_.descendant_or_self) filter cond
+    def fail: Nothing = throw new IllegalArgumentException(that)
+    def filt(cond: Node => Boolean): NodeSeq = this flatMap (_.descendant_or_self) filter cond
     that match {
       case ""                  => fail
       case "_"                 => filt(!_.isAtom)

--- a/shared/src/main/scala/scala/xml/Null.scala
+++ b/shared/src/main/scala/scala/xml/Null.scala
@@ -25,43 +25,43 @@ import scala.collection.Seq
  *  @author  Burak Emir
  */
 case object Null extends MetaData {
-  override def iterator = Iterator.empty
-  override def size = 0
+  override def iterator /* TODO type annotation */ = Iterator.empty
+  override def size: Int = 0
   override def append(m: MetaData, scope: NamespaceBinding = TopScope): MetaData = m
   override def filter(f: MetaData => Boolean): MetaData = this
 
-  override def copy(next: MetaData) = next
-  override def getNamespace(owner: Node) = null
+  override def copy(next: MetaData): MetaData = next
+  override def getNamespace(owner: Node) /* TODO type annotation */ = null
 
-  override def hasNext = false
-  override def next = null
-  override def key = null
-  override def value = null
-  override def isPrefixed = false
+  override def hasNext: Boolean = false
+  override def next /* TODO type annotation */ = null
+  override def key /* TODO type annotation */ = null
+  override def value /* TODO type annotation */ = null
+  override def isPrefixed: Boolean = false
 
-  override def length = 0
-  override def length(i: Int) = i
+  override def length: Int = 0
+  override def length(i: Int): Int = i
 
-  override def strict_==(other: Equality) = other match {
+  override def strict_==(other: Equality): Boolean = other match {
     case x: MetaData => x.length == 0
     case _           => false
   }
   override protected def basisForHashCode: Seq[Any] = Nil
 
-  override def apply(namespace: String, scope: NamespaceBinding, key: String) = null
-  override def apply(key: String) =
+  override def apply(namespace: String, scope: NamespaceBinding, key: String) /* TODO type annotation */ = null
+  override def apply(key: String) /* TODO type annotation */ =
     if (isNameStart(key.head)) null
     else throw new IllegalArgumentException("not a valid attribute name '" + key + "', so can never match !")
 
-  override protected def toString1(sb: StringBuilder) = ()
+  override protected def toString1(sb: StringBuilder): Unit = ()
   override protected def toString1(): String = ""
 
   override def toString(): String = ""
 
   override def buildString(sb: StringBuilder): StringBuilder = sb
 
-  override def wellformed(scope: NamespaceBinding) = true
+  override def wellformed(scope: NamespaceBinding): Boolean = true
 
-  override def remove(key: String) = this
-  override def remove(namespace: String, scope: NamespaceBinding, key: String) = this
+  override def remove(key: String) /* TODO type annotation */ = this
+  override def remove(namespace: String, scope: NamespaceBinding, key: String) /* TODO type annotation */ = this
 }

--- a/shared/src/main/scala/scala/xml/PCData.scala
+++ b/shared/src/main/scala/scala/xml/PCData.scala
@@ -40,7 +40,7 @@ class PCData(data: String) extends Atom[String](data) {
  *  @author  Burak Emir
  */
 object PCData {
-  def apply(data: String) = new PCData(data)
+  def apply(data: String): PCData = new PCData(data)
   def unapply(other: Any): Option[String] = other match {
     case x: PCData => Some(x.data)
     case _         => None

--- a/shared/src/main/scala/scala/xml/PrefixedAttribute.scala
+++ b/shared/src/main/scala/scala/xml/PrefixedAttribute.scala
@@ -29,7 +29,7 @@ class PrefixedAttribute(
   override val value: Seq[Node],
   val next1: MetaData)
   extends Attribute {
-  override val next = if (value ne null) next1 else next1.remove(key)
+  override val next: MetaData = if (value ne null) next1 else next1.remove(key)
 
   /** same as this(pre, key, Text(value), next), or no attribute if value is null */
   def this(pre: String, key: String, value: String, next: MetaData) =
@@ -43,10 +43,10 @@ class PrefixedAttribute(
    * Returns a copy of this unprefixed attribute with the given
    *  next field.
    */
-  override def copy(next: MetaData) =
+  override def copy(next: MetaData): PrefixedAttribute =
     new PrefixedAttribute(pre, key, value, next)
 
-  override def getNamespace(owner: Node) =
+  override def getNamespace(owner: Node): String =
     owner.getNamespace(pre)
 
   /** forwards the call to next (because caller looks for unprefixed attribute */
@@ -64,5 +64,5 @@ class PrefixedAttribute(
 }
 
 object PrefixedAttribute {
-  def unapply(x: PrefixedAttribute) = Some((x.pre, x.key, x.value, x.next))
+  def unapply(x: PrefixedAttribute) /* TODO type annotation */ = Some((x.pre, x.key, x.value, x.next))
 }

--- a/shared/src/main/scala/scala/xml/ProcInstr.scala
+++ b/shared/src/main/scala/scala/xml/ProcInstr.scala
@@ -28,16 +28,16 @@ case class ProcInstr(target: String, proctext: String) extends SpecialNode {
   if (target.toLowerCase == "xml")
     throw new IllegalArgumentException(target + " is reserved")
 
-  final override def doCollectNamespaces = false
-  final override def doTransform = false
+  final override def doCollectNamespaces: Boolean = false
+  final override def doTransform: Boolean = false
 
-  final override def label = "#PI"
-  override def text = ""
+  final override def label: String = "#PI"
+  override def text: String = ""
 
   /**
    * appends &quot;&lt;?&quot; target (&quot; &quot;+text)?+&quot;?&gt;&quot;
    *  to this stringbuffer.
    */
-  override def buildString(sb: StringBuilder) =
+  override def buildString(sb: StringBuilder): StringBuilder =
     sb append "<?%s%s?>".format(target, if (proctext == "") "" else " " + proctext)
 }

--- a/shared/src/main/scala/scala/xml/QNode.scala
+++ b/shared/src/main/scala/scala/xml/QNode.scala
@@ -20,5 +20,5 @@ package xml
  *  @author  Burak Emir
  */
 object QNode {
-  def unapplySeq(n: Node) = Some((n.scope.getURI(n.prefix), n.label, n.attributes, n.child.toSeq))
+  def unapplySeq(n: Node) /* TODO type annotation */ = Some((n.scope.getURI(n.prefix), n.label, n.attributes, n.child.toSeq))
 }

--- a/shared/src/main/scala/scala/xml/SpecialNode.scala
+++ b/shared/src/main/scala/scala/xml/SpecialNode.scala
@@ -22,13 +22,13 @@ package xml
 abstract class SpecialNode extends Node {
 
   /** always empty */
-  final override def attributes = Null
+  final override def attributes: Null.type = Null
 
   /** always Node.EmptyNamespace */
-  final override def namespace = null
+  final override def namespace: scala.Null = null
 
   /** always empty */
-  final override def child = Nil
+  final override def child /* TODO type annotation */ = Nil
 
   /** Append string representation to the given string buffer argument. */
   def buildString(sb: StringBuilder): StringBuilder

--- a/shared/src/main/scala/scala/xml/Text.scala
+++ b/shared/src/main/scala/scala/xml/Text.scala
@@ -37,7 +37,7 @@ class Text(data: String) extends Atom[String](data) {
  *  @author  Burak Emir
  */
 object Text {
-  def apply(data: String) = new Text(data)
+  def apply(data: String): Text = new Text(data)
   def unapply(other: Any): Option[String] = other match {
     case x: Text => Some(x.data)
     case _       => None

--- a/shared/src/main/scala/scala/xml/TextBuffer.scala
+++ b/shared/src/main/scala/scala/xml/TextBuffer.scala
@@ -27,7 +27,7 @@ object TextBuffer {
  *  character, and leading and trailing space will be removed completely.
  */
 class TextBuffer {
-  val sb = new StringBuilder()
+  val sb: StringBuilder = new StringBuilder()
 
   /**
    * Appends this string to the text buffer, trimming whitespaces as needed.

--- a/shared/src/main/scala/scala/xml/TopScope.scala
+++ b/shared/src/main/scala/scala/xml/TopScope.scala
@@ -20,7 +20,7 @@ package xml
  */
 object TopScope extends NamespaceBinding(null, null, null) {
 
-  import XML.{ xml, namespace }
+  import XML.{xml, namespace}
 
   override def getURI(prefix1: String): String =
     if (prefix1 == xml) namespace else null
@@ -28,8 +28,8 @@ object TopScope extends NamespaceBinding(null, null, null) {
   override def getPrefix(uri1: String): String =
     if (uri1 == namespace) xml else null
 
-  override def toString() = ""
+  override def toString(): String = ""
 
-  override def buildString(stop: NamespaceBinding) = ""
-  override def buildString(sb: StringBuilder, ignore: NamespaceBinding) = {}
+  override def buildString(stop: NamespaceBinding): String = ""
+  override def buildString(sb: StringBuilder, ignore: NamespaceBinding): Unit = ()
 }

--- a/shared/src/main/scala/scala/xml/Unparsed.scala
+++ b/shared/src/main/scala/scala/xml/Unparsed.scala
@@ -37,6 +37,6 @@ class Unparsed(data: String) extends Atom[String](data) {
  *  @author  Burak Emir
  */
 object Unparsed {
-  def apply(data: String) = new Unparsed(data)
-  def unapply(x: Unparsed) = Some(x.data)
+  def apply(data: String): Unparsed = new Unparsed(data)
+  def unapply(x: Unparsed): Some[String] = Some(x.data)
 }

--- a/shared/src/main/scala/scala/xml/UnprefixedAttribute.scala
+++ b/shared/src/main/scala/scala/xml/UnprefixedAttribute.scala
@@ -25,8 +25,8 @@ class UnprefixedAttribute(
   override val value: Seq[Node],
   next1: MetaData)
   extends Attribute {
-  final override val pre = null
-  override val next = if (value ne null) next1 else next1.remove(key)
+  final override val pre: scala.Null = null
+  override val next: MetaData = if (value ne null) next1 else next1.remove(key)
 
   /** same as this(key, Text(value), next), or no attribute if value is null */
   def this(key: String, value: String, next: MetaData) =
@@ -37,7 +37,7 @@ class UnprefixedAttribute(
     this(key, value.orNull, next)
 
   /** returns a copy of this unprefixed attribute with the given next field*/
-  override def copy(next: MetaData) = new UnprefixedAttribute(key, value, next)
+  override def copy(next: MetaData): UnprefixedAttribute = new UnprefixedAttribute(key, value, next)
 
   final override def getNamespace(owner: Node): String = null
 
@@ -62,5 +62,5 @@ class UnprefixedAttribute(
     next(namespace, scope, key)
 }
 object UnprefixedAttribute {
-  def unapply(x: UnprefixedAttribute) = Some((x.key, x.value, x.next))
+  def unapply(x: UnprefixedAttribute) /* TODO type annotation */ = Some((x.key, x.value, x.next))
 }

--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -24,7 +24,7 @@ import scala.collection.Seq
  * @author Burak Emir
  */
 object Utility extends AnyRef with parsing.TokenTests {
-  final val SU = '\u001A'
+  final val SU: Char = '\u001A'
 
   // [Martin] This looks dubious. We don't convert StringBuilders to
   // Strings anywhere else, why do it here?
@@ -32,12 +32,12 @@ object Utility extends AnyRef with parsing.TokenTests {
 
   // helper for the extremely oft-repeated sequence of creating a
   // StringBuilder, passing it around, and then grabbing its String.
-  private[xml] def sbToString(f: (StringBuilder) => Unit): String = {
-    val sb = new StringBuilder
+  private[xml] def sbToString(f: StringBuilder => Unit): String = {
+    val sb: StringBuilder = new StringBuilder
     f(sb)
     sb.toString
   }
-  private[xml] def isAtomAndNotText(x: Node) = x.isAtom && !x.isInstanceOf[Text]
+  private[xml] def isAtomAndNotText(x: Node): Boolean = x.isAtom && !x.isInstanceOf[Text]
 
   /**
    * Trims an element - call this method, when you know that it is an
@@ -50,7 +50,7 @@ object Utility extends AnyRef with parsing.TokenTests {
    */
   def trim(x: Node): Node = x match {
     case Elem(pre, lab, md, scp, child@_*) =>
-      val children = combineAdjacentTextNodes(child) flatMap trimProper
+      val children: Seq[Node] = combineAdjacentTextNodes(child) flatMap trimProper
       Elem(pre, lab, md, scp, children.isEmpty, children: _*)
   }
 
@@ -67,7 +67,7 @@ object Utility extends AnyRef with parsing.TokenTests {
    */
   def trimProper(x: Node): Seq[Node] = x match {
     case Elem(pre, lab, md, scp, child@_*) =>
-      val children = combineAdjacentTextNodes(child) flatMap trimProper
+      val children: Seq[Node] = combineAdjacentTextNodes(child) flatMap trimProper
       Elem(pre, lab, md, scp, children.isEmpty, children: _*)
     case Text(s) =>
       new TextBuffer().append(s).toText
@@ -77,9 +77,9 @@ object Utility extends AnyRef with parsing.TokenTests {
 
   /** returns a sorted attribute list */
   def sort(md: MetaData): MetaData = if ((md eq Null) || (md.next eq Null)) md else {
-    val key = md.key
-    val smaller = sort(md.filter { m => m.key < key })
-    val greater = sort(md.filter { m => m.key > key })
+    val key: String = md.key
+    val smaller: MetaData = sort(md.filter { m => m.key < key })
+    val greater: MetaData = sort(md.filter { m => m.key > key })
     smaller.foldRight (md copy greater) ((x, xs) => x copy xs)
   }
 
@@ -89,7 +89,7 @@ object Utility extends AnyRef with parsing.TokenTests {
    */
   def sort(n: Node): Node = n match {
     case Elem(pre, lab, md, scp, child@_*) =>
-      val children = child map sort
+      val children: Seq[Node] = child map sort
       Elem(pre, lab, sort(md), scp, children.isEmpty, children: _*)
     case _ => n
   }
@@ -104,15 +104,15 @@ object Utility extends AnyRef with parsing.TokenTests {
      * For reasons unclear escape and unescape are a long ways from
      * being logical inverses.
      */
-    val pairs = Map(
+    val pairs: Map[String, Char] = Map(
       "lt" -> '<',
       "gt" -> '>',
       "amp" -> '&',
       "quot" -> '"',
       "apos"  -> '\''
     )
-    val escMap = (pairs - "apos") map { case (s, c) => c -> ("&%s;" format s) }
-    val unescMap = pairs
+    val escMap: Map[Char, String] = (pairs - "apos") map { case (s, c) => c -> ("&%s;" format s) }
+    val unescMap: Map[String, Char] = pairs
   }
   import Escapes.{ escMap, unescMap }
 
@@ -252,11 +252,11 @@ object Utility extends AnyRef with parsing.TokenTests {
     {
       if (children.isEmpty) ()
       else if (children forall isAtomAndNotText) { // add space
-        val it = children.iterator
-        val f = it.next()
+        val it: Iterator[Node] = children.iterator
+        val f: Node = it.next()
         serialize(f, pscope, sb, stripComments, decodeEntities, preserveWhitespace, minimizeTags)
         while (it.hasNext) {
-          val x = it.next()
+          val x: Node = it.next()
           sb.append(' ')
           serialize(x, pscope, sb, stripComments, decodeEntities, preserveWhitespace, minimizeTags)
         }
@@ -274,7 +274,7 @@ object Utility extends AnyRef with parsing.TokenTests {
   /**
    * Returns a hashcode for the given constituents of a node
    */
-  def hashCode(pre: String, label: String, attribHashCode: Int, scpeHash: Int, children: Seq[Node]) =
+  def hashCode(pre: String, label: String, attribHashCode: Int, scpeHash: Int, children: Seq[Node]): Int =
     scala.util.hashing.MurmurHash3.orderedHash(label +: attribHashCode +: scpeHash +: children, pre.##)
 
   def appendQuoted(s: String): String = sbToString(appendQuoted(s, _))
@@ -283,8 +283,8 @@ object Utility extends AnyRef with parsing.TokenTests {
    * Appends &quot;s&quot; if string `s` does not contain &quot;,
    * &apos;s&apos; otherwise.
    */
-  def appendQuoted(s: String, sb: StringBuilder) = {
-    val ch = if (s contains '"') '\'' else '"'
+  def appendQuoted(s: String, sb: StringBuilder): StringBuilder = {
+    val ch: Char = if (s contains '"') '\'' else '"'
     sb.append(ch).append(s).append(ch)
   }
 
@@ -304,7 +304,7 @@ object Utility extends AnyRef with parsing.TokenTests {
   def getName(s: String, index: Int): String = {
     if (index >= s.length) null
     else {
-      val xs = s drop index
+      val xs: String = s drop index
       if (xs.nonEmpty && isNameStart(xs.head)) xs takeWhile isNameChar
       else ""
     }
@@ -315,13 +315,13 @@ object Utility extends AnyRef with parsing.TokenTests {
    * error message if it isn't.
    */
   def checkAttributeValue(value: String): String = {
-    var i = 0
+    var i: Int = 0
     while (i < value.length) {
       value.charAt(i) match {
         case '<' =>
           return "< not allowed in attribute value"
         case '&' =>
-          val n = getName(value, i + 1)
+          val n: String = getName(value, i + 1)
           if (n eq null)
             return "malformed entity reference in attribute value [" + value + "]"
           i = i + n.length + 1
@@ -335,19 +335,19 @@ object Utility extends AnyRef with parsing.TokenTests {
   }
 
   def parseAttributeValue(value: String): Seq[Node] = {
-    val sb = new StringBuilder
+    val sb: StringBuilder = new StringBuilder
     var rfb: StringBuilder = null
-    val nb = new NodeBuffer()
+    val nb: NodeBuffer = new NodeBuffer()
 
-    val it = value.iterator
+    val it: Iterator[Char] = value.iterator
     while (it.hasNext) {
-      var c = it.next()
+      var c: Char = it.next()
       // entity! flush buffer into text node
       if (c == '&') {
         c = it.next()
         if (c == '#') {
           c = it.next()
-          val theChar = parseCharRef ({ () => c }, { () => c = it.next() }, { s => throw new RuntimeException(s) }, { s => throw new RuntimeException(s) })
+          val theChar: String = parseCharRef ({ () => c }, { () => c = it.next() }, { s => throw new RuntimeException(s) }, { s => throw new RuntimeException(s) })
           sb.append(theChar)
         } else {
           if (rfb eq null) rfb = new StringBuilder()
@@ -357,7 +357,7 @@ object Utility extends AnyRef with parsing.TokenTests {
             rfb.append(c)
             c = it.next()
           }
-          val ref = rfb.toString()
+          val ref: String = rfb.toString()
           rfb.clear()
           unescape(ref, sb) match {
             case null =>
@@ -372,7 +372,7 @@ object Utility extends AnyRef with parsing.TokenTests {
       } else sb append c
     }
     if (sb.nonEmpty) { // flush buffer
-      val x = Text(sb.toString())
+      val x: Text = Text(sb.toString())
       if (nb.isEmpty)
         return x
       else
@@ -389,9 +389,9 @@ object Utility extends AnyRef with parsing.TokenTests {
    * See [66]
    */
   def parseCharRef(ch: () => Char, nextch: () => Unit, reportSyntaxError: String => Unit, reportTruncatedError: String => Unit): String = {
-    val hex = (ch() == 'x') && { nextch(); true }
-    val base = if (hex) 16 else 10
-    var i = 0
+    val hex: Boolean = (ch() == 'x') && { nextch(); true }
+    val base: Int = if (hex) 16 else 10
+    var i: Int = 0
     while (ch() != ';') {
       ch() match {
         case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>

--- a/shared/src/main/scala/scala/xml/XML.scala
+++ b/shared/src/main/scala/scala/xml/XML.scala
@@ -14,20 +14,19 @@ package scala
 package xml
 
 import factory.XMLLoader
-import java.io.{File, FileDescriptor, FileInputStream, FileOutputStream}
-import java.io.{InputStream, Reader, StringReader}
+import java.io.{File, FileDescriptor, FileInputStream, FileOutputStream, InputStream, Reader, StringReader, Writer}
 import java.nio.channels.Channels
 import scala.util.control.Exception.ultimately
 
 object Source {
-  def fromFile(file: File) = new InputSource(new FileInputStream(file))
-  def fromFile(fd: FileDescriptor) = new InputSource(new FileInputStream(fd))
-  def fromFile(name: String) = new InputSource(new FileInputStream(name))
+  def fromFile(file: File): InputSource = new InputSource(new FileInputStream(file))
+  def fromFile(fd: FileDescriptor): InputSource = new InputSource(new FileInputStream(fd))
+  def fromFile(name: String): InputSource = new InputSource(new FileInputStream(name))
 
-  def fromInputStream(is: InputStream) = new InputSource(is)
-  def fromReader(reader: Reader) = new InputSource(reader)
-  def fromSysId(sysID: String) = new InputSource(sysID)
-  def fromString(string: String) = fromReader(new StringReader(string))
+  def fromInputStream(is: InputStream): InputSource = new InputSource(is)
+  def fromReader(reader: Reader): InputSource = new InputSource(reader)
+  def fromSysId(sysID: String): InputSource = new InputSource(sysID)
+  def fromString(string: String): InputSource = fromReader(new StringReader(string))
 }
 
 /**
@@ -38,18 +37,18 @@ object MinimizeMode extends Enumeration {
    * Minimize empty tags if they were originally empty when parsed, or if they were constructed
    *  with [[scala.xml.Elem]]`#minimizeEmpty` == true
    */
-  val Default = Value
+  val Default: Value = Value
 
   /**
    * Always minimize empty tags.  Note that this may be problematic for XHTML, in which
    * case [[scala.xml.Xhtml]]`#toXhtml` should be used instead.
    */
-  val Always = Value
+  val Always: Value = Value
 
   /**
    * Never minimize empty tags.
    */
-  val Never = Value
+  val Never: Value = Value
 }
 
 /**
@@ -60,13 +59,13 @@ object MinimizeMode extends Enumeration {
  *  @author  Burak Emir
  */
 object XML extends XMLLoader[Elem] {
-  val xml = "xml"
-  val xmlns = "xmlns"
-  val namespace = "http://www.w3.org/XML/1998/namespace"
-  val preserve = "preserve"
-  val space = "space"
-  val lang = "lang"
-  val encoding = "UTF-8"
+  val xml: String = "xml"
+  val xmlns: String = "xmlns"
+  val namespace: String = "http://www.w3.org/XML/1998/namespace"
+  val preserve: String = "preserve"
+  val space: String = "space"
+  val lang: String = "lang"
+  val encoding: String = "UTF-8"
 
   /** Returns an XMLLoader whose load* methods will use the supplied SAXParser. */
   def withSAXParser(p: SAXParser): XMLLoader[Elem] =
@@ -97,8 +96,8 @@ object XML extends XMLLoader[Elem] {
     xmlDecl: Boolean = false,
     doctype: dtd.DocType = null): Unit =
     {
-      val fos = new FileOutputStream(filename)
-      val w = Channels.newWriter(fos.getChannel, enc)
+      val fos: FileOutputStream = new FileOutputStream(filename)
+      val w: Writer = Channels.newWriter(fos.getChannel, enc)
 
       ultimately(w.close())(
         write(w, node, enc, xmlDecl, doctype)

--- a/shared/src/main/scala/scala/xml/Xhtml.scala
+++ b/shared/src/main/scala/scala/xml/Xhtml.scala
@@ -39,7 +39,7 @@ object Xhtml {
    * Elements which we believe are safe to minimize if minimizeTags is true.
    *  See http://www.w3.org/TR/xhtml1/guidelines.html#C_3
    */
-  private val minimizableElements =
+  private val minimizableElements: List[String] =
     List("base", "meta", "link", "hr", "br", "param", "img", "area", "input", "col")
 
   def toXhtml(
@@ -51,11 +51,11 @@ object Xhtml {
     preserveWhitespace: Boolean = false,
     minimizeTags: Boolean = true): Unit =
     {
-      def decode(er: EntityRef) = XhtmlEntities.entMap.get(er.entityName) match {
+      def decode(er: EntityRef): StringBuilder = XhtmlEntities.entMap.get(er.entityName) match {
         case Some(chr) if chr.toInt >= 128 => sb.append(chr)
         case _                             => er.buildString(sb)
       }
-      def shortForm =
+      def shortForm: Boolean =
         minimizeTags &&
           (x.child == null || x.child.isEmpty) &&
           (minimizableElements contains x.label)
@@ -99,7 +99,7 @@ object Xhtml {
       if (children.isEmpty)
         return
 
-      val doSpaces = children forall isAtomAndNotText // interleave spaces
+      val doSpaces: Boolean = children forall isAtomAndNotText // interleave spaces
       for (c <- children.take(children.length - 1)) {
         toXhtml(c, pscope, sb, stripComments, decodeEntities, preserveWhitespace, minimizeTags)
         if (doSpaces) sb append ' '

--- a/shared/src/main/scala/scala/xml/dtd/ContentModel.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ContentModel.scala
@@ -38,11 +38,11 @@ object ContentModel extends WordExp {
   }
 
   case class ElemName(name: String) extends Label {
-    override def toString = """ElemName("%s")""" format name
+    override def toString: String = """ElemName("%s")""" format name
   }
 
-  def isMixed(cm: ContentModel) = cond(cm) { case _: MIXED => true }
-  def containsText(cm: ContentModel) = (cm == PCDATA) || isMixed(cm)
+  def isMixed(cm: ContentModel): Boolean = cond(cm) { case _: MIXED => true }
+  def containsText(cm: ContentModel): Boolean = (cm == PCDATA) || isMixed(cm)
 
   def getLabels(r: RegExp): Set[String] = {
     def traverse(r: RegExp): Set[String] = r match { // !!! check for match translation problem
@@ -105,11 +105,11 @@ case object ANY extends ContentModel {
   override def buildString(sb: StringBuilder): StringBuilder = sb.append("ANY")
 }
 sealed abstract class DFAContentModel extends ContentModel {
-  import ContentModel.{ ElemName, Translator }
+  import ContentModel.{ElemName, Translator}
   def r: RegExp
 
   lazy val dfa: DetWordAutom[ElemName] = {
-    val nfa = Translator.automatonFrom(r, 1)
+    val nfa: NondetWordAutom[ElemName] = Translator.automatonFrom(r, 1)
     new SubsetConstruction(nfa).determinize
   }
 }
@@ -118,7 +118,7 @@ case class MIXED(override val r: RegExp) extends DFAContentModel {
   import ContentModel.Alt
 
   override def buildString(sb: StringBuilder): StringBuilder = {
-    val newAlt = r match { case Alt(rs@_*) => Alt(rs drop 1: _*) }
+    val newAlt: Alt = r match { case Alt(rs@_*) => Alt(rs drop 1: _*) }
 
     sb append "(#PCDATA|"
     ContentModel.buildString(newAlt: RegExp, sb)

--- a/shared/src/main/scala/scala/xml/dtd/DTD.scala
+++ b/shared/src/main/scala/scala/xml/dtd/DTD.scala
@@ -23,7 +23,7 @@ import scala.collection.Seq
  *  @author Burak Emir
  */
 abstract class DTD {
-  var externalID: ExternalID = null
+  var externalID: ExternalID = _
   var decls: List[Decl] = Nil
   def notations: Seq[NotationDecl] = Nil
   def unparsedEntities: Seq[EntityDecl] = Nil
@@ -32,7 +32,7 @@ abstract class DTD {
   var attr: mutable.Map[String, AttListDecl] = new mutable.HashMap[String, AttListDecl]()
   var ent: mutable.Map[String, EntityDecl] = new mutable.HashMap[String, EntityDecl]()
 
-  override def toString =
+  override def toString: String =
     "DTD [\n%s%s]".format(
       Option(externalID).getOrElse(""),
       decls.mkString("", "\n", "\n")

--- a/shared/src/main/scala/scala/xml/dtd/Decl.scala
+++ b/shared/src/main/scala/scala/xml/dtd/Decl.scala
@@ -109,14 +109,14 @@ sealed abstract class EntityDef {
 
 case class IntDef(value: String) extends EntityDef {
   private def validateValue(): Unit = {
-    var tmp = value
-    var ix = tmp indexOf '%'
+    var tmp: String = value
+    var ix: Int = tmp indexOf '%'
     while (ix != -1) {
-      val iz = tmp.indexOf(';', ix)
+      val iz: Int = tmp.indexOf(';', ix)
       if (iz == -1 && iz == ix + 1)
         throw new IllegalArgumentException("no % allowed in entity value, except for parameter-entity-references")
       else {
-        val n = tmp.substring(ix, iz)
+        val n: String = tmp.substring(ix, iz)
 
         if (!Utility.isName(n))
           throw new IllegalArgumentException("internal entity def: \"" + n + "\" must be an XML Name")
@@ -156,12 +156,12 @@ sealed abstract class DefaultDecl {
 
 case object REQUIRED extends DefaultDecl {
   override def toString(): String = "#REQUIRED"
-  override def buildString(sb: StringBuilder) = sb append "#REQUIRED"
+  override def buildString(sb: StringBuilder): StringBuilder = sb append "#REQUIRED"
 }
 
 case object IMPLIED extends DefaultDecl {
   override def toString(): String = "#IMPLIED"
-  override def buildString(sb: StringBuilder) = sb append "#IMPLIED"
+  override def buildString(sb: StringBuilder): StringBuilder = sb append "#IMPLIED"
 }
 
 case class DEFAULT(fixed: Boolean, attValue: String) extends DefaultDecl {

--- a/shared/src/main/scala/scala/xml/dtd/DocType.scala
+++ b/shared/src/main/scala/scala/xml/dtd/DocType.scala
@@ -30,8 +30,8 @@ case class DocType(name: String, extID: ExternalID, intSubset: Seq[dtd.Decl]) {
     throw new IllegalArgumentException(name + " must be an XML Name")
 
   /** returns "&lt;!DOCTYPE + name + extID? + ("["+intSubSet+"]")? >" */
-  final override def toString = {
-    def intString =
+  final override def toString: String = {
+    def intString: String =
       if (intSubset.isEmpty) ""
       else intSubset.mkString("[", "", "]")
 

--- a/shared/src/main/scala/scala/xml/dtd/ExternalID.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ExternalID.scala
@@ -20,16 +20,16 @@ package dtd
  *  @author Burak Emir
  */
 sealed abstract class ExternalID extends parsing.TokenTests {
-  def quoted(s: String) = {
-    val c = if (s contains '"') '\'' else '"'
+  def quoted(s: String): String = {
+    val c: Char = if (s contains '"') '\'' else '"'
     c.toString + s + c
   }
 
   // public != null: PUBLIC " " publicLiteral " " [systemLiteral]
   // public == null: SYSTEM " " systemLiteral
   override def toString: String = {
-    lazy val quotedSystemLiteral = quoted(systemId)
-    lazy val quotedPublicLiteral = quoted(publicId)
+    lazy val quotedSystemLiteral: String = quoted(systemId)
+    lazy val quotedPublicLiteral: String = quoted(publicId)
 
     if (publicId == null) "SYSTEM " + quotedSystemLiteral
     else "PUBLIC " + quotedPublicLiteral +
@@ -49,7 +49,7 @@ sealed abstract class ExternalID extends parsing.TokenTests {
  *  @param  systemId the system identifier literal
  */
 case class SystemID(override val systemId: String) extends ExternalID {
-  override val publicId = null
+  override val publicId: scala.Null = null
 
   if (!checkSysID(systemId))
     throw new IllegalArgumentException("can't use both \" and ' in systemId")
@@ -70,13 +70,13 @@ case class PublicID(override val publicId: String, override val systemId: String
     throw new IllegalArgumentException("can't use both \" and ' in systemId")
 
   /** the constant "#PI" */
-  def label = "#PI"
+  def label: String = "#PI"
 
   /** always empty */
-  def attribute = Node.NoAttributes
+  def attribute: MetaData = Node.NoAttributes
 
   /** always empty */
-  def child = Nil
+  def child: Nil.type = Nil
 }
 
 /**
@@ -85,8 +85,8 @@ case class PublicID(override val publicId: String, override val systemId: String
  *  @author Michael Bayne
  */
 object NoExternalID extends ExternalID {
-  override val publicId = null
-  override val systemId = null
+  override val publicId /* TODO type annotation */ = null
+  override val systemId /* TODO type annotation */ = null
 
-  override def toString = ""
+  override def toString: String = ""
 }

--- a/shared/src/main/scala/scala/xml/dtd/Tokens.scala
+++ b/shared/src/main/scala/scala/xml/dtd/Tokens.scala
@@ -18,17 +18,17 @@ class Tokens {
 
   // Tokens
 
-  final val TOKEN_PCDATA = 0
-  final val NAME = 1
-  final val LPAREN = 3
-  final val RPAREN = 4
-  final val COMMA = 5
-  final val STAR = 6
-  final val PLUS = 7
-  final val OPT = 8
-  final val CHOICE = 9
-  final val END = 10
-  final val S = 13
+  final val TOKEN_PCDATA: Int = 0
+  final val NAME: Int = 1
+  final val LPAREN: Int = 3
+  final val RPAREN: Int = 4
+  final val COMMA: Int = 5
+  final val STAR: Int = 6
+  final val PLUS: Int = 7
+  final val OPT: Int = 8
+  final val CHOICE: Int = 9
+  final val END: Int = 10
+  final val S: Int = 13
 
   final def token2string(i: Int): String = i match {
     case 0  => "#PCDATA"

--- a/shared/src/main/scala/scala/xml/dtd/ValidationException.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ValidationException.scala
@@ -20,26 +20,26 @@ case class ValidationException(e: String) extends Exception(e)
  *  @author Burak Emir
  */
 object MakeValidationException {
-  def fromFixedAttribute(k: String, value: String, actual: String) =
+  def fromFixedAttribute(k: String, value: String, actual: String): ValidationException =
     ValidationException("value of attribute " + k + " FIXED to \"" +
       value + "\", but document tries \"" + actual + "\"")
 
-  def fromNonEmptyElement() =
+  def fromNonEmptyElement(): ValidationException =
     ValidationException("element should be *empty*")
 
-  def fromUndefinedElement(label: String) =
+  def fromUndefinedElement(label: String): ValidationException =
     ValidationException("element \"" + label + "\" not allowed here")
 
-  def fromUndefinedAttribute(key: String) =
+  def fromUndefinedAttribute(key: String): ValidationException =
     ValidationException("attribute " + key + " not allowed here")
 
-  def fromMissingAttribute(allKeys: Set[String]) = {
-    val sb = new StringBuilder("missing value for REQUIRED attribute")
+  def fromMissingAttribute(allKeys: Set[String]): ValidationException = {
+    val sb: StringBuilder = new StringBuilder("missing value for REQUIRED attribute")
     if (allKeys.size > 1) sb.append('s')
     allKeys foreach (k => sb append "'%s'".format(k))
     ValidationException(sb.toString())
   }
 
-  def fromMissingAttribute(key: String, tpe: String) =
+  def fromMissingAttribute(key: String, tpe: String): ValidationException =
     ValidationException("missing value for REQUIRED attribute %s of type %s".format(key, tpe))
 }

--- a/shared/src/main/scala/scala/xml/dtd/impl/Base.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/Base.scala
@@ -29,41 +29,41 @@ private[dtd] abstract class Base {
 
   object Alt {
     /** `Alt( R,R,R* )`. */
-    def apply(rs: _regexpT*) =
+    def apply(rs: _regexpT*): Alt =
       if (rs.size < 2) throw new SyntaxError("need at least 2 branches in Alt")
       else new Alt(rs: _*)
     // Can't enforce that statically without changing the interface
     // def apply(r1: _regexpT, r2: _regexpT, rs: _regexpT*) = new Alt(Seq(r1, r2) ++ rs: _*)
-    def unapplySeq(x: Alt) = Some(x.rs)
+    def unapplySeq(x: Alt): Some[Seq[_regexpT]] = Some(x.rs)
   }
 
   class Alt private (val rs: _regexpT*) extends RegExp {
-    final override val isNullable = rs exists (_.isNullable)
+    final override val isNullable: Boolean = rs exists (_.isNullable)
   }
 
   object Sequ {
     /** Sequ( R,R* ) */
-    def apply(rs: _regexpT*) = if (rs.isEmpty) Eps else new Sequ(rs: _*)
-    def unapplySeq(x: Sequ) = Some(x.rs)
+    def apply(rs: _regexpT*): RegExp = if (rs.isEmpty) Eps else new Sequ(rs: _*)
+    def unapplySeq(x: Sequ): Some[Seq[_regexpT]] = Some(x.rs)
   }
 
   class Sequ private (val rs: _regexpT*) extends RegExp {
-    final override val isNullable = rs forall (_.isNullable)
+    final override val isNullable: Boolean = rs forall (_.isNullable)
   }
 
   case class Star(r: _regexpT) extends RegExp {
-    final override lazy val isNullable = true
+    final override lazy val isNullable: Boolean = true
   }
 
   // The empty Sequ.
   case object Eps extends RegExp {
-    final override lazy val isNullable = true
-    override def toString = "Eps"
+    final override lazy val isNullable: Boolean = true
+    override def toString: String = "Eps"
   }
 
   /** this class can be used to add meta information to regexps. */
   class Meta(r1: _regexpT) extends RegExp {
-    final override val isNullable = r1.isNullable
-    def r = r1
+    final override val isNullable: Boolean = r1.isNullable
+    def r: _regexpT = r1
   }
 }

--- a/shared/src/main/scala/scala/xml/dtd/impl/BaseBerrySethi.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/BaseBerrySethi.scala
@@ -28,7 +28,7 @@ private[dtd] abstract class BaseBerrySethi {
   val lang: Base
   import lang.{ Alt, Eps, Meta, RegExp, Sequ, Star }
 
-  protected var pos = 0
+  protected var pos: Int = 0
 
   // results which hold all info for the NondetWordAutomaton
   protected var follow: mutable.HashMap[Int, Set[Int]] = _
@@ -41,12 +41,12 @@ private[dtd] abstract class BaseBerrySethi {
 
   final val emptySet: Set[Int] = Set()
 
-  private def doComp(r: RegExp, compFunction: RegExp => Set[Int]) = r match {
+  private def doComp(r: RegExp, compFunction: RegExp => Set[Int]): Set[Int] = r match {
     case x: Alt  => (x.rs map compFirst).foldLeft(emptySet)(_ ++ _)
     case Eps     => emptySet
     case x: Meta => compFunction(x.r)
     case x: Sequ =>
-      val (l1, l2) = x.rs span (_.isNullable)
+      val (l1: Seq[lang._regexpT], l2: Seq[lang._regexpT]) = x.rs span (_.isNullable)
       ((l1 ++ (l2 take 1)) map compFunction).foldLeft(emptySet)(_ ++ _)
     case Star(t) => compFunction(t)
     case _       => throw new IllegalArgumentException("unexpected pattern " + r.getClass)
@@ -67,7 +67,7 @@ private[dtd] abstract class BaseBerrySethi {
     follow(0) =
       if (rs.isEmpty) emptySet
       else rs.foldRight(Set(pos))((p, fol) => {
-        val first = compFollow1(fol, p)
+        val first: Set[Int] = compFollow1(fol, p)
 
         if (p.isNullable) fol ++ first
         else first
@@ -85,7 +85,7 @@ private[dtd] abstract class BaseBerrySethi {
     case x: Star => compFollow1(fol1 ++ compFirst(x.r), x.r)
     case x: Sequ =>
       x.rs.foldRight(fol1) { (p, fol) =>
-        val first = compFollow1(fol, p)
+        val first: Set[Int] = compFollow1(fol, p)
 
         if (p.isNullable) fol ++ first
         else first

--- a/shared/src/main/scala/scala/xml/dtd/impl/DetWordAutom.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/DetWordAutom.scala
@@ -30,15 +30,15 @@ private[dtd] abstract class DetWordAutom[T <: AnyRef] {
   val delta: Array[scala.collection.mutable.Map[T, Int]]
   val default: Array[Int]
 
-  def isFinal(q: Int) = finals(q) != 0
-  def isSink(q: Int) = delta(q).isEmpty && default(q) == q
-  def next(q: Int, label: T) = delta(q).getOrElse(label, default(q))
+  def isFinal(q: Int): Boolean = finals(q) != 0
+  def isSink(q: Int): Boolean = delta(q).isEmpty && default(q) == q
+  def next(q: Int, label: T): Int = delta(q).getOrElse(label, default(q))
 
-  override def toString = {
-    val sb = new StringBuilder("[DetWordAutom  nstates=")
+  override def toString: String = {
+    val sb: StringBuilder = new StringBuilder("[DetWordAutom  nstates=")
     sb.append(nstates)
     sb.append(" finals=")
-    val map = finals.zipWithIndex.map(_.swap).toMap
+    val map: Map[Int, Int] = finals.zipWithIndex.map(_.swap).toMap
     sb.append(map.toString())
     sb.append(" delta=\n")
 

--- a/shared/src/main/scala/scala/xml/dtd/impl/Inclusion.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/Inclusion.scala
@@ -29,30 +29,30 @@ private[dtd] trait Inclusion[A <: AnyRef] {
   /**
    * Returns true if `dfa1` is included in `dfa2`.
    */
-  def inclusion(dfa1: DetWordAutom[A], dfa2: DetWordAutom[A]) = {
+  def inclusion(dfa1: DetWordAutom[A], dfa2: DetWordAutom[A]): Boolean = {
 
-    def encode(q1: Int, q2: Int) = 1 + q1 + q2 * dfa1.nstates
-    def decode2(c: Int) = (c - 1) / dfa1.nstates //integer division
-    def decode1(c: Int) = (c - 1) % dfa1.nstates
+    def encode(q1: Int, q2: Int): Int = 1 + q1 + q2 * dfa1.nstates
+    def decode2(c: Int): Int = (c - 1) / dfa1.nstates //integer division
+    def decode1(c: Int): Int = (c - 1) % dfa1.nstates
 
-    var q1 = 0 //dfa1.initstate; // == 0
-    var q2 = 0 //dfa2.initstate; // == 0
+    var q1: Int = 0 //dfa1.initstate; // == 0
+    var q2: Int = 0 //dfa2.initstate; // == 0
 
-    val max = 1 + dfa1.nstates * dfa2.nstates
-    val mark = new Array[Int](max)
+    val max: Int = 1 + dfa1.nstates * dfa2.nstates
+    val mark: Array[Int] = new Array[Int](max)
 
-    var result = true
-    var current = encode(q1, q2)
-    var last = current
+    var result: Boolean = true
+    var current: Int = encode(q1, q2)
+    var last: Int = current
     mark(last) = max // mark (q1,q2)
     while (current != 0 && result) {
       //Console.println("current = [["+q1+" "+q2+"]] = "+current);
       for (letter <- labels) {
-        val r1 = dfa1.next(q1, letter)
-        val r2 = dfa2.next(q2, letter)
+        val r1: Int = dfa1.next(q1, letter)
+        val r2: Int = dfa2.next(q2, letter)
         if (dfa1.isFinal(r1) && !dfa2.isFinal(r2))
           result = false
-        val test = encode(r1, r2)
+        val test: Int = encode(r1, r2)
         //Console.println("test = [["+r1+" "+r2+"]] = "+test);
         if (mark(test) == 0) {
           mark(last) = test
@@ -60,7 +60,7 @@ private[dtd] trait Inclusion[A <: AnyRef] {
           last = test
         }
       }
-      val ncurrent = mark(current)
+      val ncurrent: Int = mark(current)
       if (ncurrent != max) {
         q1 = decode1(ncurrent)
         q2 = decode2(ncurrent)

--- a/shared/src/main/scala/scala/xml/dtd/impl/NondetWordAutom.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/NondetWordAutom.scala
@@ -13,7 +13,7 @@
 package scala
 package xml.dtd.impl
 
-import scala.collection.{ immutable, mutable }
+import scala.collection.{immutable, mutable}
 import scala.collection.Seq
 
 /**
@@ -33,16 +33,16 @@ private[dtd] abstract class NondetWordAutom[T <: AnyRef] {
   val default: Array[immutable.BitSet]
 
   /** @return true if the state is final */
-  final def isFinal(state: Int) = finals(state) > 0
+  final def isFinal(state: Int): Boolean = finals(state) > 0
 
   /** @return tag of final state */
-  final def finalTag(state: Int) = finals(state)
+  final def finalTag(state: Int): Int = finals(state)
 
   /** @return true if the set of states contains at least one final state */
   final def containsFinal(Q: immutable.BitSet): Boolean = Q exists isFinal
 
   /** @return true if there are no accepting states */
-  final def isEmpty = (0 until nstates) forall (x => !isFinal(x))
+  final def isEmpty: Boolean = (0 until nstates) forall (x => !isFinal(x))
 
   /** @return a immutable.BitSet with the next states for given state and label */
   def next(q: Int, a: T): immutable.BitSet = delta(q).getOrElse(a, default(q))
@@ -51,14 +51,14 @@ private[dtd] abstract class NondetWordAutom[T <: AnyRef] {
   def next(Q: immutable.BitSet, a: T): immutable.BitSet = next(Q, next(_, a))
   def nextDefault(Q: immutable.BitSet): immutable.BitSet = next(Q, default)
 
-  private def next(Q: immutable.BitSet, f: (Int) => immutable.BitSet): immutable.BitSet =
+  private def next(Q: immutable.BitSet, f: Int => immutable.BitSet): immutable.BitSet =
     Q.toSet.map(f).foldLeft(immutable.BitSet.empty)(_ ++ _)
 
-  private def finalStates = 0 until nstates filter isFinal
-  override def toString = {
+  private def finalStates: immutable.Seq[Int] = 0 until nstates filter isFinal
+  override def toString: String = {
 
-    val finalString = Map(finalStates map (j => j -> finals(j)): _*).toString
-    val deltaString = (0 until nstates)
+    val finalString: String = Map(finalStates map (j => j -> finals(j)): _*).toString
+    val deltaString: String = (0 until nstates)
       .map(i => "   %d->%s\n    _>%s\n".format(i, delta(i), default(i))).mkString
 
     "[NondetWordAutom  nstates=%d  finals=%s  delta=\n%s".format(nstates, finalString, deltaString)

--- a/shared/src/main/scala/scala/xml/dtd/impl/SubsetConstruction.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/SubsetConstruction.scala
@@ -13,30 +13,31 @@
 package scala
 package xml.dtd.impl
 
-import scala.collection.{ mutable, immutable }
+import scala.collection.{immutable, mutable}
 
 // TODO: still used in ContentModel -- @deprecated("This class will be removed", "2.10.0")
 private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) {
   import nfa.labels
 
-  def selectTag(Q: immutable.BitSet, finals: Array[Int]) =
+  def selectTag(Q: immutable.BitSet, finals: Array[Int]): Int =
     (Q map finals filter (_ > 0)).min
 
   def determinize: DetWordAutom[T] = {
     // for assigning numbers to bitsets
-    val indexMap = mutable.Map[immutable.BitSet, Int]()
-    val invIndexMap = mutable.Map[Int, immutable.BitSet]()
-    var ix = 0
+    val indexMap: mutable.Map[immutable.BitSet, Int] = mutable.Map[immutable.BitSet, Int]()
+    val invIndexMap: mutable.Map[Int, immutable.BitSet] = mutable.Map[Int, immutable.BitSet]()
+    var ix: Int = 0
 
     // we compute the dfa with states = bitsets
-    val q0 = immutable.BitSet(0) // the set { 0 }
-    val sink = immutable.BitSet.empty // the set { }
+    val q0: immutable.BitSet = immutable.BitSet(0) // the set { 0 }
+    val sink: immutable.BitSet = immutable.BitSet.empty // the set { }
 
-    var states = Set(q0, sink) // initial set of sets
-    val delta = new mutable.HashMap[immutable.BitSet, mutable.HashMap[T, immutable.BitSet]]
-    val deftrans = mutable.Map(q0 -> sink, sink -> sink) // initial transitions
+    var states: Set[immutable.BitSet] = Set(q0, sink) // initial set of sets
+    val delta: mutable.HashMap[immutable.BitSet, mutable.HashMap[T, immutable.BitSet]] =
+      new mutable.HashMap[immutable.BitSet, mutable.HashMap[T, immutable.BitSet]]
+    val deftrans: mutable.Map[immutable.BitSet, immutable.BitSet] = mutable.Map(q0 -> sink, sink -> sink) // initial transitions
     val finals: mutable.Map[immutable.BitSet, Int] = mutable.Map()
-    var rest = immutable.List.empty[immutable.BitSet]
+    var rest: immutable.List[immutable.BitSet] = immutable.List.empty[immutable.BitSet]
 
     rest = q0 :: sink :: rest
 
@@ -55,7 +56,7 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
     addFinal(q0) // initial state may also be a final state
 
     while (rest.nonEmpty) {
-      val P = rest.head
+      val P: immutable.BitSet = rest.head
       rest = rest.tail
       // assign a number to this bitset
       indexMap(P) = ix
@@ -63,36 +64,36 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
       ix += 1
 
       // make transition map
-      val Pdelta = new mutable.HashMap[T, immutable.BitSet]
+      val Pdelta: mutable.HashMap[T, immutable.BitSet] = new mutable.HashMap[T, immutable.BitSet]
       delta.update(P, Pdelta)
 
       labels foreach { label =>
-        val Q = nfa.next(P, label)
+        val Q: immutable.BitSet = nfa.next(P, label)
         Pdelta.update(label, Q)
         add(Q)
       }
 
       // collect default transitions
-      val Pdef = nfa nextDefault P
+      val Pdef: immutable.BitSet = nfa nextDefault P
       deftrans(P) = Pdef
       add(Pdef)
     }
 
     // create DetWordAutom, using indices instead of sets
-    val nstatesR = states.size
-    val deltaR = new Array[mutable.Map[T, Int]](nstatesR)
-    val defaultR = new Array[Int](nstatesR)
-    val finalsR = new Array[Int](nstatesR)
+    val nstatesR: Int = states.size
+    val deltaR: Array[mutable.Map[T, Int]] = new Array[mutable.Map[T, Int]](nstatesR)
+    val defaultR: Array[Int] = new Array[Int](nstatesR)
+    val finalsR: Array[Int] = new Array[Int](nstatesR)
 
     for (Q <- states) {
-      val q = indexMap(Q)
-      val trans = delta(Q)
-      val transDef = deftrans(Q)
-      val qDef = indexMap(transDef)
-      val ntrans = new mutable.HashMap[T, Int]()
+      val q: Int = indexMap(Q)
+      val trans: mutable.Map[T, immutable.BitSet] = delta(Q)
+      val transDef: immutable.BitSet = deftrans(Q)
+      val qDef: Int = indexMap(transDef)
+      val ntrans: mutable.Map[T, Int] = new mutable.HashMap[T, Int]()
 
       for ((label, value) <- trans) {
-        val p = indexMap(value)
+        val p: Int = indexMap(value)
         if (p != qDef)
           ntrans.update(label, p)
       }
@@ -104,10 +105,10 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
     finals foreach { case (k, v) => finalsR(indexMap(k)) = v }
 
     new DetWordAutom[T] {
-      override val nstates = nstatesR
-      override val delta = deltaR
-      override val default = defaultR
-      override val finals = finalsR
+      override val nstates: Int = nstatesR
+      override val delta: Array[mutable.Map[T, Int]] = deltaR
+      override val default: Array[Int] = defaultR
+      override val finals: Array[Int] = finalsR
     }
   }
 }

--- a/shared/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
@@ -13,7 +13,7 @@
 package scala
 package xml.dtd.impl
 
-import scala.collection.{ immutable, mutable }
+import scala.collection.{immutable, mutable}
 import scala.collection.Seq
 
 /**
@@ -98,7 +98,7 @@ private[dtd] abstract class WordBerrySethi extends BaseBerrySethi {
   }
 
   protected def makeTransition(src: Int, dest: Int, label: _labelT): Unit = {
-    val q = deltaq(src)
+    val q: mutable.Map[lang._labelT, List[Int]] = deltaq(src)
     q.update(label, dest :: q.getOrElse(label, Nil))
   }
 
@@ -148,22 +148,22 @@ private[dtd] abstract class WordBerrySethi extends BaseBerrySethi {
         if (x.isNullable) // initial state is final
           finals = finals.updated(0, finalTag)
 
-        val delta1 = deltaq.zipWithIndex.map(_.swap).toMap
-        val finalsArr = (0 until pos map (k => finals.getOrElse(k, 0))).toArray // 0 == not final
+        val delta1: immutable.Map[Int, mutable.HashMap[lang._labelT, List[Int]]] = deltaq.zipWithIndex.map(_.swap).toMap
+        val finalsArr: Array[Int] = (0 until pos map (k => finals.getOrElse(k, 0))).toArray // 0 == not final
 
         val deltaArr: Array[mutable.Map[_labelT, immutable.BitSet]] =
           (0 until pos map { x =>
             mutable.HashMap(delta1(x).toSeq map { case (k, v) => k -> immutable.BitSet(v: _*) }: _*)
           }).toArray
 
-        val defaultArr = (0 until pos map (k => immutable.BitSet(defaultq(k): _*))).toArray
+        val defaultArr: Array[immutable.BitSet] = (0 until pos map (k => immutable.BitSet(defaultq(k): _*))).toArray
 
         new NondetWordAutom[_labelT] {
-          override val nstates = pos
-          override val labels = WordBerrySethi.this.labels.toList
-          override val finals = finalsArr
-          override val delta = deltaArr
-          override val default = defaultArr
+          override val nstates: Int = pos
+          override val labels: Seq[lang._labelT] = WordBerrySethi.this.labels.toList
+          override val finals: Array[Int] = finalsArr
+          override val delta: Array[mutable.Map[lang._labelT, immutable.BitSet]] = deltaArr
+          override val default: Array[immutable.BitSet] = defaultArr
         }
       case z =>
         automatonFrom(Sequ(z.asInstanceOf[this.lang._regexpT]), finalTag)

--- a/shared/src/main/scala/scala/xml/dtd/impl/WordExp.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/WordExp.scala
@@ -49,12 +49,12 @@ private[dtd] abstract class WordExp extends Base {
   type _labelT <: Label
 
   case class Letter(a: _labelT) extends RegExp {
-    final override lazy val isNullable = false
-    var pos = -1
+    final override lazy val isNullable: Boolean = false
+    var pos: Int = -1
   }
 
   case class Wildcard() extends RegExp {
-    final override lazy val isNullable = false
-    var pos = -1
+    final override lazy val isNullable: Boolean = false
+    var pos: Int = -1
   }
 }

--- a/shared/src/main/scala/scala/xml/factory/NodeFactory.scala
+++ b/shared/src/main/scala/scala/xml/factory/NodeFactory.scala
@@ -17,16 +17,16 @@ package factory
 import scala.collection.Seq
 
 trait NodeFactory[A <: Node] {
-  val ignoreComments = false
-  val ignoreProcInstr = false
+  val ignoreComments: Boolean = false
+  val ignoreProcInstr: Boolean = false
 
   /* default behaviour is to use hash-consing */
-  val cache = new scala.collection.mutable.HashMap[Int, List[A]]
+  val cache: scala.collection.mutable.HashMap[Int, List[A]] = new scala.collection.mutable.HashMap[Int, List[A]]
 
   protected def create(pre: String, name: String, attrs: MetaData, scope: NamespaceBinding, children: Seq[Node]): A
 
   protected def construct(hash: Int, old: List[A], pre: String, name: String, attrSeq: MetaData, scope: NamespaceBinding, children: Seq[Node]): A = {
-    val el = create(pre, name, attrSeq, scope, children)
+    val el: A = create(pre, name, attrSeq, scope, children)
     cache.update(hash, el :: old)
     el
   }
@@ -42,8 +42,8 @@ trait NodeFactory[A <: Node] {
       eqElements(n.child, children)
 
   def makeNode(pre: String, name: String, attrSeq: MetaData, scope: NamespaceBinding, children: Seq[Node]): A = {
-    val hash = Utility.hashCode(pre, name, attrSeq.##, scope.##, children)
-    def cons(old: List[A]) = construct(hash, old, pre, name, attrSeq, scope, children)
+    val hash: Int = Utility.hashCode(pre, name, attrSeq.##, scope.##, children)
+    def cons(old: List[A]): A = construct(hash, old, pre, name, attrSeq, scope, children)
 
     cache.get(hash) match {
       case Some(list) => // find structurally equal

--- a/shared/src/main/scala/scala/xml/factory/XMLLoader.scala
+++ b/shared/src/main/scala/scala/xml/factory/XMLLoader.scala
@@ -28,9 +28,9 @@ trait XMLLoader[T <: Node] {
   import scala.xml.Source._
   def adapter: FactoryAdapter = new NoBindingFactoryAdapter()
 
-  private lazy val parserInstance = new ThreadLocal[SAXParser] {
+  private lazy val parserInstance: ThreadLocal[SAXParser] = new ThreadLocal[SAXParser] {
     override def initialValue: SAXParser = {
-      val parser = SAXParserFactory.newInstance()
+      val parser: SAXParserFactory = SAXParserFactory.newInstance()
       parser.setFeature("http://javax.xml.XMLConstants/feature/secure-processing", true)
       parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
       parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)

--- a/shared/src/main/scala/scala/xml/include/CircularIncludeException.scala
+++ b/shared/src/main/scala/scala/xml/include/CircularIncludeException.scala
@@ -25,5 +25,4 @@ class CircularIncludeException(message: String) extends XIncludeException {
    * as its error detail message.
    */
   def this() = this(null)
-
 }

--- a/shared/src/main/scala/scala/xml/include/XIncludeException.scala
+++ b/shared/src/main/scala/scala/xml/include/XIncludeException.scala
@@ -32,7 +32,7 @@ class XIncludeException(message: String) extends Exception(message) {
    */
   def this() = this(null)
 
-  private var rootCause: Throwable = null
+  private var rootCause: Throwable = _
 
   /**
    * When an `IOException`, `MalformedURLException` or other generic
@@ -58,5 +58,4 @@ class XIncludeException(message: String) extends Exception(message) {
    *                     `XIncludeException` to be thrown
    */
   def getRootCause(): Throwable = this.rootCause
-
 }

--- a/shared/src/main/scala/scala/xml/include/sax/EncodingHeuristics.scala
+++ b/shared/src/main/scala/scala/xml/include/sax/EncodingHeuristics.scala
@@ -15,6 +15,7 @@ package xml
 package include.sax
 
 import java.io.InputStream
+import scala.util.matching.Regex
 
 /**
  * `EncodingHeuristics` reads from a stream
@@ -29,13 +30,13 @@ import java.io.InputStream
 object EncodingHeuristics {
   object EncodingNames {
     // UCS-4 isn't yet implemented in java releases anyway...
-    val bigUCS4 = "UCS-4"
-    val littleUCS4 = "UCS-4"
-    val unusualUCS4 = "UCS-4"
-    val bigUTF16 = "UTF-16BE"
-    val littleUTF16 = "UTF-16LE"
-    val utf8 = "UTF-8"
-    val default = utf8
+    val bigUCS4: String = "UCS-4"
+    val littleUCS4: String = "UCS-4"
+    val unusualUCS4: String = "UCS-4"
+    val bigUTF16: String = "UTF-16BE"
+    val littleUTF16: String = "UTF-16LE"
+    val utf8: String = "UTF-8"
+    val default: String = utf8
   }
   import EncodingNames._
 
@@ -50,13 +51,13 @@ object EncodingHeuristics {
    */
   def readEncodingFromStream(in: InputStream): String = {
     var ret: String = null
-    val bytesToRead = 1024 // enough to read most XML encoding declarations
-    def resetAndRet = { in.reset(); ret }
+    val bytesToRead: Int = 1024 // enough to read most XML encoding declarations
+    def resetAndRet: String = { in.reset(); ret }
 
     // This may fail if there are a lot of space characters before the end
     // of the encoding declaration
     in mark bytesToRead
-    val bytes = (in.read, in.read, in.read, in.read)
+    val bytes: (Int, Int, Int, Int) = (in.read, in.read, in.read, in.read)
 
     // first look for byte order mark
     ret = bytes match {
@@ -73,12 +74,12 @@ object EncodingHeuristics {
       return resetAndRet
 
     def readASCIIEncoding: String = {
-      val data = new Array[Byte](bytesToRead - 4)
-      val length = in.read(data, 0, bytesToRead - 4)
+      val data: Array[Byte] = new Array[Byte](bytesToRead - 4)
+      val length: Int = in.read(data, 0, bytesToRead - 4)
 
       // Use Latin-1 (ISO-8859-1) because all byte sequences are legal.
-      val declaration = new String(data, 0, length, "ISO-8859-1")
-      val regexp = """(?m).*?encoding\s*=\s*["'](.+?)['"]""".r
+      val declaration: String = new String(data, 0, length, "ISO-8859-1")
+      val regexp: Regex = """(?m).*?encoding\s*=\s*["'](.+?)['"]""".r
       regexp.findFirstMatchIn(declaration) match {
         case None     => default
         case Some(md) => md.subgroups(0)

--- a/shared/src/main/scala/scala/xml/include/sax/XIncluder.scala
+++ b/shared/src/main/scala/scala/xml/include/sax/XIncluder.scala
@@ -26,9 +26,9 @@ import java.io.{ OutputStream, OutputStreamWriter, IOException }
  */
 class XIncluder(outs: OutputStream, encoding: String) extends ContentHandler with LexicalHandler {
 
-  var out = new OutputStreamWriter(outs, encoding)
+  var out: OutputStreamWriter = new OutputStreamWriter(outs, encoding)
 
-  override def setDocumentLocator(locator: Locator): Unit = {}
+  override def setDocumentLocator(locator: Locator): Unit = ()
 
   override def startDocument(): Unit = {
     try {
@@ -49,18 +49,19 @@ class XIncluder(outs: OutputStream, encoding: String) extends ContentHandler wit
     }
   }
 
-  override def startPrefixMapping(prefix: String, uri: String): Unit = {}
+  override def startPrefixMapping(prefix: String, uri: String): Unit = ()
 
-  override def endPrefixMapping(prefix: String): Unit = {}
+  override def endPrefixMapping(prefix: String): Unit = ()
 
-  override def startElement(namespaceURI: String, localName: String, qualifiedName: String, atts: Attributes) = {
+  override def startElement(namespaceURI: String, localName: String, qualifiedName: String, atts: Attributes): Unit = {
     try {
       out.write("<" + qualifiedName)
-      var i = 0; while (i < atts.getLength) {
+      var i: Int = 0
+      while (i < atts.getLength) {
         out.write(" ")
         out.write(atts.getQName(i))
         out.write("='")
-        val value = atts.getValue(i)
+        val value: String = atts.getValue(i)
         // @todo Need to use character references if the encoding
         // can't support the character
         out.write(scala.xml.Utility.escape(value))
@@ -87,8 +88,9 @@ class XIncluder(outs: OutputStream, encoding: String) extends ContentHandler wit
   // encoding using character references????
   override def characters(ch: Array[Char], start: Int, length: Int): Unit = {
     try {
-      var i = 0; while (i < length) {
-        val c = ch(start + i)
+      var i: Int = 0
+      while (i < length) {
+        val c: Char = ch(start + i)
         if (c == '&') out.write("&amp;")
         else if (c == '<') out.write("&lt;")
         // This next fix is normally not necessary.
@@ -135,7 +137,7 @@ class XIncluder(outs: OutputStream, encoding: String) extends ContentHandler wit
     inDTD = true
     // if this is the source document, output a DOCTYPE declaration
     if (entities.isEmpty) {
-      var id = ""
+      var id: String = ""
       if (publicID != null) id = " PUBLIC \"" + publicID + "\" \"" + systemID + '"'
       else if (systemID != null) id = " SYSTEM \"" + systemID + '"'
       try {
@@ -146,7 +148,7 @@ class XIncluder(outs: OutputStream, encoding: String) extends ContentHandler wit
       }
     }
   }
-  override def endDTD(): Unit = {}
+  override def endDTD(): Unit = ()
 
   override def startEntity(name: String): Unit = {
     entities =  name :: entities
@@ -156,12 +158,12 @@ class XIncluder(outs: OutputStream, encoding: String) extends ContentHandler wit
     entities = entities.tail
   }
 
-  override def startCDATA(): Unit = {}
-  override def endCDATA(): Unit = {}
+  override def startCDATA(): Unit = ()
+  override def endCDATA(): Unit = ()
 
   // Just need this reference so we can ask if a comment is
   // inside an include element or not
-  private var filter: XIncludeFilter = null
+  private var filter: XIncludeFilter = _
 
   def setFilter(filter: XIncludeFilter): Unit = {
     this.filter = filter

--- a/shared/src/main/scala/scala/xml/package.scala
+++ b/shared/src/main/scala/scala/xml/package.scala
@@ -74,7 +74,7 @@ package scala
  * transform XML data with a [[scala.xml.transform.RuleTransformer]].
  */
 package object xml {
-  val XercesClassName = "org.apache.xerces.parsers.SAXParser"
+  val XercesClassName: String = "org.apache.xerces.parsers.SAXParser"
 
   type SAXException = org.xml.sax.SAXException
   type SAXParseException = org.xml.sax.SAXParseException

--- a/shared/src/main/scala/scala/xml/parsing/ConstructingHandler.scala
+++ b/shared/src/main/scala/scala/xml/parsing/ConstructingHandler.scala
@@ -26,10 +26,8 @@ abstract class ConstructingHandler extends MarkupHandler {
            pscope: NamespaceBinding, empty: Boolean, nodes: NodeSeq): NodeSeq =
     Elem(pre, label, attrs, pscope, empty, nodes: _*)
 
-  override def procInstr(pos: Int, target: String, txt: String) =
-    ProcInstr(target, txt)
-
-  override def comment(pos: Int, txt: String) = Comment(txt)
-  override def entityRef(pos: Int, n: String) = EntityRef(n)
-  override def text(pos: Int, txt: String) = Text(txt)
+  override def procInstr(pos: Int, target: String, txt: String): ProcInstr = ProcInstr(target, txt)
+  override def comment(pos: Int, txt: String): Comment = Comment(txt)
+  override def entityRef(pos: Int, n: String): EntityRef = EntityRef(n)
+  override def text(pos: Int, txt: String): Text = Text(txt)
 }

--- a/shared/src/main/scala/scala/xml/parsing/ConstructingParser.scala
+++ b/shared/src/main/scala/scala/xml/parsing/ConstructingParser.scala
@@ -18,10 +18,10 @@ import java.io.File
 import scala.io.Source
 
 object ConstructingParser {
-  def fromFile(inp: File, preserveWS: Boolean) =
+  def fromFile(inp: File, preserveWS: Boolean): ConstructingParser =
     new ConstructingParser(Source.fromFile(inp), preserveWS).initialize
 
-  def fromSource(inp: Source, preserveWS: Boolean) =
+  def fromSource(inp: Source, preserveWS: Boolean): ConstructingParser =
     new ConstructingParser(inp, preserveWS).initialize
 }
 

--- a/shared/src/main/scala/scala/xml/parsing/DefaultMarkupHandler.scala
+++ b/shared/src/main/scala/scala/xml/parsing/DefaultMarkupHandler.scala
@@ -18,14 +18,13 @@ package parsing
 abstract class DefaultMarkupHandler extends MarkupHandler {
 
   override def elem(pos: Int, pre: String, label: String, attrs: MetaData,
-           scope: NamespaceBinding, empty: Boolean, args: NodeSeq) = NodeSeq.Empty
+           scope: NamespaceBinding, empty: Boolean, args: NodeSeq): NodeSeq = NodeSeq.Empty
 
-  override def procInstr(pos: Int, target: String, txt: String) = NodeSeq.Empty
+  override def procInstr(pos: Int, target: String, txt: String): NodeSeq = NodeSeq.Empty
 
   override def comment(pos: Int, comment: String): NodeSeq = NodeSeq.Empty
 
-  override def entityRef(pos: Int, n: String) = NodeSeq.Empty
+  override def entityRef(pos: Int, n: String): NodeSeq = NodeSeq.Empty
 
-  override def text(pos: Int, txt: String) = NodeSeq.Empty
-
+  override def text(pos: Int, txt: String): NodeSeq = NodeSeq.Empty
 }

--- a/shared/src/main/scala/scala/xml/parsing/MarkupHandler.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupHandler.scala
@@ -114,7 +114,7 @@ abstract class MarkupHandler {
     edef match {
       case _: ExtDef if !isValidating => // ignore (cf REC-xml 4.4.1)
       case _ =>
-        val y = f(name, edef)
+        val y: EntityDecl = f(name, edef)
         decls ::= y
         ent.update(name, y)
     }

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
@@ -23,7 +23,7 @@ import Utility.SU
  *  All members should be accessed through those.
  */
 private[scala] trait MarkupParserCommon extends TokenTests {
-  protected def unreachable = truncatedError("Cannot be reached.")
+  protected def unreachable: Nothing = truncatedError("Cannot be reached.")
 
   // type HandleType       // MarkupHandler, SymbolicXMLBuilder
   type InputType // Source, CharArrayReader
@@ -41,7 +41,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
    *  [44] EmptyElemTag ::= '<' Name { S Attribute } [S]
    */
   protected def xTag(pscope: NamespaceType): (String, AttributesType) = {
-    val name = xName
+    val name: String = xName
     xSpaceOpt()
 
     (name, mkAttributes(name, pscope))
@@ -53,7 +53,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
    * see [15]
    */
   def xProcInstr: ElementType = {
-    val n = xName
+    val n: String = xName
     xSpaceOpt()
     xTakeUntil(mkProcInstr(_, n, _), () => tmppos, "?>")
   }
@@ -63,7 +63,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
    * @param endCh either `'` or `"`
    */
   def xAttributeValue(endCh: Char): String = {
-    val buf = new StringBuilder
+    val buf: StringBuilder = new StringBuilder
     while (ch != endCh && !eof) {
       // well-formedness constraint
       if (ch == '<') reportSyntaxError("'<' not allowed in attrib value")
@@ -76,13 +76,13 @@ private[scala] trait MarkupParserCommon extends TokenTests {
   }
 
   def xAttributeValue(): String = {
-    val str = xAttributeValue(ch_returning_nextch)
+    val str: String = xAttributeValue(ch_returning_nextch)
     // well-formedness constraint
     normalizeAttributeValue(str)
   }
 
   private def takeUntilChar(it: Iterator[Char], end: Char): String = {
-    val buf = new StringBuilder
+    val buf: StringBuilder = new StringBuilder
     while (it.hasNext) it.next() match {
       case `end` => return buf.toString
       case ch    => buf append ch
@@ -117,7 +117,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
     else if (!isNameStart(ch))
       return errorAndResult("name expected, but char '%s' cannot start a name" format ch, "")
 
-    val buf = new StringBuilder
+    val buf: StringBuilder = new StringBuilder
 
     while ({ buf append ch_returning_nextch
     ; isNameChar(ch)}) ()
@@ -128,7 +128,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
     } else buf.toString
   }
 
-  private def attr_unescape(s: String) = s match {
+  private def attr_unescape(s: String): String = s match {
     case "lt"    => "<"
     case "gt"    => ">"
     case "amp"   => "&"
@@ -143,8 +143,8 @@ private[scala] trait MarkupParserCommon extends TokenTests {
    *  see spec 3.3.3
    */
   private def normalizeAttributeValue(attval: String): String = {
-    val buf = new StringBuilder
-    val it = attval.iterator.buffered
+    val buf: StringBuilder = new StringBuilder
+    val it: BufferedIterator[Char] = attval.iterator.buffered
 
     while (it.hasNext) buf append (it.next() match {
       case ' ' | '\t' | '\n' | '\r' => " "
@@ -167,7 +167,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
     Utility.parseCharRef(ch, nextch, reportSyntaxError, truncatedError)
 
   def xCharRef(it: Iterator[Char]): String = {
-    var c = it.next()
+    var c: Char = it.next()
     Utility.parseCharRef(() => c, () => { c = it.next() }, reportSyntaxError, truncatedError)
   }
 
@@ -211,13 +211,13 @@ private[scala] trait MarkupParserCommon extends TokenTests {
   def xToken(that: Seq[Char]): Unit = { that foreach xToken }
 
   /** scan [S] '=' [S]*/
-  def xEQ() = { xSpaceOpt(); xToken('='); xSpaceOpt() }
+  def xEQ(): Unit = { xSpaceOpt(); xToken('='); xSpaceOpt() }
 
   /** skip optional space S? */
-  def xSpaceOpt() = while (isSpace(ch) && !eof) nextch()
+  def xSpaceOpt(): Unit = while (isSpace(ch) && !eof) nextch()
 
   /** scan [3] S ::= (#x20 | #x9 | #xD | #xA)+ */
-  def xSpace() =
+  def xSpace(): Unit =
     if (isSpace(ch)) { nextch(); xSpaceOpt() }
     else xHandleError(ch, "whitespace expected")
 
@@ -226,7 +226,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
 
   /** Execute body with a variable saved and restored after execution */
   def saving[A, B](getter: A, setter: A => Unit)(body: => B): B = {
-    val saved = getter
+    val saved: A = getter
     try body
     finally setter(saved)
   }
@@ -241,9 +241,9 @@ private[scala] trait MarkupParserCommon extends TokenTests {
     positioner: () => PositionType,
     until: String): T =
     {
-      val sb = new StringBuilder
-      val head = until.head
-      val rest = until.tail
+      val sb: StringBuilder = new StringBuilder
+      val head: Char = until.head
+      val rest: String = until.tail
 
       while (!eof) {
         if (ch == head && peek(rest))

--- a/shared/src/main/scala/scala/xml/parsing/NoBindingFactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/NoBindingFactoryAdapter.scala
@@ -23,7 +23,7 @@ import factory.NodeFactory
  */
 class NoBindingFactoryAdapter extends FactoryAdapter with NodeFactory[Elem] {
   /** True.  Every XML node may contain text that the application needs */
-  override def nodeContainsText(label: String) = true
+  override def nodeContainsText(label: String): Boolean = true
 
   /** From NodeFactory.  Constructs an instance of scala.xml.Elem -- TODO: deprecate as in Elem */
   override protected def create(pre: String, label: String, attrs: MetaData, scope: NamespaceBinding, children: Seq[Node]): Elem =

--- a/shared/src/main/scala/scala/xml/parsing/TokenTests.scala
+++ b/shared/src/main/scala/scala/xml/parsing/TokenTests.scala
@@ -38,8 +38,8 @@ trait TokenTests {
   final def isSpace(cs: Seq[Char]): Boolean = cs.nonEmpty && (cs forall isSpace)
 
   /** These are 99% sure to be redundant but refactoring on the safe side. */
-  def isAlpha(c: Char) = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
-  def isAlphaDigit(c: Char) = isAlpha(c) || (c >= '0' && c <= '9')
+  def isAlpha(c: Char): Boolean = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+  def isAlphaDigit(c: Char): Boolean = isAlpha(c) || (c >= '0' && c <= '9')
 
   /**
    * {{{
@@ -48,7 +48,7 @@ trait TokenTests {
    *  }}}
    *  See [4] and [4a] of Appendix B of XML 1.0 specification.
    */
-  def isNameChar(ch: Char) = {
+  def isNameChar(ch: Char): Boolean = {
     import java.lang.Character._
     // The constants represent groups Mc, Me, Mn, Lm, and Nd.
 
@@ -70,7 +70,7 @@ trait TokenTests {
    *  We do not allow a name to start with `:`.
    *  See [4] and Appendix B of XML 1.0 specification
    */
-  def isNameStart(ch: Char) = {
+  def isNameStart(ch: Char): Boolean = {
     import java.lang.Character._
 
     getType(ch).toByte match {
@@ -87,7 +87,7 @@ trait TokenTests {
    *  }}}
    *  See [5] of XML 1.0 specification.
    */
-  def isName(s: String) =
+  def isName(s: String): Boolean =
     s.nonEmpty && isNameStart(s.head) && (s.tail forall isNameChar)
 
   def isPubIDChar(ch: Char): Boolean =
@@ -102,13 +102,13 @@ trait TokenTests {
    *
    * @param ianaEncoding The IANA encoding name.
    */
-  def isValidIANAEncoding(ianaEncoding: Seq[Char]) = {
-    def charOK(c: Char) = isAlphaDigit(c) || ("._-" contains c)
+  def isValidIANAEncoding(ianaEncoding: Seq[Char]): Boolean = {
+    def charOK(c: Char): Boolean = isAlphaDigit(c) || ("._-" contains c)
 
     ianaEncoding.nonEmpty && isAlpha(ianaEncoding.head) &&
       (ianaEncoding.tail forall charOK)
   }
 
-  def checkSysID(s: String) = List('"', '\'') exists (c => !(s contains c))
-  def checkPubID(s: String) = s forall isPubIDChar
+  def checkSysID(s: String): Boolean = List('"', '\'') exists (c => !(s contains c))
+  def checkPubID(s: String): Boolean = s forall isPubIDChar
 }

--- a/shared/src/main/scala/scala/xml/parsing/XhtmlEntities.scala
+++ b/shared/src/main/scala/scala/xml/parsing/XhtmlEntities.scala
@@ -21,7 +21,7 @@ import scala.xml.dtd.{ IntDef, ParsedEntityDecl }
  *
  */
 object XhtmlEntities {
-  val entList = List(("quot", 34), ("amp", 38), ("lt", 60), ("gt", 62), ("nbsp", 160), ("iexcl", 161), ("cent", 162), ("pound", 163), ("curren", 164), ("yen", 165),
+  val entList: List[(String, Int)] = List(("quot", 34), ("amp", 38), ("lt", 60), ("gt", 62), ("nbsp", 160), ("iexcl", 161), ("cent", 162), ("pound", 163), ("curren", 164), ("yen", 165),
     ("euro", 8364), ("brvbar", 166), ("sect", 167), ("uml", 168), ("copy", 169), ("ordf", 170), ("laquo", 171), ("shy", 173), ("reg", 174), ("trade", 8482),
     ("macr", 175), ("deg", 176), ("plusmn", 177), ("sup2", 178), ("sup3", 179), ("acute", 180), ("micro", 181), ("para", 182), ("middot", 183), ("cedil", 184),
     ("sup1", 185), ("ordm", 186), ("raquo", 187), ("frac14", 188), ("frac12", 189), ("frac34", 190), ("iquest", 191), ("times", 215), ("divide", 247),
@@ -51,8 +51,8 @@ object XhtmlEntities {
 
   val entMap: Map[String, Char] = Map.empty[String, Char] ++ entList.map { case (name, value) => (name, value.toChar) }
 
-  val entities = entList.
+  val entities: List[(String, ParsedEntityDecl)] = entList.
     map { case (name, value) => (name, ParsedEntityDecl(name, IntDef(value.toChar.toString))) }
 
-  def apply() = entities
+  def apply(): List[(String, ParsedEntityDecl)] = entities
 }

--- a/shared/src/main/scala/scala/xml/parsing/XhtmlParser.scala
+++ b/shared/src/main/scala/scala/xml/parsing/XhtmlParser.scala
@@ -23,7 +23,7 @@ import scala.io.Source
  *  @author (c) David Pollak, 2007 WorldWide Conferencing, LLC.
  */
 class XhtmlParser(override val input: Source) extends ConstructingHandler with MarkupParser with ExternalSources {
-  override val preserveWS = true
+  override val preserveWS: Boolean = true
   ent ++= XhtmlEntities()
 }
 

--- a/shared/src/main/scala/scala/xml/transform/BasicTransformer.scala
+++ b/shared/src/main/scala/scala/xml/transform/BasicTransformer.scala
@@ -21,8 +21,8 @@ import scala.collection.Seq
  *
  *  @author  Burak Emir
  */
-abstract class BasicTransformer extends Function1[Node, Node] {
-  protected def unchanged(n: Node, ns: Seq[Node]) =
+abstract class BasicTransformer extends (Node => Node) {
+  protected def unchanged(n: Node, ns: Seq[Node]): Boolean =
     ns.length == 1 && (ns.head == n)
 
   /**
@@ -37,7 +37,7 @@ abstract class BasicTransformer extends Function1[Node, Node] {
    *  otherwise a new sequence of concatenated results.
    */
   def transform(ns: Seq[Node]): Seq[Node] = {
-    val changed = ns flatMap transform
+    val changed: Seq[Node] = ns flatMap transform
     if (changed.length != ns.length || changed.zip(ns).exists(p => p._1 != p._2)) changed
     else ns
 }
@@ -46,8 +46,8 @@ abstract class BasicTransformer extends Function1[Node, Node] {
     if (n.doTransform) n match {
       case Group(xs) => Group(transform(xs)) // un-group the hack Group tag
       case _ =>
-        val ch = n.child
-        val nch = transform(ch)
+        val ch: Seq[Node] = n.child
+        val nch: Seq[Node] = transform(ch)
 
         if (ch eq nch) n
         else Elem(n.prefix, n.label, n.attributes, n.scope, nch.isEmpty, nch: _*)
@@ -56,7 +56,7 @@ abstract class BasicTransformer extends Function1[Node, Node] {
   }
 
   override def apply(n: Node): Node = {
-    val seq = transform(n)
+    val seq: Seq[Node] = transform(n)
     if (seq.length > 1)
       throw new UnsupportedOperationException("transform must return single node for root")
     else seq.head

--- a/shared/src/main/scala/scala/xml/transform/RuleTransformer.scala
+++ b/shared/src/main/scala/scala/xml/transform/RuleTransformer.scala
@@ -17,7 +17,7 @@ package transform
 import scala.collection.Seq
 
 class RuleTransformer(rules: RewriteRule*) extends BasicTransformer {
-  private val transformers = rules.map(new NestingTransformer(_))
+  private val transformers: Seq[NestingTransformer] = rules.map(new NestingTransformer(_))
   override def transform(n: Node): Seq[Node] = {
     if (transformers.isEmpty) n
     else transformers.tail.foldLeft(transformers.head.transform(n)) { (res, transformer) => transformer.transform(res) }

--- a/shared/src/test/scala-2.x/scala/xml/ShouldCompile.scala
+++ b/shared/src/test/scala-2.x/scala/xml/ShouldCompile.scala
@@ -5,6 +5,6 @@ package scala.xml
 
 // t1626
 object o {
-  val n = <a xmlns=""/>
+  val n: Elem = <a xmlns=""/>
   n.namespace == null
 }

--- a/shared/src/test/scala-2.x/scala/xml/TransformersTest.scala
+++ b/shared/src/test/scala-2.x/scala/xml/TransformersTest.scala
@@ -8,8 +8,7 @@ import org.junit.Assert.assertEquals
 
 class TransformersTest {
 
-
-  def transformer = new RuleTransformer(new RewriteRule {
+  def transformer: RuleTransformer = new RuleTransformer(new RewriteRule {
     override def transform(n: Node): NodeSeq = n match {
       case <t>{ _* }</t> => <q/>
       case n => n
@@ -17,17 +16,17 @@ class TransformersTest {
   })
 
   @Test
-  def transform = // SI-2124
+  def transform(): Unit = // SI-2124
     assertEquals(transformer.transform(<p><lost/><t><s><r></r></s></t></p>),
       <p><lost/><q/></p>)
 
   @Test
-  def transformNamespaced = // SI-2125
+  def transformNamespaced(): Unit = // SI-2125
     assertEquals(transformer.transform(<xml:group><p><lost/><t><s><r></r></s></t></p></xml:group>),
       Group(<p><lost/><q/></p>))
 
   @Test
-  def rewriteRule = { // SI-2276
+  def rewriteRule(): Unit = { // SI-2276
     val inputXml: Node =
       <root>
         <subnode>
@@ -45,7 +44,7 @@ class TransformersTest {
       }
     }
 
-    val ruleTransformer = new RuleTransformer(t1)
+    val ruleTransformer: RuleTransformer = new RuleTransformer(t1)
     JUnitAssertsForXML.assertEquals(ruleTransformer(inputXml).toString, // TODO: why do we need toString?
       <root>
         <subnode>
@@ -58,10 +57,10 @@ class TransformersTest {
   }
 
   @Test
-  def preserveReferentialComplexityInLinearComplexity = { // SI-4528
-    var i = 0
+  def preserveReferentialComplexityInLinearComplexity(): Unit = { // SI-4528
+    var i: Int = 0
 
-    val xmlNode = <a><b><c><h1>Hello Example</h1></c></b></a>
+    val xmlNode: Elem = <a><b><c><h1>Hello Example</h1></c></b></a>
 
     new RuleTransformer(new RewriteRule {
       override def transform(n: Node): Seq[Node] = {
@@ -78,15 +77,15 @@ class TransformersTest {
   }
 
   @Test
-  def appliesRulesRecursivelyOnPreviousChanges = { // #257
-    def add(outer: Elem, inner: Node) = new RewriteRule {
+  def appliesRulesRecursivelyOnPreviousChanges(): Unit = { // #257
+    def add(outer: Elem, inner: Node): RewriteRule = new RewriteRule {
       override def transform(n: Node): Seq[Node] = n match {
         case e: Elem if e.label == outer.label => e.copy(child = e.child ++ inner)
         case other => other
       }
     }
 
-    def transformer = new RuleTransformer(add(<element/>, <new/>), add(<new/>, <thing/>))
+    def transformer: RuleTransformer = new RuleTransformer(add(<element/>, <new/>), add(<new/>, <thing/>))
 
     assertEquals(<element><new><thing/></new></element>, transformer(<element/>))
   }

--- a/shared/src/test/scala-2.x/scala/xml/XMLTest2x.scala
+++ b/shared/src/test/scala-2.x/scala/xml/XMLTest2x.scala
@@ -13,19 +13,19 @@ class XMLTest2x {
     </wsdl:definitions>
 
   @UnitTest
-  def wsdl = {
+  def wsdl(): Unit = {
     assertEquals("""<wsdl:definitions name="service3" xmlns:tns="target3">
     </wsdl:definitions>""", wsdlTemplate3("service3") toString)
   }
 
   @UnitTest
-  def t5154: Unit = {
+  def t5154(): Unit = {
 
     // extra space made the pattern OK
-    def f = <z> {{3}}</z> match { case <z> {{3}}</z> => true }
+    def f: Boolean = <z> {{3}}</z> match { case <z> {{3}}</z> => true }
 
     // lack of space used to error: illegal start of simple pattern
-    def g = <z>{{3}}</z> match { case <z>{{3}}</z> => true }
+    def g: Boolean = <z>{{3}}</z> match { case <z>{{3}}</z> => true }
 
     assertTrue(f)
     assertTrue(g)

--- a/shared/src/test/scala/scala/xml/AttributeTest.scala
+++ b/shared/src/test/scala/scala/xml/AttributeTest.scala
@@ -6,21 +6,22 @@ import org.junit.Assert.assertEquals
 
 class AttributeTest {
   @Test
-  def unprefixedAttribute: Unit = {
-    val x = new UnprefixedAttribute("foo","bar", Null)
+  def unprefixedAttribute(): Unit = {
+    val x: UnprefixedAttribute = new UnprefixedAttribute("foo","bar", Null)
     assertEquals(Some(Text("bar")), x.get("foo"))
     assertEquals(Text("bar"), x("foo"))
     assertEquals(None, x.get("no_foo"))
     assertEquals(null, x("no_foo"))
 
-    val y = x.remove("foo")
+    val y: MetaData = x.remove("foo")
     assertEquals(Null, y)
 
-    val z = new UnprefixedAttribute("foo", null:NodeSeq, x)
+    val z: UnprefixedAttribute = new UnprefixedAttribute("foo", null:NodeSeq, x)
     assertEquals(None, z.get("foo"))
 
-    var appended = x append x append x append x
-    var len = 0; while (appended ne Null) {
+    var appended: MetaData = x append x append x append x
+    var len: Int = 0
+    while (appended ne Null) {
       appended = appended.next
       len = len + 1
     }
@@ -28,154 +29,154 @@ class AttributeTest {
   }
 
   @Test
-  def attributeWithOption: Unit = {
-    val x = new UnprefixedAttribute("foo", Some(Text("bar")), Null)
+  def attributeWithOption(): Unit = {
+    val x: UnprefixedAttribute = new UnprefixedAttribute("foo", Some(Text("bar")), Null)
 
     assertEquals(Some(Text("bar")), x.get("foo"))
     assertEquals(Text("bar"), x("foo"))
     assertEquals(None, x.get("no_foo"))
     assertEquals(null, x("no_foo"))
 
-    val attr1 = Some(Text("foo value"))
-    val attr2 = None
-    val y = <b foo={attr1} bar={attr2} />
+    val attr1: Option[Text] = Some(Text("foo value"))
+    val attr2: Option[Text] = None
+    val y: Elem = <b foo={attr1} bar={attr2} />
     assertEquals(Some(Text("foo value")), y.attributes.get("foo"))
     assertEquals(Text("foo value"), y.attributes("foo"))
     assertEquals(None, y.attributes.get("bar"))
     assertEquals(null, y.attributes("bar"))
 
-    val z = new UnprefixedAttribute("foo", None, x)
+    val z: UnprefixedAttribute = new UnprefixedAttribute("foo", None, x)
     assertEquals(None, z.get("foo"))
   }
 
   @Test
-  def attributeOrder: Unit = {
-    val x = <x y="1" z="2"/>
+  def attributeOrder(): Unit = {
+    val x: Elem = <x y="1" z="2"/>
     assertEquals("""<x y="1" z="2"/>""", x.toString)
   }
 
-  def attributeToString: Unit = {
+  def attributeToString(): Unit = {
     val expected: String = """<b x="&amp;"/>"""
     assertEquals(expected, <b x="&amp;"/>.toString)
     assertEquals(expected, <b x={"&"}/>.toString)
   }
 
   @Test
-  def attributeOperator: Unit = {
-    val xml = <foo bar="apple" />
+  def attributeOperator(): Unit = {
+    val xml: Elem = <foo bar="apple" />
     assertEquals("apple", xml \@ "bar")
   }
 
   @Test
-  def attributePathRootNoAttribute: Unit = {
-    val xml = <foo />
+  def attributePathRootNoAttribute(): Unit = {
+    val xml: Elem = <foo />
     assertEquals(NodeSeq.Empty, xml \ "@bar")
   }
 
   @Test(expected=classOf[IllegalArgumentException])
-  def attributePathIllegalEmptyAttribute: Unit = {
-    val xml = <foo />
+  def attributePathIllegalEmptyAttribute(): Unit = {
+    val xml: Elem = <foo />
     xml \ "@"
   }
 
   @Test
-  def attributePathRootWithOneAttribute: Unit = {
-    val xml = <foo bar="apple" />
+  def attributePathRootWithOneAttribute(): Unit = {
+    val xml: Elem = <foo bar="apple" />
     assertEquals(Group(Text("apple")), xml \ "@bar")
     // assertEquals(NodeSeq.fromSeq(Seq(Text("apple"))), xml \ "@bar")
   }
 
   @Test
-  def attributePathRootWithMissingAttributes: Unit = {
-    val xml = <foo bar="apple" />
+  def attributePathRootWithMissingAttributes(): Unit = {
+    val xml: Elem = <foo bar="apple" />
     assertEquals(NodeSeq.Empty, xml \ "@oops")
   }
 
   @Test
-  def attributePathDuplicateAttribute: Unit = {
-    val xml = Elem(null, "foo",
+  def attributePathDuplicateAttribute(): Unit = {
+    val xml: Elem = Elem(null, "foo",
       Attribute("bar", Text("apple"),
-        Attribute("bar", Text("orange"), Null)), TopScope, true)
+        Attribute("bar", Text("orange"), Null)), TopScope, minimizeEmpty = true)
     assertEquals(Group(Text("apple")), xml \ "@bar")
   }
 
   @Test
-  def attributePathDescendantAttributes: Unit = {
-    val xml = <a><b bar="1" /><b bar="2" /></a>
+  def attributePathDescendantAttributes(): Unit = {
+    val xml: Elem = <a><b bar="1" /><b bar="2" /></a>
     assertEquals(NodeSeq.fromSeq(Seq(Text("1"), Text("2"))), xml \\ "@bar")
   }
 
   @Test
-  def attributeDescendantPathChildAttributes: Unit = {
-    val xml = <a><b bar="1" /><b bar="2" /></a>
+  def attributeDescendantPathChildAttributes(): Unit = {
+    val xml: Elem = <a><b bar="1" /><b bar="2" /></a>
     assertEquals(NodeSeq.fromSeq(Seq(Text("1"), Text("2"))), xml \ "b" \\ "@bar")
   }
 
   @Test
-  def attributeDescendantPathDescendantAttributes: Unit = {
-    val xml = <a><b bar="1" /><b bar="2" /></a>
+  def attributeDescendantPathDescendantAttributes(): Unit = {
+    val xml: Elem = <a><b bar="1" /><b bar="2" /></a>
     assertEquals(NodeSeq.fromSeq(Seq(Text("1"), Text("2"))), xml \\ "b" \\ "@bar")
   }
 
   @Test
-  def attributeChildDescendantPathDescendantAttributes: Unit = {
-    val xml = <x><a><b bar="1" /><b bar="2" /></a></x>
+  def attributeChildDescendantPathDescendantAttributes(): Unit = {
+    val xml: Elem = <x><a><b bar="1" /><b bar="2" /></a></x>
     assertEquals(NodeSeq.fromSeq(Seq(Text("1"), Text("2"))), xml \ "a" \\ "@bar")
   }
 
   @Test
-  def attributeDescendantDescendantPathDescendantAttributes: Unit = {
-    val xml = <x><a><b bar="1" /><b bar="2" /></a></x>
+  def attributeDescendantDescendantPathDescendantAttributes(): Unit = {
+    val xml: Elem = <x><a><b bar="1" /><b bar="2" /></a></x>
     assertEquals(NodeSeq.fromSeq(Seq(Text("1"), Text("2"))), xml \\ "b" \\ "@bar")
   }
 
   @Test(expected=classOf[IllegalArgumentException])
-  def attributePathDescendantIllegalEmptyAttribute: Unit = {
-    val xml = <foo />
+  def attributePathDescendantIllegalEmptyAttribute(): Unit = {
+    val xml: Elem = <foo />
     xml \\ "@"
   }
 
   @Test
-  def attributePathNoDescendantAttributes: Unit = {
-    val xml = <a><b bar="1" /><b bar="2" /></a>
+  def attributePathNoDescendantAttributes(): Unit = {
+    val xml: Elem = <a><b bar="1" /><b bar="2" /></a>
     assertEquals(NodeSeq.Empty, xml \\ "@oops")
   }
 
   @Test
-  def attributePathOneChildWithAttributes: Unit = {
-    val xml = <a><b bar="1" />></a>
+  def attributePathOneChildWithAttributes(): Unit = {
+    val xml: Elem = <a><b bar="1" />></a>
     assertEquals(Group(Seq(Text("1"))), xml \ "b" \ "@bar")
   }
 
   @Test
-  def attributePathTwoChildrenWithAttributes: Unit = {
-    val xml = <a><b bar="1" /><b bar="2" /></a>
-    val b = xml \ "b"
+  def attributePathTwoChildrenWithAttributes(): Unit = {
+    val xml: Elem = <a><b bar="1" /><b bar="2" /></a>
+    val b: NodeSeq = xml \ "b"
     assertEquals(2, b.length.toLong)
     assertEquals(NodeSeq.fromSeq(Seq(<b bar="1"/>, <b bar="2"/>)), b)
-    val barFail = b \ "@bar"
-    val barList =  b.map(_ \ "@bar")
+    val barFail: NodeSeq = b \ "@bar"
+    val barList: Seq[NodeSeq] =  b.map(_ \ "@bar")
     assertEquals(NodeSeq.Empty, barFail)
     assertEquals(List(Group(Seq(Text("1"))), Group(Seq(Text("2")))), barList)
   }
 
   @Test(expected=classOf[IllegalArgumentException])
-  def invalidAttributeFailForOne: Unit = {
+  def invalidAttributeFailForOne(): Unit = {
     <x/> \ "@"
   }
 
   @Test(expected=classOf[IllegalArgumentException])
-  def invalidAttributeFailForMany: Unit = {
+  def invalidAttributeFailForMany(): Unit = {
     <x><y/><z/></x>.child \ "@"
   }
 
   @Test(expected=classOf[IllegalArgumentException])
-  def invalidEmptyAttributeFailForOne: Unit = {
+  def invalidEmptyAttributeFailForOne(): Unit = {
     <x/> \@ ""
   }
 
   @Test(expected=classOf[IllegalArgumentException])
-  def invalidEmptyAttributeFailForMany: Unit = {
+  def invalidEmptyAttributeFailForMany(): Unit = {
     <x><y/><z/></x>.child \@ ""
   }
 }

--- a/shared/src/test/scala/scala/xml/CommentTest.scala
+++ b/shared/src/test/scala/scala/xml/CommentTest.scala
@@ -6,23 +6,23 @@ import org.junit.Test
 final class CommentTest {
 
   @Test(expected=classOf[IllegalArgumentException])
-  def invalidCommentWithTwoDashes: Unit = {
+  def invalidCommentWithTwoDashes(): Unit = {
     Comment("invalid--comment")
   }
 
   @Test(expected=classOf[IllegalArgumentException])
-  def invalidCommentWithFinalDash: Unit = {
+  def invalidCommentWithFinalDash(): Unit = {
     Comment("invalid comment-")
   }
 
   @Test
-  def validCommentWithDash: Unit = {
+  def validCommentWithDash(): Unit = {
     val valid: String = "valid-comment"
     assertEquals(s"<!--$valid-->", Comment(valid).toString)
   }
 
   @Test
-  def validEmptyComment: Unit = {
+  def validEmptyComment(): Unit = {
     val valid: String = ""
     assertEquals(s"<!--$valid-->", Comment(valid).toString)
   }

--- a/shared/src/test/scala/scala/xml/JUnitAssertsForXML.scala
+++ b/shared/src/test/scala/scala/xml/JUnitAssertsForXML.scala
@@ -4,5 +4,4 @@ object JUnitAssertsForXML {
 
   private[xml] def assertEquals(expected: String, actual: NodeSeq): Unit =
     org.junit.Assert.assertEquals(expected, actual.toString)
-
 }

--- a/shared/src/test/scala/scala/xml/MetaDataTest.scala
+++ b/shared/src/test/scala/scala/xml/MetaDataTest.scala
@@ -6,22 +6,22 @@ import org.junit.Assert.assertEquals
 class MetaDataTest {
 
   @Test
-  def absentElementPrefixed1: Unit = {
+  def absentElementPrefixed1(): Unit = {
     // type ascription to help overload resolution pick the right variant
     assertEquals(null: Object, Null("za://foo.com", TopScope, "bar"))
     assertEquals(null, Null("bar"))
   }
 
   @Test
-  def absentElementPrefixed2: Unit = {
+  def absentElementPrefixed2(): Unit = {
     assertEquals(Option.empty, Null.get("za://foo.com", TopScope, "bar" ))
     assertEquals(Option.empty, Null.get("bar"))
   }
 
   @Test
-  def presentElement1: Unit = {
-    val x = new PrefixedAttribute("zo","bar", new Atom(42), Null)
-    val s = NamespaceBinding("zo","za://foo.com", TopScope)
+  def presentElement1(): Unit = {
+    val x: PrefixedAttribute = new PrefixedAttribute("zo","bar", new Atom(42), Null)
+    val s: NamespaceBinding = NamespaceBinding("zo","za://foo.com", TopScope)
     assertEquals(new Atom(42), x("za://foo.com", s, "bar" ))
     assertEquals(null, x("bar"))
     assertEquals(Some(new Atom(42)), x.get("za://foo.com", s, "bar"))
@@ -29,10 +29,10 @@ class MetaDataTest {
   }
 
   @Test
-  def presentElement2: Unit = {
-    val s = NamespaceBinding("zo","za://foo.com", TopScope)
-    val x1 = new PrefixedAttribute("zo","bar", new Atom(42), Null)
-    val x = new UnprefixedAttribute("bar","meaning", x1)
+  def presentElement2(): Unit = {
+    val s: NamespaceBinding = NamespaceBinding("zo","za://foo.com", TopScope)
+    val x1: PrefixedAttribute = new PrefixedAttribute("zo","bar", new Atom(42), Null)
+    val x: UnprefixedAttribute = new UnprefixedAttribute("bar","meaning", x1)
     assertEquals(null, x(null, s, "bar"))
     assertEquals(Text("meaning"), x("bar"))
     assertEquals(None, x.get(null, s, "bar" ))
@@ -40,25 +40,24 @@ class MetaDataTest {
   }
 
   @Test
-  def attributeExtractor: Unit = {
-    def domatch(x:Node): Node = {
+  def attributeExtractor(): Unit = {
+    def domatch(x: Node): Node = {
       x match {
             case Node("foo", md @ UnprefixedAttribute(_, value, _), _*) if value.nonEmpty =>
                  md("bar")(0)
             case _ => new Atom(3)
       }
     }
-    val z =  <foo bar="gar"/>
-    val z2 = <foo/>
+    val z: Elem =  <foo bar="gar"/>
+    val z2: Elem = <foo/>
     assertEquals(Text("gar"), domatch(z))
     assertEquals(new Atom(3), domatch(z2))
   }
 
   @Test
-  def reverseTest: Unit = {
+  def reverseTest(): Unit = {
     assertEquals("", Null.reverse.toString)
     assertEquals(""" b="c"""", <a b="c"/>.attributes.reverse.toString)
     assertEquals(""" d="e" b="c"""", <a b="c" d="e"/>.attributes.reverse.toString)
   }
-
 }

--- a/shared/src/test/scala/scala/xml/NodeBufferTest.scala
+++ b/shared/src/test/scala/scala/xml/NodeBufferTest.scala
@@ -6,8 +6,8 @@ import org.junit.Assert.assertEquals
 class NodeBufferTest {
 
   @Test
-  def testToString: Unit = {
-    val nodeBuffer = new NodeBuffer
+  def testToString(): Unit = {
+    val nodeBuffer: NodeBuffer = new NodeBuffer
     assertEquals("NodeBuffer()", nodeBuffer.toString)
   }
 }

--- a/shared/src/test/scala/scala/xml/NodeSeqTest.scala
+++ b/shared/src/test/scala/scala/xml/NodeSeqTest.scala
@@ -1,43 +1,44 @@
 package scala.xml
 
 import scala.xml.NodeSeq.seqToNodeSeq
-
 import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
 
+import scala.collection.immutable
+
 class NodeSeqTest {
 
   @Test
-  def testAppend: Unit = { // Bug #392.
+  def testAppend(): Unit = { // Bug #392.
     val a: NodeSeq = <a>Hello</a>
-    val b = <b>Hi</b>
+    val b: Elem = <b>Hi</b>
     a ++ <b>Hi</b> match {
       case res: NodeSeq => assertEquals(2, res.size.toLong)
       case res: Seq[Node] => fail("Should be NodeSeq was Seq[Node]") // Unreachable code?
     }
     val res: NodeSeq = a ++ b
-    val exp = NodeSeq.fromSeq(Seq(<a>Hello</a>, <b>Hi</b>))
+    val exp: NodeSeq = NodeSeq.fromSeq(Seq(<a>Hello</a>, <b>Hi</b>))
     assertEquals(exp, res)
   }
 
   @Test
-  def testAppendedAll: Unit = { // Bug #392.
+  def testAppendedAll(): Unit = { // Bug #392.
     val a: NodeSeq = <a>Hello</a>
-    val b = <b>Hi</b>
+    val b: Elem = <b>Hi</b>
     a :+ <b>Hi</b> match {
       case res: Seq[Node] => assertEquals(2, res.size.toLong)
       case res: NodeSeq => fail("Should be Seq[Node] was NodeSeq") // Unreachable code?
     }
     val res: NodeSeq = a :+ b
-    val exp = NodeSeq.fromSeq(Seq(<a>Hello</a>, <b>Hi</b>))
+    val exp: NodeSeq = NodeSeq.fromSeq(Seq(<a>Hello</a>, <b>Hi</b>))
     assertEquals(exp, res)
   }
 
   @Test
-  def testPrepended: Unit = {
+  def testPrepended(): Unit = {
     val a: NodeSeq = <a>Hello</a>
-    val b = <b>Hi</b>
+    val b: Elem = <b>Hi</b>
     a +: <b>Hi</b> match {
       case res: Seq[Node] => assertEquals(2, res.size.toLong)
       case res: NodeSeq => fail("Should be Seq[Node] was NodeSeq") // Unreachable code?
@@ -50,21 +51,21 @@ class NodeSeqTest {
   }
 
   @Test
-  def testPrependedAll: Unit = {
+  def testPrependedAll(): Unit = {
     val a: NodeSeq = <a>Hello</a>
-    val b = <b>Hi</b>
-    val c = <c>Hey</c>
+    val b: Elem = <b>Hi</b>
+    val c: Elem = <c>Hey</c>
     a ++: <b>Hi</b> ++: <c>Hey</c> match {
       case res: Seq[Node] => assertEquals(3, res.size.toLong)
       case res: NodeSeq => fail("Should be Seq[Node] was NodeSeq") // Unreachable code?
     }
     val res: NodeSeq = a ++: b ++: c
-    val exp = NodeSeq.fromSeq(Seq(<a>Hello</a>, <b>Hi</b>, <c>Hey</c>))
+    val exp: NodeSeq = NodeSeq.fromSeq(Seq(<a>Hello</a>, <b>Hi</b>, <c>Hey</c>))
     assertEquals(exp, res)
   }
 
   @Test
-  def testMap: Unit = {
+  def testMap(): Unit = {
     val a: NodeSeq = <a>Hello</a>
     val exp: NodeSeq = Seq(<b>Hi</b>)
     assertEquals(exp, a.map(_ => <b>Hi</b>))
@@ -72,7 +73,7 @@ class NodeSeqTest {
   }
 
   @Test
-  def testFlatMap: Unit = {
+  def testFlatMap(): Unit = {
     val a: NodeSeq = <a>Hello</a>
     val exp: NodeSeq = Seq(<b>Hi</b>)
     assertEquals(exp, a.flatMap(_ => Seq(<b>Hi</b>)))
@@ -81,8 +82,8 @@ class NodeSeqTest {
   }
 
   @Test
-  def testStringProjection: Unit = {
-    val a =
+  def testStringProjection(): Unit = {
+    val a: Elem =
       <a>
         <b>b</b>
         <b>
@@ -93,7 +94,7 @@ class NodeSeqTest {
           <c>c</c>
         </b>
       </a>
-    val res = for {
+    val res: Seq[String] = for {
       b <- a \ "b"
       c <- b.child
       e <- (c \ "e").headOption

--- a/shared/src/test/scala/scala/xml/PCDataTest.scala
+++ b/shared/src/test/scala/scala/xml/PCDataTest.scala
@@ -5,33 +5,23 @@ import org.junit.Assert.assertEquals
 
 class PCDataTest {
 
-  @Test
-  def emptyTest = {
-    val pcdata = new PCData("")
-    assertEquals("<![CDATA[]]>", pcdata.toString)
+  def check(pcdata: String, expected: String): Unit = {
+    val actual: PCData = new PCData(pcdata)
+    assertEquals(expected, actual.toString)
   }
 
   @Test
-  def bracketTest = {
-    val pcdata = new PCData("[]")
-    assertEquals("<![CDATA[[]]]>", pcdata.toString)
-  }
+  def emptyTest(): Unit = check("", "<![CDATA[]]>")
 
   @Test
-  def hellaBracketingTest = {
-    val pcdata = new PCData("[[[[[[[[]]]]]]]]")
-    assertEquals("<![CDATA[[[[[[[[[]]]]]]]]]]>", pcdata.toString)
-  }
+  def bracketTest(): Unit = check("[]", "<![CDATA[[]]]>")
 
   @Test
-  def simpleNestingTest = {
-    val pcdata = new PCData("]]>")
-    assertEquals("<![CDATA[]]]]><![CDATA[>]]>", pcdata.toString)
-  }
+  def hellaBracketingTest(): Unit = check("[[[[[[[[]]]]]]]]", "<![CDATA[[[[[[[[[]]]]]]]]]]>")
 
   @Test
-  def recursiveNestingTest = {
-    val pcdata = new PCData("<![CDATA[]]>")
-    assertEquals("<![CDATA[<![CDATA[]]]]><![CDATA[>]]>", pcdata.toString)
-  }
+  def simpleNestingTest(): Unit = check("]]>", "<![CDATA[]]]]><![CDATA[>]]>")
+
+  @Test
+  def recursiveNestingTest(): Unit = check("<![CDATA[]]>", "<![CDATA[<![CDATA[]]]]><![CDATA[>]]>")
 }

--- a/shared/src/test/scala/scala/xml/PatternMatchingTest.scala
+++ b/shared/src/test/scala/scala/xml/PatternMatchingTest.scala
@@ -7,39 +7,39 @@ import org.junit.Assert.assertEquals
 
 class PatternMatchingTest {
   @Test
-  def unprefixedAttribute: Unit = {
-    val li = List("1", "2", "3", "4")
+  def unprefixedAttribute(): Unit = {
+    val li: List[String] = List("1", "2", "3", "4")
     assertTrue(matchSeq(li))
     assertTrue(matchList(li))
   }
 
-  def matchSeq(args: Seq[String]) = args match {
+  def matchSeq(args: Seq[String]): Boolean = args match {
     case Seq(a, b, c, d @ _*) => true
   }
 
-  def matchList(args: List[String]) =
+  def matchList(args: List[String]): Boolean =
     Elem(null, "bla", Null, TopScope, minimizeEmpty = true, args.map { x => Text(x) }: _*) match {
       case Elem(_, _, _, _, Text("1"), _*) => true
     }
 
   @Test
-  def simpleNode =
+  def simpleNode(): Unit =
     assertTrue(<hello/> match {
       case <hello/> => true
     })
 
   @Test
-  def nameSpaced =
+  def nameSpaced(): Unit =
     assertTrue(<x:ga xmlns:x="z"/> match {
       case <x:ga/> => true
     })
 
-  val cx = <z:hello foo="bar" xmlns:z="z" x:foo="baz" xmlns:x="the namespace from outer space">
-             crazy text world
-           </z:hello>
+  val cx: Elem = <z:hello foo="bar" xmlns:z="z" x:foo="baz" xmlns:x="the namespace from outer space">
+                   crazy text world
+                 </z:hello>
 
   @Test
-  def nodeContents = {
+  def nodeContents(): Unit = {
     assertTrue(Utility.trim(cx) match {
       case n @ <hello>crazy text world</hello> if (n \ "@foo") xml_== "bar" => true
     })
@@ -47,13 +47,12 @@ class PatternMatchingTest {
       case n @ <z:hello>crazy text world</z:hello> if (n \ "@foo") xml_== "bar" => true
     })
     assertTrue(<x:foo xmlns:x="gaga"/> match {
-      case scala.xml.QNode("gaga", "foo", md, child @ _*) => true
+      case QNode("gaga", "foo", md, child @ _*) => true
     })
 
     assertTrue(<x:foo xmlns:x="gaga"/> match {
-      case scala.xml.Node("foo", md, child @ _*) => true
+      case Node("foo", md, child @ _*) => true
     })
-
   }
 
   object SafeNodeSeq {
@@ -67,10 +66,8 @@ class PatternMatchingTest {
   }
 
   @Test
-  def nodeSeq = { // t0646
-    import scala.xml.NodeSeq
-
-    val books =
+  def nodeSeq(): Unit = { // t0646
+    val books: Elem =
       <bks>
         <title>Blabla</title>
         <title>Blubabla</title>
@@ -90,7 +87,7 @@ class PatternMatchingTest {
   }
 
   @Test
-  def SI_4124 = {
+  def SI_4124(): Unit = {
     val body: Node = <elem>hi</elem>
 
     assertTrue((body: AnyRef, "foo") match {

--- a/shared/src/test/scala/scala/xml/PrintEmptyElementsTest.scala
+++ b/shared/src/test/scala/scala/xml/PrintEmptyElementsTest.scala
@@ -6,7 +6,7 @@ import JUnitAssertsForXML.assertEquals
 class PrintEmptyElementsTest {
 
   @Test
-  def representEmptyXMLElementsInShortForm: Unit = {
+  def representEmptyXMLElementsInShortForm(): Unit = {
     val expected: String =
       """|
          |<hi/> <!-- literal short -->
@@ -29,27 +29,26 @@ class PrintEmptyElementsTest {
   }
 
   @Test
-  def programmaticLong: Unit = {
+  def programmaticLong(): Unit = {
     assertEquals("<emptiness></emptiness> <!--programmatic long-->",
-      Elem(null, "emptiness", Null, TopScope, false) ++ Text(" ") ++ Comment("programmatic long"))
+      Elem(null, "emptiness", Null, TopScope, minimizeEmpty = false) ++ Text(" ") ++ Comment("programmatic long"))
   }
 
   @Test
-  def programmaticShort: Unit = {
+  def programmaticShort(): Unit = {
     assertEquals("<vide/> <!--programmatic short-->",
-      Elem(null, "vide", Null, TopScope, true) ++ Text(" ") ++ Comment("programmatic short"))
+      Elem(null, "vide", Null, TopScope, minimizeEmpty = true) ++ Text(" ") ++ Comment("programmatic short"))
   }
 
   @Test
-  def programmaticShortWithAttribute: Unit = {
+  def programmaticShortWithAttribute(): Unit = {
     assertEquals("""<elem attr="value"/> <!--programmatic short with attribute-->""",
-      Elem(null, "elem", Attribute("attr", Text("value"), Null), TopScope, true) ++ Text(" ") ++ Comment ("programmatic short with attribute"))
+      Elem(null, "elem", Attribute("attr", Text("value"), Null), TopScope, minimizeEmpty = true) ++ Text(" ") ++ Comment ("programmatic short with attribute"))
   }
 
   @Test
-  def programmaticLongWithAttribute: Unit = {
+  def programmaticLongWithAttribute(): Unit = {
     assertEquals("""<elem2 attr2="value2"></elem2> <!--programmatic long with attribute-->""",
-      Elem(null, "elem2", Attribute("attr2", Text("value2"), Null), TopScope, false) ++ Text(" ") ++ Comment ("programmatic long with attribute"))
+      Elem(null, "elem2", Attribute("attr2", Text("value2"), Null), TopScope, minimizeEmpty = false) ++ Text(" ") ++ Comment ("programmatic long with attribute"))
   }
-
 }

--- a/shared/src/test/scala/scala/xml/Properties.scala
+++ b/shared/src/test/scala/scala/xml/Properties.scala
@@ -14,6 +14,6 @@ package scala
 package xml
 
 object Properties extends util.PropertiesTrait {
-  override protected def propCategory    = "scala-xml"
-  override protected def pickJarBasedOn  = classOf[scala.xml.Node]
+  override protected def propCategory: String = "scala-xml"
+  override protected def pickJarBasedOn: Class[Node] = classOf[Node]
 }

--- a/shared/src/test/scala/scala/xml/ShouldCompile.scala
+++ b/shared/src/test/scala/scala/xml/ShouldCompile.scala
@@ -17,15 +17,15 @@ class Foo {
 
 // t2281
 class t2281A {
-  def f(x: Boolean) = if (x) <br/><br/> else <br/>
+  def f(x: Boolean): Seq[Node] = if (x) <br/><br/> else <br/>
 }
 
 class t2281B {
   def splitSentences(text: String): ArrayBuffer[String] = {
-    val outarr = new ArrayBuffer[String]
-    var outstr = new StringBuffer
-    var prevspace = false
-    val ctext = text.replaceAll("\n+", "\n")
+    val outarr: ArrayBuffer[String] = new ArrayBuffer[String]
+    var outstr: StringBuffer = new StringBuffer
+    var prevspace: Boolean = false
+    val ctext: String = text.replaceAll("\n+", "\n")
     ctext foreach { c =>
       outstr append c
       if (c == '.' || c == '!' || c == '?' || c == '\n' || c == ':' || c == ';' || (prevspace && c == '-')) {
@@ -43,15 +43,15 @@ class t2281B {
     outarr
   }
 
-  def spanForSentence(x: String, picktext: String) =
+  def spanForSentence(x: String, picktext: String): Seq[Node] =
     if (x == "\n\n") {
       <br/><br/>
     } else {
       <span class='clicksentence' style={ if (x == picktext) "background-color: yellow" else "" }>{ x }</span>
     }
 
-  def selectableSentences(text: String, picktext: String) = {
-    val sentences = splitSentences(text)
+  def selectableSentences(text: String, picktext: String): ArrayBuffer[Seq[Node]] = {
+    val sentences: ArrayBuffer[String] = splitSentences(text)
     sentences.map(x => spanForSentence(x, picktext))
   }
 }
@@ -62,7 +62,7 @@ object SI_5858 {
 }
 
 class Floozy {
-  def fooz(x: Node => String) = {}
+  def fooz(x: Node => String): Unit = ()
   def foo(m: Node): Unit = fooz {
     case Elem(_, _, _, _, n, _*) if n == m => "gaga"
   }
@@ -82,7 +82,7 @@ object guardedMatch { // SI-3705
 
 // SI-6897
 object shouldCompile {
-  val html = (null: Any) match {
+  val html: Seq[Node] = (null: Any) match {
     case 1 => <xml:group></xml:group>
     case 2 => <p></p>
   }

--- a/shared/src/test/scala/scala/xml/UtilityTest.scala
+++ b/shared/src/test/scala/scala/xml/UtilityTest.scala
@@ -9,45 +9,45 @@ import org.junit.Assert.assertNotEquals
 class UtilityTest {
 
   @Test
-  def isNameStart: Unit = {
+  def isNameStart(): Unit = {
     assertTrue(Utility.isNameStart('b'))
     assertTrue(Utility.isNameStart(':'))
   }
 
   @Test
-  def trim: Unit = {
-    val x = <foo>
-                 <toomuchws/>
-              </foo>
-    val y = xml.Utility.trim(x)
+  def trim(): Unit = {
+    val x: Elem = <foo>
+                     <toomuchws/>
+                  </foo>
+    val y: Node = Utility.trim(x)
     assertTrue(y match { case <foo><toomuchws/></foo> => true })
 
-    val x2 = <foo>
+    val x2: Elem = <foo>
       <toomuchws>  a b  b a  </toomuchws>
     </foo>
-    val y2 = xml.Utility.trim(x2)
+    val y2: Node = Utility.trim(x2)
     assertTrue(y2 match { case <foo><toomuchws>a b b a</toomuchws></foo> => true })
   }
 
   @Test
-  def aposEscaping: Unit = {
-    val z = <bar>''</bar>
-    val z1 = z.toString
+  def aposEscaping(): Unit = {
+    val z: Elem = <bar>''</bar>
+    val z1: String = z.toString
     assertEquals("<bar>''</bar>", z1)
   }
 
   @Test
-  def sort: Unit = {
-    assertEquals("", xml.Utility.sort(<a/>.attributes).toString)
-    assertEquals(""" b="c"""", xml.Utility.sort(<a b="c"/>.attributes).toString)
-    val q = xml.Utility.sort(<a g='3' j='2' oo='2' a='2'/>)
-    assertEquals(" a=\"2\" g=\"3\" j=\"2\" oo=\"2\"", xml.Utility.sort(q.attributes).toString)
-    val pp = new xml.PrettyPrinter(80,5)
+  def sort(): Unit = {
+    assertEquals("", Utility.sort(<a/>.attributes).toString)
+    assertEquals(""" b="c"""", Utility.sort(<a b="c"/>.attributes).toString)
+    val q: Node = Utility.sort(<a g='3' j='2' oo='2' a='2'/>)
+    assertEquals(" a=\"2\" g=\"3\" j=\"2\" oo=\"2\"", Utility.sort(q.attributes).toString)
+    val pp: PrettyPrinter = new PrettyPrinter(80,5)
     assertEquals("<a a=\"2\" g=\"3\" j=\"2\" oo=\"2\"/>", pp.format(q))
   }
 
   @Test
-  def issue777: Unit = {
+  def issue777(): Unit = {
     <hi>
       <there/>
       <guys/>
@@ -55,14 +55,14 @@ class UtilityTest {
   }
 
   @Test
-  def issue90: Unit = {
-    val x = <node><leaf></leaf></node>
+  def issue90(): Unit = {
+    val x: Elem = <node><leaf></leaf></node>
     assertEquals("<node><leaf/></node>", Utility.serialize(x, minimizeTags = MinimizeMode.Always).toString)
   }
 
   @Test
-  def issue183: Unit = {
-    val x = <node><!-- comment  --></node>
+  def issue183(): Unit = {
+    val x: Elem = <node><!-- comment  --></node>
     assertEquals("<node></node>", Utility.serialize(x, stripComments = true).toString)
     assertEquals("<node><!-- comment  --></node>", Utility.serialize(x, stripComments = false).toString)
   }
@@ -81,7 +81,7 @@ class UtilityTest {
     Utility.Escapes.escMap.keys.toSeq
 
   @Test
-  def escapePrintablesTest: Unit = {
+  def escapePrintablesTest(): Unit = {
     for {
       char <- printableAscii.diff(escapedChars)
     } yield {
@@ -90,7 +90,7 @@ class UtilityTest {
   }
 
   @Test
-  def escapeEscapablesTest: Unit = {
+  def escapeEscapablesTest(): Unit = {
     for {
       char <- escapedChars
     } yield {
@@ -99,7 +99,7 @@ class UtilityTest {
   }
 
   @Test
-  def escapeAsciiControlCharsTest: Unit = {
+  def escapeAsciiControlCharsTest(): Unit = {
 
     /* Escapes that Scala (Java) doesn't support.
      * \u0007 -> \a  (bell)
@@ -107,18 +107,18 @@ class UtilityTest {
      * \u000B -> \v  (vertical tab)
      * \u007F -> DEL (delete)
      */
-    val input = " \u0007\b\u001B\f\n\r\t\u000B\u007F"
+    val input: String = " \u0007\b\u001B\f\n\r\t\u000B\u007F"
 
-    val expect = " \n\r\t\u007F"
+    val expect: String = " \n\r\t\u007F"
 
-    val result = Utility.escape(input)
+    val result: String = Utility.escape(input)
 
     assertEquals(printfc(expect), printfc(result)) // Pretty,
     assertEquals(expect, result)                   // but verify.
   }
 
   @Test
-  def escapeUnicodeExtendedControlCodesTest: Unit = {
+  def escapeUnicodeExtendedControlCodesTest(): Unit = {
     for {
       char <- '\u0080' to '\u009f' // Extended control codes (C1)
     } yield {
@@ -127,7 +127,7 @@ class UtilityTest {
   }
 
   @Test
-  def escapeUnicodeTwoBytesTest: Unit = {
+  def escapeUnicodeTwoBytesTest(): Unit = {
     for {
       char <- '\u00A0' to '\u07FF' // Two bytes (cont.)
     } yield {
@@ -136,7 +136,7 @@ class UtilityTest {
   }
 
   @Test
-  def escapeUnicodeThreeBytesTest: Unit = {
+  def escapeUnicodeThreeBytesTest(): Unit = {
     for {
       char <- '\u0800' to '\uFFFF' // Three bytes
     } yield {
@@ -151,7 +151,7 @@ class UtilityTest {
    * 
    * Or think of `printf("%c", i)` in C, but a little better.
    */
-  def printfc(str: String) = {
+  def printfc(str: String): String = {
     str.map(prettyChar).mkString
   }
 
@@ -197,26 +197,26 @@ class UtilityTest {
     (key: Char) => key.toString
   }
 
-  def issue73StartsWithAndEndsWithWSInFirst: Unit = {
-    val x = <div>{Text("    My name is ")}{Text("Harry")}</div>
+  def issue73StartsWithAndEndsWithWSInFirst(): Unit = {
+    val x: Elem = <div>{Text("    My name is ")}{Text("Harry")}</div>
     assertEquals(<div>My name is Harry</div>, Utility.trim(x))
   }
 
   @Test
-  def issue73EndsWithWSInLast: Unit = {
-    val x = <div>{Text("My name is ")}{Text("Harry    ")}</div>
+  def issue73EndsWithWSInLast(): Unit = {
+    val x: Elem = <div>{Text("My name is ")}{Text("Harry    ")}</div>
     assertEquals(<div>My name is Harry</div>, Utility.trim(x)) 
   }
 
   @Test
-  def issue73HasWSInMiddle: Unit = {
-    val x = <div>{Text("My name is")}{Text(" ")}{Text("Harry")}</div>
+  def issue73HasWSInMiddle(): Unit = {
+    val x: Elem = <div>{Text("My name is")}{Text(" ")}{Text("Harry")}</div>
     assertEquals(<div>My name is Harry</div>, Utility.trim(x))
   }
 
   @Test
-  def issue73HasWSEverywhere: Unit = {
-    val x = <div>{Text("   My name ")}{Text("  is  ")}{Text("  Harry   ")}</div>
+  def issue73HasWSEverywhere(): Unit = {
+    val x: Elem = <div>{Text("   My name ")}{Text("  is  ")}{Text("  Harry   ")}</div>
     assertEquals(<div>My name is Harry</div>, Utility.trim(x))
   }
 }

--- a/shared/src/test/scala/scala/xml/XMLEmbeddingTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLEmbeddingTest.scala
@@ -6,13 +6,12 @@ import org.junit.Assert.assertEquals
 class XMLEmbeddingTest {
 
   @Test
-  def basic: Unit = {
-    val ya = <x>{{</x>
+  def basic(): Unit = {
+    val ya: Elem = <x>{{</x>
     assertEquals("{", ya.text)
-    val ua = <x>}}</x>
+    val ua: Elem = <x>}}</x>
     assertEquals("}", ua.text)
-    val za = <x>{{}}{{}}{{}}</x>
+    val za: Elem = <x>{{}}{{}}{{}}</x>
     assertEquals("{}{}{}", za.text)
   }
-
 }

--- a/shared/src/test/scala/scala/xml/XMLSyntaxTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLSyntaxTest.scala
@@ -14,37 +14,37 @@ class XMLSyntaxTest {
 
   @Test
   def test1(): Unit = {
-    val xNull = <hello>{null}</hello> // these used to be Atom(unit), changed to empty children
+    val xNull: Elem = <hello>{null}</hello> // these used to be Atom(unit), changed to empty children
     assertTrue(xNull.child sameElements Nil)
 
-    val x0 = <hello>{}</hello> // these used to be Atom(unit), changed to empty children
-    val x00 = <hello>{ }</hello> //  dto.
-    val xa = <hello>{ "world" }</hello>
+    val x0: Elem = <hello>{}</hello> // these used to be Atom(unit), changed to empty children
+    val x00: Elem = <hello>{ }</hello> //  dto.
+    val xa: Elem = <hello>{ "world" }</hello>
 
     assertTrue(x0.child sameElements Nil)
     assertTrue(x00.child sameElements Nil)
     assertEquals("world", handle[String](xa))
 
-    val xb = <hello>{ 1.5 }</hello>
+    val xb: Elem = <hello>{ 1.5 }</hello>
     assertEquals(1.5, handle[Double](xb), 0.0)
 
-    val xc = <hello>{ 5 }</hello>
+    val xc: Elem = <hello>{ 5 }</hello>
     assertEquals(5, handle[Int](xc).toLong)
 
-    val xd = <hello>{ true }</hello>
+    val xd: Elem = <hello>{ true }</hello>
     assertEquals(true, handle[Boolean](xd))
 
-    val xe = <hello>{ 5:Short }</hello>
+    val xe: Elem = <hello>{ 5:Short }</hello>
     assertEquals((5:Short).toLong, handle[Short](xe).toLong)
 
-    val xf = <hello>{ val x = 27; x }</hello>
+    val xf: Elem = <hello>{ val x = 27; x }</hello>
     assertEquals(27, handle[Int](xf).toLong)
 
-    val xg = <hello>{ List(1,2,3,4) }</hello>
+    val xg: Elem = <hello>{ List(1,2,3,4) }</hello>
     assertEquals("<hello>1 2 3 4</hello>", xg.toString)
     assertFalse(xg.child.map(_.isInstanceOf[Text]).exists(identity))
 
-    val xh = <hello>{ for(x <- List(1,2,3,4) if x % 2 == 0) yield x }</hello>
+    val xh: Elem = <hello>{ for(x <- List(1,2,3,4) if x % 2 == 0) yield x }</hello>
     assertEquals("<hello>2 4</hello>", xh.toString)
     assertFalse(xh.child.map(_.isInstanceOf[Text]).exists(identity))
   }
@@ -55,12 +55,11 @@ class XMLSyntaxTest {
   @Test
   def test2(): Unit = {
     val x1: Option[Seq[Node]] = Some(<b>hello</b>)
-    val n1 = <elem key={x1} />
+    val n1: Elem = <elem key={x1} />
     assertEquals(x1, n1.attribute("key"))
 
     val x2: Option[Seq[Node]] = None
-    val n2 = <elem key={x2} />
+    val n2: Elem = <elem key={x2} />
     assertEquals(x2, n2.attribute("key"))
   }
-
 }

--- a/shared/src/test/scala/scala/xml/dtd/DeclTest.scala
+++ b/shared/src/test/scala/scala/xml/dtd/DeclTest.scala
@@ -7,7 +7,7 @@ import org.junit.Assert.assertEquals
 class DeclTest {
 
   @Test
-  def elemDeclToString: Unit = {
+  def elemDeclToString(): Unit = {
     assertEquals(
       "<!ELEMENT x (#PCDATA)>",
       ElemDecl("x", PCDATA).toString
@@ -15,14 +15,14 @@ class DeclTest {
   }
 
   @Test
-  def attListDeclToString: Unit = {
+  def attListDeclToString(): Unit = {
 
-    val expected =
+    val expected: String =
       """|<!ATTLIST x
          |  y CDATA #REQUIRED
          |  z CDATA #REQUIRED>""".stripMargin
 
-    val actual = AttListDecl("x",
+    val actual: String = AttListDecl("x",
       List(
         AttrDecl("y", "CDATA", REQUIRED),
         AttrDecl("z", "CDATA", REQUIRED)
@@ -33,7 +33,7 @@ class DeclTest {
   }
 
   @Test
-  def parsedEntityDeclToString: Unit = {
+  def parsedEntityDeclToString(): Unit = {
     assertEquals(
       """<!ENTITY foo SYSTEM "bar">""",
       ParsedEntityDecl("foo", ExtDef(SystemID("bar"))).toString

--- a/shared/src/test/scala/scala/xml/parsing/PiParsingTest.scala
+++ b/shared/src/test/scala/scala/xml/parsing/PiParsingTest.scala
@@ -6,15 +6,14 @@ import scala.xml.JUnitAssertsForXML.assertEquals
 class PiParsingTest {
 
   @Test
-  def piNoWSLiteral: Unit = {
-    val expected = "<foo>a<?pi?>b</foo>"
+  def piNoWSLiteral(): Unit = {
+    val expected: String = "<foo>a<?pi?>b</foo>"
     assertEquals(expected, <foo>a<?pi?>b</foo>)
   }
 
   @Test
-  def piLiteral: Unit = {
-    val expected = "<foo> a <?pi?> b </foo>"
+  def piLiteral(): Unit = {
+    val expected: String = "<foo> a <?pi?> b </foo>"
     assertEquals(expected, <foo> a <?pi?> b </foo>)
   }
-
 }

--- a/shared/src/test/scala/scala/xml/parsing/Ticket0632Test.scala
+++ b/shared/src/test/scala/scala/xml/parsing/Ticket0632Test.scala
@@ -6,24 +6,23 @@ import scala.xml.JUnitAssertsForXML.assertEquals
 class Ticket0632Test {
 
   @Test
-  def singleAmp: Unit = {
-    val expected = "<foo x=\"&amp;\"/>"
+  def singleAmp(): Unit = {
+    val expected: String = "<foo x=\"&amp;\"/>"
     assertEquals(expected, <foo x="&amp;"/>)
     assertEquals(expected, <foo x={ "&" }/>)
   }
 
   @Test
-  def oneAndHalfAmp: Unit = {
-    val expected = "<foo x=\"&amp;amp;\"/>"
+  def oneAndHalfAmp(): Unit = {
+    val expected: String = "<foo x=\"&amp;amp;\"/>"
     assertEquals(expected, <foo x="&amp;amp;"/>)
     assertEquals(expected, <foo x={ "&amp;" }/>)
   }
 
   @Test
-  def doubleAmp: Unit = {
-    val expected = "<foo x=\"&amp;&amp;\"/>"
+  def doubleAmp(): Unit = {
+    val expected: String = "<foo x=\"&amp;&amp;\"/>"
     assertEquals(expected, <foo x="&amp;&amp;"/>)
     assertEquals(expected, <foo x={ "&&" }/>)
   }
-
 }


### PR DESCRIPTION
Added type annotations for `val`s, `var`s and `def`s that did not have them; primary motivation: clarity.
Types inferred by IDEs like IntelliJ Idea are not always the types inferred by the Scala compiler.
In fact, different _versions_ of the Scala compiler infer types _differently_!
As a result, in around 20 places it is impossible to add missing type annotations without breaking binary compatibility...