### PR TITLE
cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,7 +150,7 @@ lazy val xml = crossProject(JSPlatform, JVMPlatform, NativePlatform)
           retrieveDir,
           log
         )
-        .fold(w => throw w.resolveException, identity(_))
+        .fold(w => throw w.resolveException, identity)
       val jarPath = cp
         .find(_.toString.contains("junit-plugin"))
         .getOrElse(throw new Exception("Can't find Scala Native junit-plugin jar"))

--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -33,7 +33,7 @@ class XMLTestJVM {
   def equality(): Unit = {
     val c: Node = new Node {
       override def label: String = "hello"
-      override def hashCode(): Int =
+      override def hashCode: Int =
         Utility.hashCode(prefix, label, this.attributes.hashCode(), scope.hashCode(), child)
       override def child: Seq[Node] = Elem(null, "world", e, sc)
       //def attributes = e
@@ -54,7 +54,6 @@ class XMLTestJVM {
       Elem(null, "author", e, sc, Text("Peter Buneman")),
       Elem(null, "author", e, sc, Text("Dan Suciu")),
       Elem(null, "title", e, sc, Text("Data on ze web"))), x2p)
-
   }
 
   @UnitTest
@@ -640,7 +639,7 @@ class XMLTestJVM {
     parserFactory.setNamespaceAware(namespaceAware)
     parserFactory.setXIncludeAware(namespaceAware)
 
-    assertEquals(xml, XML.withSAXParser(parserFactory.newSAXParser).loadString(xml).toString())
+    assertEquals(xml, XML.withSAXParser(parserFactory.newSAXParser).loadString(xml).toString)
   }
 
   @UnitTest

--- a/shared/src/main/scala/scala/xml/Attribute.scala
+++ b/shared/src/main/scala/scala/xml/Attribute.scala
@@ -65,10 +65,10 @@ trait Attribute extends MetaData {
 
   override def remove(key: String): MetaData =
     if (!isPrefixed && this.key == key) next
-    else copy(next remove key)
+    else copy(next.remove(key))
 
   override def remove(namespace: String, scope: NamespaceBinding, key: String): MetaData =
-    if (this.key == key && (scope getURI pre) == namespace) next
+    if (this.key == key && scope.getURI(pre) == namespace) next
     else copy(next.remove(namespace, scope, key))
 
   override def isPrefixed: Boolean = pre != null
@@ -76,8 +76,8 @@ trait Attribute extends MetaData {
   override def getNamespace(owner: Node): String
 
   override def wellformed(scope: NamespaceBinding): Boolean = {
-    val arg: String = if (isPrefixed) scope getURI pre else null
-    (next(arg, scope, key) == null) && (next wellformed scope)
+    val arg: String = if (isPrefixed) scope.getURI(pre) else null
+    (next(arg, scope, key) == null) && next.wellformed(scope)
   }
 
   /** Returns an iterator on attributes */
@@ -98,9 +98,9 @@ trait Attribute extends MetaData {
     if (value == null)
       return
     if (isPrefixed)
-      sb append pre append ':'
+      sb.append(pre).append(':')
 
-    sb append key append '='
+    sb.append(key).append('=')
     val sb2: StringBuilder = new StringBuilder()
     Utility.sequenceToXML(value, TopScope, sb2, stripComments = true)
     Utility.appendQuoted(sb2.toString, sb)

--- a/shared/src/main/scala/scala/xml/Equality.scala
+++ b/shared/src/main/scala/scala/xml/Equality.scala
@@ -85,7 +85,7 @@ trait Equality extends scala.Equals {
    *  which heads off a lot of inconsistency up front.
    */
   override def canEqual(other: Any): Boolean = other match {
-    case x: Equality => true
+    case _: Equality => true
     case _           => false
   }
 
@@ -96,7 +96,7 @@ trait Equality extends scala.Equals {
    *  are final since clearly individual classes cannot be trusted
    *  to maintain a semblance of order.
    */
-  override def hashCode(): Int = basisForHashCode.##
+  override def hashCode: Int = basisForHashCode.##
   override def equals(other: Any): Boolean = doComparison(other, blithe = false)
   final def xml_==(other: Any): Boolean = doComparison(other, blithe = true)
   final def xml_!=(other: Any): Boolean = !xml_==(other)

--- a/shared/src/main/scala/scala/xml/Group.scala
+++ b/shared/src/main/scala/scala/xml/Group.scala
@@ -24,7 +24,7 @@ final case class Group(nodes: Seq[Node]) extends Node {
   override def theSeq: Seq[Node] = nodes
 
   override def canEqual(other: Any): Boolean = other match {
-    case x: Group => true
+    case _: Group => true
     case _        => false
   }
 

--- a/shared/src/main/scala/scala/xml/MetaData.scala
+++ b/shared/src/main/scala/scala/xml/MetaData.scala
@@ -75,7 +75,7 @@ object MetaData {
  *  attributes. Every instance of this class is either
  *  - an instance of `UnprefixedAttribute key,value` or
  *  - an instance of `PrefixedAttribute namespace_prefix,key,value` or
- *  - `Null, the empty attribute list.
+ *  - `Null`, the empty attribute list.
  *
  *  Namespace URIs are obtained by using the namespace scope of the element
  *  owning this attribute (see `getNamespace`).
@@ -204,17 +204,17 @@ abstract class MetaData
    * @param  uri namespace of key
    * @param  scope a namespace scp (usually of the element owning this attribute list)
    * @param  key to be looked fore
-   * @return value as Some[Seq[Node]] if key is found, None otherwise
+   * @return value as `Some[Seq[Node]]` if key is found, None otherwise
    */
   final def get(uri: String, scope: NamespaceBinding, key: String): Option[Seq[Node]] =
     Option(apply(uri, scope, key))
 
-  protected def toString1(): String = sbToString(toString1)
+  protected def toString1: String = sbToString(toString1)
 
   // appends string representations of single attribute to StringBuilder
   protected def toString1(sb: StringBuilder): Unit
 
-  override def toString(): String = sbToString(buildString)
+  override def toString: String = sbToString(buildString)
 
   def buildString(sb: StringBuilder): StringBuilder = {
     sb append ' '

--- a/shared/src/main/scala/scala/xml/Node.scala
+++ b/shared/src/main/scala/scala/xml/Node.scala
@@ -140,8 +140,8 @@ abstract class Node extends NodeSeq {
   def descendant_or_self: List[Node] = this :: descendant
 
   override def canEqual(other: Any): Boolean = other match {
-    case x: Group => false
-    case x: Node  => true
+    case _: Group => false
+    case _: Node  => true
     case _        => false
   }
 
@@ -178,7 +178,7 @@ abstract class Node extends NodeSeq {
   /**
    * Same as `toString('''false''')`.
    */
-  override def toString(): String = buildString(stripComments = false)
+  override def toString: String = buildString(stripComments = false)
 
   /**
    * Appends qualified name of this node to `StringBuilder`.
@@ -194,7 +194,7 @@ abstract class Node extends NodeSeq {
   /**
    * Returns a type symbol (e.g. DTD, XSD), default `'''null'''`.
    */
-  def xmlType(): TypeSymbol = null
+  def xmlType: TypeSymbol = null
 
   /**
    * Returns a text representation of this node. Note that this is not equivalent to

--- a/shared/src/main/scala/scala/xml/NodeSeq.scala
+++ b/shared/src/main/scala/scala/xml/NodeSeq.scala
@@ -102,7 +102,7 @@ abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with S
         else if (that(1) == '{') {
           val i: Int = that indexOf '}'
           if (i == -1) fail
-          val (uri: String, key: String) = (that.substring(2, i), that.substring(i + 1, that.length()))
+          val (uri: String, key: String) = (that.substring(2, i), that.substring(i + 1, that.length))
           if (uri == "" || key == "") fail
           else y.attribute(uri, key)
         } else y.attribute(that drop 1)
@@ -128,7 +128,7 @@ abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with S
   /**
    * Projection function, which returns elements of `this` sequence and of
    *  all its subsequences, based on the string `that`. Use:
-   *   - `this \\ "foo" to get a list of all elements that are labelled with `"foo"`,
+   *   - `this \\ "foo"` to get a list of all elements that are labelled with "foo"`,
    *     including `this`;
    *   - `this \\ "_"` to get a list of all elements (wildcard), including `this`;
    *   - `this \\ "@foo"` to get all unprefixed attributes `"foo"`;
@@ -159,7 +159,7 @@ abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with S
    */
   def \@(attributeName: String): String = (this \ ("@" + attributeName)).text
 
-  override def toString(): String = theSeq.mkString
+  override def toString: String = theSeq.mkString
 
   def text: String = (this map (_.text)).mkString
 }

--- a/shared/src/main/scala/scala/xml/Null.scala
+++ b/shared/src/main/scala/scala/xml/Null.scala
@@ -13,7 +13,6 @@
 package scala
 package xml
 
-import Utility.isNameStart
 import scala.collection.Iterator
 import scala.collection.Seq
 
@@ -50,13 +49,13 @@ case object Null extends MetaData {
 
   override def apply(namespace: String, scope: NamespaceBinding, key: String) /* TODO type annotation */ = null
   override def apply(key: String) /* TODO type annotation */ =
-    if (isNameStart(key.head)) null
+    if (Utility.isNameStart(key.head)) null
     else throw new IllegalArgumentException("not a valid attribute name '" + key + "', so can never match !")
 
   override protected def toString1(sb: StringBuilder): Unit = ()
-  override protected def toString1(): String = ""
+  override protected def toString1: String = ""
 
-  override def toString(): String = ""
+  override def toString: String = ""
 
   override def buildString(sb: StringBuilder): StringBuilder = sb
 

--- a/shared/src/main/scala/scala/xml/PrettyPrinter.scala
+++ b/shared/src/main/scala/scala/xml/PrettyPrinter.scala
@@ -150,11 +150,11 @@ class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean) {
 
   protected def traverse(node: Node, pscope: NamespaceBinding, ind: Int): Unit = node match {
 
-    case Text(s) if s.trim() == "" =>
+    case Text(s) if s.trim == "" =>
 
     case _: Atom[_] | _: Comment | _: EntityRef | _: ProcInstr =>
-      makeBox(ind, node.toString().trim())
-    case g@Group(xs) =>
+      makeBox(ind, node.toString.trim)
+    case Group(xs) =>
       traverse(xs.iterator, pscope, ind)
     case _ =>
       val test: String = {

--- a/shared/src/main/scala/scala/xml/SpecialNode.scala
+++ b/shared/src/main/scala/scala/xml/SpecialNode.scala
@@ -24,7 +24,7 @@ abstract class SpecialNode extends Node {
   /** always empty */
   final override def attributes: Null.type = Null
 
-  /** always Node.EmptyNamespace */
+  /** always Node.EmptyNamespace - TODO not really: Node.EmptyNamespace is "", but this is null. */
   final override def namespace: scala.Null = null
 
   /** always empty */

--- a/shared/src/main/scala/scala/xml/TopScope.scala
+++ b/shared/src/main/scala/scala/xml/TopScope.scala
@@ -28,7 +28,7 @@ object TopScope extends NamespaceBinding(null, null, null) {
   override def getPrefix(uri1: String): String =
     if (uri1 == namespace) xml else null
 
-  override def toString(): String = ""
+  override def toString: String = ""
 
   override def buildString(stop: NamespaceBinding): String = ""
   override def buildString(sb: StringBuilder, ignore: NamespaceBinding): Unit = ()

--- a/shared/src/main/scala/scala/xml/Utility.scala
+++ b/shared/src/main/scala/scala/xml/Utility.scala
@@ -28,7 +28,7 @@ object Utility extends AnyRef with parsing.TokenTests {
 
   // [Martin] This looks dubious. We don't convert StringBuilders to
   // Strings anywhere else, why do it here?
-  implicit def implicitSbToString(sb: StringBuilder): String = sb.toString()
+  implicit def implicitSbToString(sb: StringBuilder): String = sb.toString
 
   // helper for the extremely oft-repeated sequence of creating a
   // StringBuilder, passing it around, and then grabbing its String.
@@ -50,7 +50,7 @@ object Utility extends AnyRef with parsing.TokenTests {
    */
   def trim(x: Node): Node = x match {
     case Elem(pre, lab, md, scp, child@_*) =>
-      val children: Seq[Node] = combineAdjacentTextNodes(child) flatMap trimProper
+      val children: Seq[Node] = combineAdjacentTextNodes(child).flatMap(trimProper)
       Elem(pre, lab, md, scp, children.isEmpty, children: _*)
   }
 
@@ -67,7 +67,7 @@ object Utility extends AnyRef with parsing.TokenTests {
    */
   def trimProper(x: Node): Seq[Node] = x match {
     case Elem(pre, lab, md, scp, child@_*) =>
-      val children: Seq[Node] = combineAdjacentTextNodes(child) flatMap trimProper
+      val children: Seq[Node] = combineAdjacentTextNodes(child).flatMap(trimProper)
       Elem(pre, lab, md, scp, children.isEmpty, children: _*)
     case Text(s) =>
       new TextBuffer().append(s).toText
@@ -173,7 +173,7 @@ object Utility extends AnyRef with parsing.TokenTests {
   //   minimizeTags: Boolean = false): String =
   // {
   //   toXMLsb(x, pscope, sb, stripComments, decodeEntities, preserveWhitespace, minimizeTags)
-  //   sb.toString()
+  //   sb.toString
   // }
 
   /**
@@ -263,13 +263,16 @@ object Utility extends AnyRef with parsing.TokenTests {
       } else children foreach { serialize(_, pscope, sb, stripComments, decodeEntities, preserveWhitespace, minimizeTags) }
     }
 
+  def splitName(name: String): (Option[String], String) = {
+    val colon: Int = name.indexOf(':')
+    if (colon < 0) (None, name)
+    else (Some(name.take(colon)), name.drop(colon + 1))
+  }
+
   /**
    * Returns prefix of qualified name if any.
    */
-  final def prefix(name: String): Option[String] = name.indexOf(':') match {
-    case -1 => None
-    case i  => Some(name.substring(0, i))
-  }
+  final def prefix(name: String): Option[String] = splitName(name)._1
 
   /**
    * Returns a hashcode for the given constituents of a node
@@ -357,12 +360,12 @@ object Utility extends AnyRef with parsing.TokenTests {
             rfb.append(c)
             c = it.next()
           }
-          val ref: String = rfb.toString()
+          val ref: String = rfb.toString
           rfb.clear()
           unescape(ref, sb) match {
             case null =>
               if (sb.nonEmpty) { // flush buffer
-                nb += Text(sb.toString())
+                nb += Text(sb.toString)
                 sb.clear()
               }
               nb += EntityRef(ref) // add entityref
@@ -372,7 +375,7 @@ object Utility extends AnyRef with parsing.TokenTests {
       } else sb append c
     }
     if (sb.nonEmpty) { // flush buffer
-      val x: Text = Text(sb.toString())
+      val x: Text = Text(sb.toString)
       if (nb.isEmpty)
         return x
       else

--- a/shared/src/main/scala/scala/xml/XML.scala
+++ b/shared/src/main/scala/scala/xml/XML.scala
@@ -117,7 +117,7 @@ object XML extends XMLLoader[Elem] {
   final def write(w: java.io.Writer, node: Node, enc: String, xmlDecl: Boolean, doctype: dtd.DocType, minimizeTags: MinimizeMode.Value = MinimizeMode.Default): Unit = {
     /* TODO: optimize by giving writer parameter to toXML*/
     if (xmlDecl) w.write("<?xml version='1.0' encoding='" + enc + "'?>\n")
-    if (doctype ne null) w.write(doctype.toString() + "\n")
+    if (doctype ne null) w.write(doctype.toString + "\n")
     w.write(Utility.serialize(node, minimizeTags = minimizeTags).toString)
   }
 }

--- a/shared/src/main/scala/scala/xml/dtd/Decl.scala
+++ b/shared/src/main/scala/scala/xml/dtd/Decl.scala
@@ -150,22 +150,22 @@ case class PEReference(ent: String) extends MarkupDecl {
 // default declarations for attributes
 
 sealed abstract class DefaultDecl {
-  override def toString(): String
+  def toString: String
   def buildString(sb: StringBuilder): StringBuilder
 }
 
 case object REQUIRED extends DefaultDecl {
-  override def toString(): String = "#REQUIRED"
+  override def toString: String = "#REQUIRED"
   override def buildString(sb: StringBuilder): StringBuilder = sb append "#REQUIRED"
 }
 
 case object IMPLIED extends DefaultDecl {
-  override def toString(): String = "#IMPLIED"
+  override def toString: String = "#IMPLIED"
   override def buildString(sb: StringBuilder): StringBuilder = sb append "#IMPLIED"
 }
 
 case class DEFAULT(fixed: Boolean, attValue: String) extends DefaultDecl {
-  override def toString(): String = sbToString(buildString)
+  override def toString: String = sbToString(buildString)
   override def buildString(sb: StringBuilder): StringBuilder = {
     if (fixed) sb append "#FIXED "
     Utility.appendEscapedQuoted(attValue, sb)

--- a/shared/src/main/scala/scala/xml/dtd/DocType.scala
+++ b/shared/src/main/scala/scala/xml/dtd/DocType.scala
@@ -35,7 +35,7 @@ case class DocType(name: String, extID: ExternalID, intSubset: Seq[dtd.Decl]) {
       if (intSubset.isEmpty) ""
       else intSubset.mkString("[", "", "]")
 
-    """<!DOCTYPE %s %s%s>""".format(name, extID.toString(), intString)
+    """<!DOCTYPE %s %s%s>""".format(name, extID.toString, intString)
   }
 }
 

--- a/shared/src/main/scala/scala/xml/dtd/ExternalID.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ExternalID.scala
@@ -36,7 +36,7 @@ sealed abstract class ExternalID extends parsing.TokenTests {
       (if (systemId == null) "" else " " + quotedSystemLiteral)
   }
   def buildString(sb: StringBuilder): StringBuilder =
-    sb.append(this.toString())
+    sb.append(this.toString)
 
   def systemId: String
   def publicId: String

--- a/shared/src/main/scala/scala/xml/dtd/ValidationException.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ValidationException.scala
@@ -37,7 +37,7 @@ object MakeValidationException {
     val sb: StringBuilder = new StringBuilder("missing value for REQUIRED attribute")
     if (allKeys.size > 1) sb.append('s')
     allKeys foreach (k => sb append "'%s'".format(k))
-    ValidationException(sb.toString())
+    ValidationException(sb.toString)
   }
 
   def fromMissingAttribute(key: String, tpe: String): ValidationException =

--- a/shared/src/main/scala/scala/xml/dtd/impl/BaseBerrySethi.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/BaseBerrySethi.scala
@@ -20,7 +20,7 @@ import scala.collection.Seq
 
 /**
  * This class turns a regular expression over `A` into a
- * [[scala.util.automata.NondetWordAutom]] over `A` using the celebrated
+ * [[scala.xml.dtd.impl.NondetWordAutom]] over `A` using the celebrated
  * position automata construction (also called ''Berry-Sethi'' or ''Glushkov'').
  */
 @deprecated("This class will be removed", "2.10.0")

--- a/shared/src/main/scala/scala/xml/dtd/impl/DetWordAutom.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/DetWordAutom.scala
@@ -39,7 +39,7 @@ private[dtd] abstract class DetWordAutom[T <: AnyRef] {
     sb.append(nstates)
     sb.append(" finals=")
     val map: Map[Int, Int] = finals.zipWithIndex.map(_.swap).toMap
-    sb.append(map.toString())
+    sb.append(map.toString)
     sb.append(" delta=\n")
 
     for (i <- 0 until nstates) {

--- a/shared/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
@@ -17,7 +17,7 @@ import scala.collection.{immutable, mutable}
 import scala.collection.Seq
 
 /**
- * This class turns a regular expression into a [[scala.util.automata.NondetWordAutom]]
+ * This class turns a regular expression into a [[scala.xml.dtd.impl.NondetWordAutom]]
  * celebrated position automata construction (also called ''Berry-Sethi'' or ''Glushkov'').
  *
  *  @author Burak Emir

--- a/shared/src/main/scala/scala/xml/factory/XMLLoader.scala
+++ b/shared/src/main/scala/scala/xml/factory/XMLLoader.scala
@@ -30,7 +30,7 @@ trait XMLLoader[T <: Node] {
 
   private lazy val parserInstance: ThreadLocal[SAXParser] = new ThreadLocal[SAXParser] {
     override def initialValue: SAXParser = {
-      val parser: SAXParserFactory = SAXParserFactory.newInstance()
+      val parser: SAXParserFactory = SAXParserFactory.newInstance
       parser.setFeature("http://javax.xml.XMLConstants/feature/secure-processing", true)
       parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
       parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
@@ -39,7 +39,7 @@ trait XMLLoader[T <: Node] {
       parser.setFeature("http://xml.org/sax/features/resolve-dtd-uris", false)
       parser.setXIncludeAware(false)
       parser.setNamespaceAware(false)
-      parser.newSAXParser()
+      parser.newSAXParser
     }
   }
 

--- a/shared/src/main/scala/scala/xml/include/XIncludeException.scala
+++ b/shared/src/main/scala/scala/xml/include/XIncludeException.scala
@@ -57,5 +57,5 @@ class XIncludeException(message: String) extends Exception(message) {
    * @return Throwable   the underlying exception which caused the
    *                     `XIncludeException` to be thrown
    */
-  def getRootCause(): Throwable = this.rootCause
+  def getRootCause: Throwable = this.rootCause
 }

--- a/shared/src/main/scala/scala/xml/include/sax/XIncludeFilter.scala
+++ b/shared/src/main/scala/scala/xml/include/sax/XIncludeFilter.scala
@@ -94,7 +94,7 @@ class XIncludeFilter extends XMLFilterImpl {
     try {
       bases.push(new URL(base))
     } catch {
-      case e: MalformedURLException =>
+      case _: MalformedURLException =>
         throw new UnsupportedOperationException("Unrecognized SYSTEM ID: " + base)
     }
     super.setDocumentLocator(locator)
@@ -113,7 +113,7 @@ class XIncludeFilter extends XMLFilterImpl {
    *
    * @return boolean
    */
-  def insideIncludeElement(): Boolean = level != 0
+  def insideIncludeElement: Boolean = level != 0
 
   override def startElement(uri: String, localName: String, qName: String, atts1: Attributes): Unit = {
     var atts: Attributes = atts1
@@ -222,9 +222,9 @@ class XIncludeFilter extends XMLFilterImpl {
   }
 
   // convenience method for error messages
-  private def getLocation(): String = {
+  private def getLocation: String = {
     var locationString: String = ""
-    val locator: Locator = locators.peek()
+    val locator: Locator = locators.peek
     var publicID: String = ""
     var systemID: String = ""
     var column: Int = -1
@@ -256,21 +256,21 @@ class XIncludeFilter extends XMLFilterImpl {
    */
   private def includeTextDocument(url: String, encoding1: String): Unit = {
     var encoding: String = encoding1
-    if (encoding == null || encoding.trim().equals("")) encoding = "UTF-8"
+    if (encoding == null || encoding.trim.equals("")) encoding = "UTF-8"
     var source: URL = null
     try {
-      val base: URL = bases.peek()
+      val base: URL = bases.peek
       source = new URL(base, url)
     } catch {
       case e: MalformedURLException =>
         val ex: UnavailableResourceException = new UnavailableResourceException("Unresolvable URL " + url
-          + getLocation())
+          + getLocation)
         ex.setRootCause(e)
-        throw new SAXException("Unresolvable URL " + url + getLocation(), ex)
+        throw new SAXException("Unresolvable URL " + url + getLocation, ex)
     }
 
     try {
-      val uc: URLConnection = source.openConnection()
+      val uc: URLConnection = source.openConnection
       val in: BufferedInputStream = new BufferedInputStream(uc.getInputStream)
       val encodingFromHeader: String = uc.getContentEncoding
       var contentType: String = uc.getContentType
@@ -281,7 +281,7 @@ class XIncludeFilter extends XMLFilterImpl {
         // MIME types are case-insensitive
         // Java may be picking this up from file URL
         if (contentType != null) {
-          contentType = contentType.toLowerCase()
+          contentType = contentType.toLowerCase
           if (contentType.equals("text/xml")
             || contentType.equals("application/xml")
             || (contentType.startsWith("text/") && contentType.endsWith("+xml"))
@@ -300,12 +300,11 @@ class XIncludeFilter extends XMLFilterImpl {
     } catch {
       case e: UnsupportedEncodingException =>
         throw new SAXException("Unsupported encoding: "
-          + encoding + getLocation(), e)
+          + encoding + getLocation, e)
       case e: IOException =>
         throw new SAXException("Document not found: "
-          + source.toExternalForm + getLocation(), e)
+          + source.toExternalForm + getLocation, e)
     }
-
   }
 
   private var atRoot: Boolean = false
@@ -322,19 +321,19 @@ class XIncludeFilter extends XMLFilterImpl {
    */
   private def includeXMLDocument(url: String): Unit = {
     val source: URL =
-      try new URL(bases.peek(), url)
+      try new URL(bases.peek, url)
       catch {
         case e: MalformedURLException =>
-          val ex: UnavailableResourceException = new UnavailableResourceException("Unresolvable URL " + url + getLocation())
+          val ex: UnavailableResourceException = new UnavailableResourceException("Unresolvable URL " + url + getLocation)
           ex setRootCause e
-          throw new SAXException("Unresolvable URL " + url + getLocation(), ex)
+          throw new SAXException("Unresolvable URL " + url + getLocation, ex)
       }
 
     try {
       val parser: XMLReader =
         try XMLReaderFactory.createXMLReader()
         catch {
-          case e: SAXException =>
+          case _: SAXException =>
             try XMLReaderFactory.createXMLReader(XercesClassName)
             catch { case _: SAXException => return System.err.println("Could not find an XML parser") }
         }
@@ -350,7 +349,7 @@ class XIncludeFilter extends XMLFilterImpl {
       if (bases contains source)
         throw new SAXException(
           "Circular XInclude Reference",
-          new CircularIncludeException("Circular XInclude Reference to " + source + getLocation())
+          new CircularIncludeException("Circular XInclude Reference to " + source + getLocation)
         )
 
       bases push source
@@ -362,7 +361,7 @@ class XIncludeFilter extends XMLFilterImpl {
       bases.pop()
     } catch {
       case e: IOException =>
-        throw new SAXException("Document not found: " + source.toExternalForm + getLocation(), e)
+        throw new SAXException("Document not found: " + source.toExternalForm + getLocation, e)
     }
   }
 }

--- a/shared/src/main/scala/scala/xml/include/sax/XIncluder.scala
+++ b/shared/src/main/scala/scala/xml/include/sax/XIncluder.scala
@@ -170,7 +170,7 @@ class XIncluder(outs: OutputStream, encoding: String) extends ContentHandler wit
   }
 
   override def comment(ch: Array[Char], start: Int, length: Int): Unit = {
-    if (!inDTD && !filter.insideIncludeElement()) {
+    if (!inDTD && !filter.insideIncludeElement) {
       try {
         out.write("<!--")
         out.write(ch, start, length)

--- a/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
@@ -163,13 +163,6 @@ abstract class FactoryAdapter extends DefaultHandler2 with factory.XMLLoader[Nod
    */
   override def endCDATA(): Unit = captureText()
 
-  // TODO move into Utility
-  private def splitName(s: String): (Option[String], String) = {
-    val idx: Int = s indexOf ':'
-    if (idx < 0) (None, s)
-    else (Some(s take idx), s drop (idx + 1))
-  }
-
   /* ContentHandler methods */
 
   /* Start element. */
@@ -190,7 +183,7 @@ abstract class FactoryAdapter extends DefaultHandler2 with factory.XMLLoader[Nod
       tagStack = curTag :: tagStack
       curTag = qname
 
-      val localName: String = splitName(qname)._2
+      val localName: String = Utility.splitName(qname)._2
       capture = nodeContainsText(localName)
 
       hStack = null :: hStack
@@ -202,7 +195,7 @@ abstract class FactoryAdapter extends DefaultHandler2 with factory.XMLLoader[Nod
       for (i <- (0 until attributes.getLength).reverse) {
         val qname: String = attributes getQName i
         val value: String = attributes getValue i
-        val (pre: Option[String], key: String) = splitName(qname)
+        val (pre: Option[String], key: String) = Utility.splitName(qname)
         def nullIfEmpty(s: String): String = if (s == "") null else s
 
         if (pre.contains("xmlns") || (pre.isEmpty && qname == "xmlns")) {
@@ -263,7 +256,7 @@ abstract class FactoryAdapter extends DefaultHandler2 with factory.XMLLoader[Nod
       case null :: hs => hs
       case hs => hs
     }
-    val (pre: Option[String], localName: String) = splitName(qname)
+    val (pre: Option[String], localName: String) = Utility.splitName(qname)
     val scp: NamespaceBinding = scopeStack.head
     scopeStack = scopeStack.tail
 

--- a/shared/src/main/scala/scala/xml/parsing/MarkupHandler.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupHandler.scala
@@ -34,12 +34,8 @@ abstract class MarkupHandler {
   var decls: List[Decl] = Nil
   var ent: mutable.Map[String, EntityDecl] = new mutable.HashMap[String, EntityDecl]()
 
-  def lookupElemDecl(Label: String): ElemDecl = {
-    for (z@ElemDecl(Label, _) <- decls)
-      return z
-
-    null
-  }
+  def lookupElemDecl(Label: String): ElemDecl =
+    (for (case z@ElemDecl(Label, _) <- decls) yield z).headOption.orNull
 
   def replacementText(entityName: String): Source =
     Source.fromString(ent.get(entityName) match {

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
@@ -367,7 +367,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
       nextch()
     }
     nextch()
-    val str: String = cbuf.toString()
+    val str: String = cbuf.toString
     cbuf.setLength(0)
     str
   }
@@ -403,7 +403,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
         sb.setLength(sb.length - 1)
         nextch()
         xToken('>')
-        return handle.comment(pos, sb.toString())
+        return handle.comment(pos, sb.toString)
       } else sb.append(ch)
       nextch()
     }
@@ -582,11 +582,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
   def element1(pscope: NamespaceBinding): NodeSeq = {
     val pos: Int = this.pos
     val (qname: String, (aMap: MetaData, scope: NamespaceBinding)) = xTag(pscope)
-    // TODO move into Utility
-    val (pre: Option[String], local: String) = Utility.prefix(qname) match {
-      case Some(p) => (Some(p), qname drop p.length + 1)
-      case _       => (None, qname)
-    }
+    val (pre: Option[String], local: String) = Utility.splitName(qname)
     val ts: NodeSeq = {
       if (ch == '/') { // empty element
         xToken("/>")
@@ -640,7 +636,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
       nextch()
     }
     nextch()
-    val str: String = cbuf.toString()
+    val str: String = cbuf.toString
     cbuf.setLength(0)
     str
   }
@@ -809,7 +805,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
     }
     //Console.println("END["+ch+"]")
     nextch()
-    val cmstr: String = cbuf.toString()
+    val cmstr: String = cbuf.toString
     cbuf.setLength(0)
     handle.elemDecl(n, cmstr)
   }

--- a/shared/src/test/scala-2.x/scala/xml/XMLTest2x.scala
+++ b/shared/src/test/scala-2.x/scala/xml/XMLTest2x.scala
@@ -15,7 +15,7 @@ class XMLTest2x {
   @UnitTest
   def wsdl(): Unit = {
     assertEquals("""<wsdl:definitions name="service3" xmlns:tns="target3">
-    </wsdl:definitions>""", wsdlTemplate3("service3") toString)
+    </wsdl:definitions>""", wsdlTemplate3("service3").toString)
   }
 
   @UnitTest

--- a/shared/src/test/scala/scala/xml/NodeSeqTest.scala
+++ b/shared/src/test/scala/scala/xml/NodeSeqTest.scala
@@ -15,7 +15,7 @@ class NodeSeqTest {
     val b: Elem = <b>Hi</b>
     a ++ <b>Hi</b> match {
       case res: NodeSeq => assertEquals(2, res.size.toLong)
-      case res: Seq[Node] => fail("Should be NodeSeq was Seq[Node]") // Unreachable code?
+      case _: Seq[Node] => fail("Should be NodeSeq was Seq[Node]") // Unreachable code?
     }
     val res: NodeSeq = a ++ b
     val exp: NodeSeq = NodeSeq.fromSeq(Seq(<a>Hello</a>, <b>Hi</b>))
@@ -28,7 +28,7 @@ class NodeSeqTest {
     val b: Elem = <b>Hi</b>
     a :+ <b>Hi</b> match {
       case res: Seq[Node] => assertEquals(2, res.size.toLong)
-      case res: NodeSeq => fail("Should be Seq[Node] was NodeSeq") // Unreachable code?
+      case _: NodeSeq => fail("Should be Seq[Node] was NodeSeq") // Unreachable code?
     }
     val res: NodeSeq = a :+ b
     val exp: NodeSeq = NodeSeq.fromSeq(Seq(<a>Hello</a>, <b>Hi</b>))
@@ -41,7 +41,7 @@ class NodeSeqTest {
     val b: Elem = <b>Hi</b>
     a +: <b>Hi</b> match {
       case res: Seq[Node] => assertEquals(2, res.size.toLong)
-      case res: NodeSeq => fail("Should be Seq[Node] was NodeSeq") // Unreachable code?
+      case _: NodeSeq => fail("Should be Seq[Node] was NodeSeq") // Unreachable code?
     }
     val res: Seq[NodeSeq] = a +: b
     val exp: NodeBuffer = {
@@ -57,7 +57,7 @@ class NodeSeqTest {
     val c: Elem = <c>Hey</c>
     a ++: <b>Hi</b> ++: <c>Hey</c> match {
       case res: Seq[Node] => assertEquals(3, res.size.toLong)
-      case res: NodeSeq => fail("Should be Seq[Node] was NodeSeq") // Unreachable code?
+      case _: NodeSeq => fail("Should be Seq[Node] was NodeSeq") // Unreachable code?
     }
     val res: NodeSeq = a ++: b ++: c
     val exp: NodeSeq = NodeSeq.fromSeq(Seq(<a>Hello</a>, <b>Hi</b>, <c>Hey</c>))

--- a/shared/src/test/scala/scala/xml/XMLTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLTest.scala
@@ -87,7 +87,7 @@ class XMLTest {
     assertEquals(results1Expected, results1)
 
     {
-      val actual: List[Node] = for (t @ <book><title>Blabla</title></book> <- NodeSeq.fromSeq(books.child).toList)
+      val actual: List[Node] = for (case t @ <book><title>Blabla</title></book> <- NodeSeq.fromSeq(books.child).toList)
         yield t
       val expected: List[Elem] = List(<book><title>Blabla</title></book>)
       assertEquals(expected, actual)
@@ -247,11 +247,11 @@ class XMLTest {
 
   @UnitTest
   def comment(): Unit =
-    assertEquals("<!-- thissa comment -->", <!-- thissa comment --> toString)
+    assertEquals("<!-- thissa comment -->", <!-- thissa comment -->.toString)
 
   @UnitTest
   def weirdElem(): Unit =
-    assertEquals("<?this is a pi foo bar = && {{ ?>", <?this is a pi foo bar = && {{ ?> toString)
+    assertEquals("<?this is a pi foo bar = && {{ ?>", <?this is a pi foo bar = && {{ ?>.toString)
 
   @UnitTest
   def escape(): Unit =
@@ -265,12 +265,12 @@ Ours is the portal of hope, come as you are.&quot;
 Heathen, fire worshipper or idolatrous, come!
 Come even if you broke your penitence a hundred times,
 Ours is the portal of hope, come as you are."
-                              Mevlana Celaleddin Rumi]]> toString) // this guy will escaped, and rightly so
+                              Mevlana Celaleddin Rumi]]>.toString) // this guy will escaped, and rightly so
 
   @UnitTest
   def unparsed2(): Unit = {
     object myBreak extends Unparsed("<br />")
-    assertEquals("<foo><br /></foo>", <foo>{ myBreak }</foo> toString) // shows use of unparsed
+    assertEquals("<foo><br /></foo>", <foo>{ myBreak }</foo>.toString) // shows use of unparsed
   }
 
   @UnitTest
@@ -297,7 +297,7 @@ Ours is the portal of hope, come as you are."
     assertEquals(
       """<entry>
       <elem>a</elem><elem>b</elem><elem>c</elem>
-    </entry>""", f("a,b,c") toString)
+    </entry>""", f("a,b,c").toString)
 
   // t-486
   def wsdlTemplate1(serviceName: String): Node =
@@ -315,11 +315,11 @@ Ours is the portal of hope, come as you are."
   @UnitTest
   def wsdl(): Unit = {
     assertEquals("""<wsdl:definitions name="service1" xmlns:tns="target1">
-    </wsdl:definitions>""", wsdlTemplate1("service1") toString)
+    </wsdl:definitions>""", wsdlTemplate1("service1").toString)
     assertEquals("""<wsdl:definitions name="service2" xmlns:tns="target2">
-    </wsdl:definitions>""", wsdlTemplate2("service2", "target2") toString)
+    </wsdl:definitions>""", wsdlTemplate2("service2", "target2").toString)
     assertEquals("""<wsdl:definitions name="service4" xmlns:tns="target4">
-    </wsdl:definitions>""", wsdlTemplate4("service4", () => "target4") toString)
+    </wsdl:definitions>""", wsdlTemplate4("service4", () => "target4").toString)
   }
 
   @UnitTest
@@ -426,28 +426,28 @@ Ours is the portal of hope, come as you are."
     val bar: Attribute = Attribute(null, "bar", "2", foo)
     val ns: NamespaceBinding = NamespaceBinding(null, "uri", TopScope)
 
-    assertEquals(""" foo="1"""", foo toString)
+    assertEquals(""" foo="1"""", foo.toString)
     assertEquals(null, TopScope.getURI(foo.pre))
-    assertEquals(""" bar="2"""", bar remove "foo" toString)
-    assertEquals(""" foo="1"""", bar remove "bar" toString)
-    assertEquals(""" bar="2"""", bar remove (null, TopScope, "foo") toString)
-    assertEquals(""" foo="1"""", bar remove (null, TopScope, "bar") toString)
-    assertEquals(""" bar="2" foo="1"""", bar toString)
-    assertEquals(""" bar="2" foo="1"""", bar remove (null, ns, "foo") toString)
-    assertEquals(""" bar="2" foo="1"""", bar remove (null, ns, "bar") toString)
+    assertEquals(""" bar="2"""", bar.remove("foo").toString)
+    assertEquals(""" foo="1"""", bar.remove("bar").toString)
+    assertEquals(""" bar="2"""", bar.remove(null, TopScope, "foo").toString)
+    assertEquals(""" foo="1"""", bar.remove(null, TopScope, "bar").toString)
+    assertEquals(""" bar="2" foo="1"""", bar.toString)
+    assertEquals(""" bar="2" foo="1"""", bar.remove(null, ns, "foo").toString)
+    assertEquals(""" bar="2" foo="1"""", bar.remove(null, ns, "bar").toString)
   }
 
   @UnitTest
   def t7074(): Unit = {
-    assertEquals("""<a/>""", sort(<a/>) toString)
-    assertEquals("""<a b="2" c="3" d="1"/>""", sort(<a d="1" b="2" c="3"/>) toString)
-    assertEquals("""<a b="2" c="4" d="1" e="3" f="5"/>""", sort(<a d="1" b="2" e="3" c="4" f="5"/>) toString)
-    assertEquals("""<a b="5" c="4" d="3" e="2" f="1"/>""", sort(<a f="1" e="2" d="3" c="4" b="5"/>) toString)
-    assertEquals("""<a b="1" c="2" d="3" e="4" f="5"/>""", sort(<a b="1" c="2" d="3" e="4" f="5"/>) toString)
-    assertEquals("""<a a:b="2" a:c="3" a:d="1"/>""", sort(<a a:d="1" a:b="2" a:c="3"/>) toString)
-    assertEquals("""<a a:b="2" a:c="4" a:d="1" a:e="3" a:f="5"/>""", sort(<a a:d="1" a:b="2" a:e="3" a:c="4" a:f="5"/>) toString)
-    assertEquals("""<a a:b="5" a:c="4" a:d="3" a:e="2" a:f="1"/>""", sort(<a a:f="1" a:e="2" a:d="3" a:c="4" a:b="5"/>) toString)
-    assertEquals("""<a a:b="1" a:c="2" a:d="3" a:e="4" a:f="5"/>""", sort(<a a:b="1" a:c="2" a:d="3" a:e="4" a:f="5"/>) toString)
+    assertEquals("""<a/>""", sort(<a/>).toString)
+    assertEquals("""<a b="2" c="3" d="1"/>""", sort(<a d="1" b="2" c="3"/>).toString)
+    assertEquals("""<a b="2" c="4" d="1" e="3" f="5"/>""", sort(<a d="1" b="2" e="3" c="4" f="5"/>).toString)
+    assertEquals("""<a b="5" c="4" d="3" e="2" f="1"/>""", sort(<a f="1" e="2" d="3" c="4" b="5"/>).toString)
+    assertEquals("""<a b="1" c="2" d="3" e="4" f="5"/>""", sort(<a b="1" c="2" d="3" e="4" f="5"/>).toString)
+    assertEquals("""<a a:b="2" a:c="3" a:d="1"/>""", sort(<a a:d="1" a:b="2" a:c="3"/>).toString)
+    assertEquals("""<a a:b="2" a:c="4" a:d="1" a:e="3" a:f="5"/>""", sort(<a a:d="1" a:b="2" a:e="3" a:c="4" a:f="5"/>).toString)
+    assertEquals("""<a a:b="5" a:c="4" a:d="3" a:e="2" a:f="1"/>""", sort(<a a:f="1" a:e="2" a:d="3" a:c="4" a:b="5"/>).toString)
+    assertEquals("""<a a:b="1" a:c="2" a:d="3" a:e="4" a:f="5"/>""", sort(<a a:b="1" a:c="2" a:d="3" a:e="4" a:f="5"/>).toString)
   }
 
   @UnitTest
@@ -468,20 +468,20 @@ Ours is the portal of hope, come as you are."
     assertEquals(xml1, xml2)
     assertEquals(xml1, xml3)
 
-    assertEquals("""<t/>""", noAttr toString)
-    assertEquals("""<t/>""", attrNull toString)
-    assertEquals("""<t/>""", attrNone toString)
-    assertEquals("""<t/>""", preAttrNull toString)
-    assertEquals("""<t/>""", preAttrNone toString)
-    assertEquals("""<t b="1" d="2"/>""", xml1 toString)
-    assertEquals("""<t b="1" d="2"/>""", xml2 toString)
-    assertEquals("""<t b="1" d="2"/>""", xml3 toString)
+    assertEquals("""<t/>""", noAttr.toString)
+    assertEquals("""<t/>""", attrNull.toString)
+    assertEquals("""<t/>""", attrNone.toString)
+    assertEquals("""<t/>""", preAttrNull.toString)
+    assertEquals("""<t/>""", preAttrNone.toString)
+    assertEquals("""<t b="1" d="2"/>""", xml1.toString)
+    assertEquals("""<t b="1" d="2"/>""", xml2.toString)
+    assertEquals("""<t b="1" d="2"/>""", xml3.toString)
 
     // Check if attribute order is retained
-    assertEquals("""<t a="1" d="2"/>""", <t a="1" d="2"/> toString)
-    assertEquals("""<t b="1" d="2"/>""", <t b="1" d="2"/> toString)
-    assertEquals("""<t a="1" b="2" c="3"/>""", <t a="1" b="2" c="3"/> toString)
-    assertEquals("""<t g="1" e="2" p:a="3" f:e="4" mgruhu:ji="5"/>""", <t g="1" e="2" p:a="3" f:e="4" mgruhu:ji="5"/> toString)
+    assertEquals("""<t a="1" d="2"/>""", <t a="1" d="2"/>.toString)
+    assertEquals("""<t b="1" d="2"/>""", <t b="1" d="2"/>.toString)
+    assertEquals("""<t a="1" b="2" c="3"/>""", <t a="1" b="2" c="3"/>.toString)
+    assertEquals("""<t g="1" e="2" p:a="3" f:e="4" mgruhu:ji="5"/>""", <t g="1" e="2" p:a="3" f:e="4" mgruhu:ji="5"/>.toString)
   }
 
   @UnitTest


### PR DESCRIPTION
- fix some dangling ScalaDoc references
- drop `()` after `toString` and a few other methods
- replace unused pattern variables with `_`
- remove code duplication in name-splitting

I split the code cleanup part out of the #649 so that we can get it out of the way and concentrate on the type-tightening and binary compatibility...