### PR TITLE
Missing type annotations

### DIFF
--- a/shared/src/main/scala/scala/xml/Group.scala
+++ b/shared/src/main/scala/scala/xml/Group.scala
@@ -44,6 +44,6 @@ final case class Group(nodes: Seq[Node]) extends Node {
   override def label: Nothing = fail("label")
   override def attributes: Nothing = fail("attributes")
   override def namespace: Nothing = fail("namespace")
-  override def child /* TODO type annotation */ = fail("child")
+  override def child: Nothing = fail("child")
   def buildString(sb: StringBuilder): Nothing = fail("toString(StringBuilder)")
 }

--- a/shared/src/main/scala/scala/xml/Node.scala
+++ b/shared/src/main/scala/scala/xml/Node.scala
@@ -23,12 +23,12 @@ import scala.collection.Seq
  */
 object Node {
   /** the constant empty attribute sequence */
-  final def NoAttributes: MetaData = Null
+  final def NoAttributes: Null.type = Null
 
   /** the empty namespace */
   val EmptyNamespace: String = ""
 
-  def unapplySeq(n: Node) /* TODO type annotation */ = Some((n.label, n.attributes, n.child.toSeq))
+  def unapplySeq(n: Node) /* TODO type annotation Some[(String, MetaData, Seq[Node])] */ = Some((n.label, n.attributes, n.child.toSeq))
 }
 
 /**

--- a/shared/src/main/scala/scala/xml/Null.scala
+++ b/shared/src/main/scala/scala/xml/Null.scala
@@ -27,15 +27,15 @@ case object Null extends MetaData {
   override def iterator: Iterator[Nothing] = Iterator.empty
   override def size: Int = 0
   override def append(m: MetaData, scope: NamespaceBinding = TopScope): MetaData = m
-  override def filter(f: MetaData => Boolean): MetaData = this
+  override def filter(f: MetaData => Boolean): Null.type = this
 
   override def copy(next: MetaData): MetaData = next
-  override def getNamespace(owner: Node) /* TODO type annotation */ = null
+  override def getNamespace(owner: Node): scala.Null = null
 
   override def hasNext: Boolean = false
-  override def next /* TODO type annotation */ = null
-  override def key /* TODO type annotation */ = null
-  override def value /* TODO type annotation */ = null
+  override def next: scala.Null = null
+  override def key: scala.Null = null
+  override def value: scala.Null = null
   override def isPrefixed: Boolean = false
 
   override def length: Int = 0
@@ -47,8 +47,9 @@ case object Null extends MetaData {
   }
   override protected def basisForHashCode: Seq[Any] = Nil
 
-  override def apply(namespace: String, scope: NamespaceBinding, key: String) /* TODO type annotation */ = null
-  override def apply(key: String) /* TODO type annotation */ =
+  override def apply(namespace: String, scope: NamespaceBinding, key: String): scala.Null = null
+
+  override def apply(key: String): scala.Null =
     if (Utility.isNameStart(key.head)) null
     else throw new IllegalArgumentException("not a valid attribute name '" + key + "', so can never match !")
 
@@ -61,6 +62,6 @@ case object Null extends MetaData {
 
   override def wellformed(scope: NamespaceBinding): Boolean = true
 
-  override def remove(key: String) /* TODO type annotation */ = this
-  override def remove(namespace: String, scope: NamespaceBinding, key: String) /* TODO type annotation */ = this
+  override def remove(key: String): Null.type = this
+  override def remove(namespace: String, scope: NamespaceBinding, key: String): Null.type = this
 }

--- a/shared/src/main/scala/scala/xml/SpecialNode.scala
+++ b/shared/src/main/scala/scala/xml/SpecialNode.scala
@@ -28,7 +28,7 @@ abstract class SpecialNode extends Node {
   final override def namespace: scala.Null = null
 
   /** always empty */
-  final override def child /* TODO type annotation */ = Nil
+  final override def child: Nil.type = Nil
 
   /** Append string representation to the given string buffer argument. */
   def buildString(sb: StringBuilder): StringBuilder

--- a/shared/src/main/scala/scala/xml/dtd/ExternalID.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ExternalID.scala
@@ -73,7 +73,7 @@ case class PublicID(override val publicId: String, override val systemId: String
   def label: String = "#PI"
 
   /** always empty */
-  def attribute: MetaData = Node.NoAttributes
+  def attribute: Null.type = Node.NoAttributes
 
   /** always empty */
   def child: Nil.type = Nil
@@ -85,8 +85,8 @@ case class PublicID(override val publicId: String, override val systemId: String
  *  @author Michael Bayne
  */
 object NoExternalID extends ExternalID {
-  override val publicId /* TODO type annotation */ = null
-  override val systemId /* TODO type annotation */ = null
+  override val publicId: scala.Null = null
+  override val systemId: scala.Null = null
 
   override def toString: String = ""
 }


### PR DESCRIPTION
- introduce Scala-version-specific  MiMa exclusions
- add type annotations that break binary compatibility except for the `unapply()` methods for the `Node` subclasses;
- add appropriate MiMa exclusions

@SethTisue as discussed in #649:

> could we have one set of MiMa exclusions for Scala 2 and one for Scala 3, so that we can know for sure that any potential bincompat breakage is only on the Scala 3 side?

done; only Scala 3-specific exclusions are added in this pull request
**NOTE**: no longer true; I added all the remaining missing type annotations except for the `unapply()` methods: since even with the Scala 3-only exclusions this pull request is considered too risky (although not even one example of the breakage it can cause is known), I think it is better to record all the related changes in one pull request.

> do you understand why MiMa considers the more specific types to break binary compatibility?

probably because MiMa can not take subtyping into account since JVM class linking does not...

I understand the reluctance to break binary compatibility between the current and the next versions of this library _just_ to add some type annotations, but please consider that _because_ those type annotations are not there, binary compatibility is _already broken_ between the builds of the same version of this library for different versions of Scala: code that uses the methods with the type annotations missing that is built with Scala 2 will stop compiling - or will start behaving differently - when switched to Scala 3 _with the same version of this library_...