### PR TITLE
Demonstrate XInclude work - and fail

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,6 +113,7 @@ lazy val xml = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     libraryDependencies += "junit" % "junit" % "4.13.2" % Test,
     libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
     libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.12.0" % Test,
+    libraryDependencies += "xerces" % "xercesImpl" % "2.12.2" % Test,
     libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((3, _)) =>
         Seq()

--- a/jvm/src/test/resources/scala/xml/archive/books.xml
+++ b/jvm/src/test/resources/scala/xml/archive/books.xml
@@ -1,0 +1,3 @@
+<store xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:include href="books/book/author.xml"/>
+</store>

--- a/jvm/src/test/resources/scala/xml/archive/books/book/author.xml
+++ b/jvm/src/test/resources/scala/xml/archive/books/book/author.xml
@@ -1,0 +1,3 @@
+<store xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:include href="author/volume/1.xml"/>
+</store>

--- a/jvm/src/test/resources/scala/xml/archive/books/book/author/volume/1.xml
+++ b/jvm/src/test/resources/scala/xml/archive/books/book/author/volume/1.xml
@@ -1,0 +1,1 @@
+<collection n="1"/>

--- a/jvm/src/test/resources/scala/xml/includee.xml
+++ b/jvm/src/test/resources/scala/xml/includee.xml
@@ -1,0 +1,3 @@
+<includee>
+    <content>Blah!</content>
+</includee>

--- a/jvm/src/test/resources/scala/xml/includer.xml
+++ b/jvm/src/test/resources/scala/xml/includer.xml
@@ -1,0 +1,3 @@
+<includer>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="includee.xml"/>
+</includer>

--- a/jvm/src/test/resources/scala/xml/site.xml
+++ b/jvm/src/test/resources/scala/xml/site.xml
@@ -1,0 +1,3 @@
+<site xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:include href="archive/books.xml"/>
+</site>


### PR DESCRIPTION
This pull request does not affect production code at all; it:
- adds a test dependency on `Xerces`;
- adjust tests that assume that JDK-built-in `Xerces` is the only `Xerces` on the classpath;
- adds tests demonstrating that `XInclude` works;
- adds tests demonstrating when `XInclude` fails miserably because of the old and never fixed `Xerces` bug...