### PR TITLE
Fix infinite loop caused by unclosed character ref

### DIFF
--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -392,7 +392,7 @@ object Utility extends AnyRef with parsing.TokenTests {
     val hex: Boolean = (ch() == 'x') && { nextch(); true }
     val base: Int = if (hex) 16 else 10
     var i: Int = 0
-    while (ch() != ';') {
+    while (ch() != ';' && ch() != 0) {
       ch() match {
         case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
           i = i * base + ch().asDigit
@@ -410,6 +410,6 @@ object Utility extends AnyRef with parsing.TokenTests {
       }
       nextch()
     }
-    new String(Array(i), 0, 1)
+    if (i != 0) new String(Array(i), 0, 1) else ""
   }
 }

--- a/shared/src/test/scala/scala/xml/UtilityTest.scala
+++ b/shared/src/test/scala/scala/xml/UtilityTest.scala
@@ -219,4 +219,15 @@ class UtilityTest {
     val x: Elem = <div>{Text("   My name ")}{Text("  is  ")}{Text("  Harry   ")}</div>
     assertEquals(<div>My name is Harry</div>, Utility.trim(x))
   }
+
+  @Test
+  def issue306InvalidUnclosedEntity(): Unit = {
+    val entity = "&# test </body></html>"
+    val it: Iterator[Char] = entity.iterator
+    var c = it.next()
+    val next = () => if (it.hasNext) c = it.next() else c = 0.asInstanceOf[Char]
+    val result = Utility.parseCharRef({ () => c }, next, _ => {}, _ => {})
+    assertEquals("", result)
+  }
+
 }


### PR DESCRIPTION
Resolves #306

If parseCharRef is called for an unclosed character reference it will get caught in an infinite loop if the end of file is reached. Add a check to exit the loop when an EOF is encountered.