### PR TITLE
XMLLoader returns Document

### DIFF
--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -1,14 +1,10 @@
 package scala.xml
 
 import language.postfixOps
-
 import org.junit.{Test => UnitTest}
-import org.junit.Assert.assertTrue
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import java.io.StringWriter
 import java.io.ByteArrayOutputStream
-import java.io.StringReader
 import scala.xml.dtd.{DocType, PublicID}
 import scala.xml.parsing.ConstructingParser
 import scala.xml.Utility.sort
@@ -610,7 +606,7 @@ class XMLTestJVM {
                 |    section]]>   </b> suffix</a>""".stripMargin)
   }
 
-  def roundtripNodes(xml: String): Unit = assertEquals(xml, XML.loadStringNodes(xml).map(_.toString).mkString(""))
+  def roundtripNodes(xml: String): Unit = assertEquals(xml, XML.loadStringDocument(xml).children.map(_.toString).mkString(""))
 
   @UnitTest
   def xmlLoaderLoadNodes(): Unit = {

--- a/shared/src/main/scala/scala/xml/factory/XMLLoader.scala
+++ b/shared/src/main/scala/scala/xml/factory/XMLLoader.scala
@@ -14,9 +14,9 @@ package scala
 package xml
 package factory
 
-import org.xml.sax.{SAXNotRecognizedException, SAXNotSupportedException, XMLReader}
+import org.xml.sax.XMLReader
+import scala.xml.Source
 import javax.xml.parsers.SAXParserFactory
-import parsing.{FactoryAdapter, NoBindingFactoryAdapter}
 import java.io.{File, FileDescriptor, InputStream, Reader}
 import java.net.URL
 
@@ -25,9 +25,6 @@ import java.net.URL
  *  created by "def parser" or the reader created by "def reader".
  */
 trait XMLLoader[T <: Node] {
-  import scala.xml.Source._
-  def adapter: FactoryAdapter = new NoBindingFactoryAdapter()
-
   private def setSafeDefaults(parserFactory: SAXParserFactory): Unit = {
     parserFactory.setFeature("http://javax.xml.XMLConstants/feature/secure-processing", true)
     parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
@@ -54,69 +51,49 @@ trait XMLLoader[T <: Node] {
   def reader: XMLReader = parser.getXMLReader
 
   /**
-   * Loads XML from the given InputSource, using the supplied parser.
+   * Loads XML from the given InputSource, using the supplied parser or reader.
    * The methods available in scala.xml.XML use the XML parser in the JDK
    * (unless another parser is present on the classpath).
    */
-  def loadXML(inputSource: InputSource, parser: SAXParser): T = loadXML(inputSource, parser.getXMLReader)
+  private def getDocElem(document: Document): T = document.docElem.asInstanceOf[T]
 
-  def loadXMLNodes(inputSource: InputSource, parser: SAXParser): Seq[Node] = loadXMLNodes(inputSource, parser.getXMLReader)
+  def loadXML(inputSource: InputSource, parser: SAXParser): T = getDocElem(loadDocument(inputSource, parser))
+  def loadXMLNodes(inputSource: InputSource, parser: SAXParser): Seq[Node] = loadDocument(inputSource, parser).children
 
-  private def loadXML(inputSource: InputSource, reader: XMLReader): T = {
-    val result: FactoryAdapter = parse(inputSource, reader)
-    result.rootElem.asInstanceOf[T]
-  }
+  private def loadDocument(inputSource: InputSource, parser: SAXParser): Document = adapter.loadDocument(inputSource, parser)
+  private def loadDocument(inputSource: InputSource, reader: XMLReader): Document = adapter.loadDocument(inputSource, reader)
+  def adapter: parsing.FactoryAdapter = new parsing.NoBindingFactoryAdapter()
 
-  private def loadXMLNodes(inputSource: InputSource, reader: XMLReader): Seq[Node] = {
-    val result: FactoryAdapter = parse(inputSource, reader)
-    result.prolog ++ (result.rootElem :: result.epilogue)
-  }
+  /** Loads XML Document. */
+  def loadDocument(source: InputSource): Document = loadDocument(source, reader)
+  def loadFileDocument(fileName: String): Document = loadDocument(Source.fromFile(fileName))
+  def loadFileDocument(file: File): Document = loadDocument(Source.fromFile(file))
+  def loadDocument(url: URL): Document = loadDocument(Source.fromUrl(url))
+  def loadDocument(sysId: String): Document = loadDocument(Source.fromSysId(sysId))
+  def loadFileDocument(fileDescriptor: FileDescriptor): Document = loadDocument(Source.fromFile(fileDescriptor))
+  def loadDocument(inputStream: InputStream): Document = loadDocument(Source.fromInputStream(inputStream))
+  def loadDocument(reader: Reader): Document = loadDocument(Source.fromReader(reader))
+  def loadStringDocument(string: String): Document = loadDocument(Source.fromString(string))
 
-  private def parse(inputSource: InputSource, xmlReader: XMLReader): FactoryAdapter = {
-    if (inputSource == null) throw new IllegalArgumentException("InputSource cannot be null")
-
-    val result: FactoryAdapter = adapter
-
-    xmlReader.setContentHandler(result)
-    xmlReader.setDTDHandler(result)
-    /* Do not overwrite pre-configured EntityResolver. */
-    if (xmlReader.getEntityResolver == null) xmlReader.setEntityResolver(result)
-    /* Do not overwrite pre-configured ErrorHandler. */
-    if (xmlReader.getErrorHandler == null) xmlReader.setErrorHandler(result)
-
-    try {
-      xmlReader.setProperty("http://xml.org/sax/properties/lexical-handler", result)
-    } catch {
-      case _: SAXNotRecognizedException =>
-      case _: SAXNotSupportedException =>
-    }
-
-    result.scopeStack = TopScope :: result.scopeStack
-    xmlReader.parse(inputSource)
-    result.scopeStack = result.scopeStack.tail
-
-    result
-  }
-
-  /** Loads XML. */
-  def load(inputSource: InputSource): T = loadXML(inputSource, reader)
-  def loadFile(fileName: String): T = load(fromFile(fileName))
-  def loadFile(file: File): T = load(fromFile(file))
-  def load(url: URL): T = load(fromUrl(url))
-  def load(sysId: String): T = load(fromSysId(sysId))
-  def loadFile(fileDescriptor: FileDescriptor): T = load(fromFile(fileDescriptor))
-  def load(inputStream: InputStream): T = load(fromInputStream(inputStream))
-  def load(reader: Reader): T = load(fromReader(reader))
-  def loadString(string: String): T = load(fromString(string))
+  /** Loads XML element. */
+  def load(inputSource: InputSource): T = getDocElem(loadDocument(inputSource))
+  def loadFile(fileName: String): T = getDocElem(loadFileDocument(fileName))
+  def loadFile(file: File): T = getDocElem(loadFileDocument(file))
+  def load(url: URL): T = getDocElem(loadDocument(url))
+  def load(sysId: String): T = getDocElem(loadDocument(sysId))
+  def loadFile(fileDescriptor: FileDescriptor): T = getDocElem(loadFileDocument(fileDescriptor))
+  def load(inputStream: InputStream): T = getDocElem(loadDocument(inputStream))
+  def load(reader: Reader): T = getDocElem(loadDocument(reader))
+  def loadString(string: String): T = getDocElem(loadStringDocument(string))
 
   /** Load XML nodes, including comments and processing instructions that precede and follow the root element. */
-  def loadNodes(inputSource: InputSource): Seq[Node] = loadXMLNodes(inputSource, reader)
-  def loadFileNodes(fileName: String): Seq[Node] = loadNodes(fromFile(fileName))
-  def loadFileNodes(file: File): Seq[Node] = loadNodes(fromFile(file))
-  def loadNodes(url: URL): Seq[Node] = loadNodes(fromUrl(url))
-  def loadNodes(sysId: String): Seq[Node] = loadNodes(fromSysId(sysId))
-  def loadFileNodes(fileDescriptor: FileDescriptor): Seq[Node] = loadNodes(fromFile(fileDescriptor))
-  def loadNodes(inputStream: InputStream): Seq[Node] = loadNodes(fromInputStream(inputStream))
-  def loadNodes(reader: Reader): Seq[Node] = loadNodes(fromReader(reader))
-  def loadStringNodes(string: String): Seq[Node] = loadNodes(fromString(string))
+  def loadNodes(inputSource: InputSource): Seq[Node] = loadDocument(inputSource).children
+  def loadFileNodes(fileName: String): Seq[Node] = loadFileDocument(fileName).children
+  def loadFileNodes(file: File): Seq[Node] = loadFileDocument(file).children
+  def loadNodes(url: URL): Seq[Node] = loadDocument(url).children
+  def loadNodes(sysId: String): Seq[Node] = loadDocument(sysId).children
+  def loadFileNodes(fileDescriptor: FileDescriptor): Seq[Node] = loadFileDocument(fileDescriptor).children
+  def loadNodes(inputStream: InputStream): Seq[Node] = loadDocument(inputStream).children
+  def loadNodes(reader: Reader): Seq[Node] = loadDocument(reader).children
+  def loadStringNodes(string: String): Seq[Node] = loadStringDocument(string).children
 }

--- a/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
@@ -15,7 +15,7 @@ package xml
 package parsing
 
 import scala.collection.Seq
-import org.xml.sax.Attributes
+import org.xml.sax.{Attributes, SAXNotRecognizedException, SAXNotSupportedException}
 import org.xml.sax.ext.DefaultHandler2
 
 // can be mixed into FactoryAdapter if desired
@@ -37,9 +37,15 @@ trait ConsoleErrorHandler extends DefaultHandler2 {
 /**
  * SAX adapter class, for use with Java SAX parser. Keeps track of
  *  namespace bindings, without relying on namespace handling of the
- *  underlying SAX parser.
+ *  underlying SAX parser (but processing the parser's namespace-related events if it is namespace-aware).
  */
 abstract class FactoryAdapter extends DefaultHandler2 with factory.XMLLoader[Node] {
+  val normalizeWhitespace: Boolean = false
+
+  private var document: Option[Document] = None
+
+  private var prefixMappings: List[(String, String)] = List.empty
+
   var prolog: List[Node] = List.empty
   var rootElem: Node = _
   var epilogue: List[Node] = List.empty
@@ -78,6 +84,52 @@ abstract class FactoryAdapter extends DefaultHandler2 with factory.XMLLoader[Nod
 
   var curTag: String = _
   var capture: Boolean = false
+
+  /**
+   * Captures text or cdata.
+   */
+  def captureText(): Unit = {
+    if (capture && buffer.nonEmpty) {
+      val text: String = buffer.toString
+      val newNode: Node = if (inCDATA) createPCData(text) else createText(text)
+      hStack ::= newNode
+    }
+
+    buffer.clear()
+    inCDATA = false
+  }
+
+  /**
+   * Load XML document from the source using the parser.
+   */
+  def loadDocument(source: InputSource, parser: SAXParser): Document =
+    loadDocument(source, parser.getXMLReader)
+
+  /**
+   * Load XML document from the source using the reader.
+   */
+  def loadDocument(source: InputSource, xmlReader: XMLReader): Document = {
+    if (source == null) throw new IllegalArgumentException("InputSource cannot be null")
+
+    xmlReader.setContentHandler(this)
+    xmlReader.setDTDHandler(this)
+    /* Do not overwrite pre-configured EntityResolver. */
+    if (xmlReader.getEntityResolver == null) xmlReader.setEntityResolver(this)
+    /* Do not overwrite pre-configured ErrorHandler. */
+    if (xmlReader.getErrorHandler == null) xmlReader.setErrorHandler(this)
+
+    /* Use LexicalHandler if it is supported by the xmlReader. */
+    try {
+      xmlReader.setProperty("http://xml.org/sax/properties/lexical-handler", this)
+    } catch {
+      case _: SAXNotRecognizedException =>
+      case _: SAXNotSupportedException =>
+    }
+
+    xmlReader.parse(source)
+
+    document.get
+  }
 
   // abstract methods
 
@@ -121,121 +173,100 @@ abstract class FactoryAdapter extends DefaultHandler2 with factory.XMLLoader[Nod
    */
   def createComment(characters: String): Seq[Comment]
 
-  //
-  // ContentHandler methods
-  //
-
-  val normalizeWhitespace: Boolean = false
-
-  /**
-   * Capture characters, possibly normalizing whitespace.
-   * @param ch
-   * @param offset
-   * @param length
-   */
-  override def characters(ch: Array[Char], offset: Int, length: Int): Unit = {
-    if (!capture) ()
-    // compliant: report every character
-    else if (!normalizeWhitespace) buffer.appendAll(ch, offset, length)
-    // normalizing whitespace is not compliant, but useful
-    else {
-      var it: Iterator[Char] = ch.slice(offset, offset + length).iterator
-      while (it.hasNext) {
-        val c: Char = it.next()
-        val isSpace: Boolean = c.isWhitespace
-        buffer append (if (isSpace) ' ' else c)
-        if (isSpace)
-          it = it dropWhile (_.isWhitespace)
-      }
-    }
-  }
-
-  /**
-   * Start of a CDATA section.
-   */
-  override def startCDATA(): Unit = {
-    captureText()
-    inCDATA = true
-  }
-
-  /**
-   * End of a CDATA section.
-   */
-  override def endCDATA(): Unit = captureText()
-
   /* ContentHandler methods */
+
+  override def startDocument(): Unit = {
+    scopeStack ::= TopScope // TODO remove
+  }
+
+  override def endDocument(): Unit = {
+    // capture the epilogue at the end of the document
+    epilogue = hStack.init.reverse
+
+    val document = new Document
+    this.document = Some(document)
+    document.children = prolog ++ rootElem ++ epilogue
+    document.docElem = rootElem
+    document.dtd = null
+    document.baseURI = null
+    document.encoding = None
+    document.standAlone = None
+    document.version = None
+
+    // Note: resetting to the freshly-created state; needed only if this instance is reused, which we do not do...
+    hStack = hStack.last :: Nil // TODO List.empty
+    scopeStack = scopeStack.tail // TODO List.empty
+
+    rootElem = null
+    prolog = List.empty
+    epilogue = List.empty
+
+    buffer.clear()
+    inCDATA = false
+    capture = false
+    curTag = null
+
+    attribStack = List.empty
+    tagStack = List.empty
+  }
+
+  override def startPrefixMapping(prefix: String, uri: String): Unit =
+    prefixMappings ::= (prefix, uri)
+
+  override def endPrefixMapping(prefix: String): Unit = ()
 
   /* Start element. */
   override def startElement(
     uri: String,
     _localName: String,
     qname: String,
-    attributes: Attributes): Unit =
-    {
-      captureText()
+    attributes: Attributes
+  ): Unit = {
+    captureText()
 
-      // capture the prolog at the start of the root element
-      if (tagStack.isEmpty) {
-        prolog = hStack.reverse
-        hStack = List.empty
-      }
-
-      tagStack = curTag :: tagStack
-      curTag = qname
-
-      val localName: String = Utility.splitName(qname)._2
-      capture = nodeContainsText(localName)
-
-      hStack = null :: hStack
-      var m: MetaData = Null
-      var scpe: NamespaceBinding =
-        if (scopeStack.isEmpty) TopScope
-        else scopeStack.head
-
-      for (i <- (0 until attributes.getLength).reverse) {
-        val qname: String = attributes getQName i
-        val value: String = attributes getValue i
-        val (pre: Option[String], key: String) = Utility.splitName(qname)
-        def nullIfEmpty(s: String): String = if (s == "") null else s
-
-        if (pre.contains("xmlns") || (pre.isEmpty && qname == "xmlns")) {
-          val arg: String = if (pre.isEmpty) null else key
-          scpe = NamespaceBinding(arg, nullIfEmpty(value), scpe)
-        } else
-          m = Attribute(pre, key, Text(value), m)
-      }
-
-      // Add namespace bindings for the prefix mappings declared by this element
-      // (if there are any, the parser is namespace-aware, and no namespace bindings were delivered as attributes).
-      // All `startPrefixMapping()` events will occur immediately before the corresponding `startElement()` event.
-      for ((prefix: String, uri: String) <- prefixMappings)
-        scpe = NamespaceBinding(if (prefix.isEmpty) null else prefix, uri, scpe)
-
-      // Once the `prefixMappings` are processed into `scpe`, the list is emptied out
-      // so that already-declared namespaces are not re-declared on the nested elements.
-      prefixMappings = List.empty
-
-      scopeStack = scpe :: scopeStack
-      attribStack =  m :: attribStack
+    // capture the prolog at the start of the root element
+    if (tagStack.isEmpty) {
+      prolog = hStack.reverse
+      hStack = List.empty
     }
 
-  private var prefixMappings: List[(String, String)] = List.empty
+    tagStack ::= curTag
+    curTag = qname
 
-  override def startPrefixMapping(prefix: String, uri: String): Unit =
-    prefixMappings = (prefix, uri) :: prefixMappings
+    val localName: String = Utility.splitName(qname)._2
+    capture = nodeContainsText(localName)
 
-  /**
-   * Captures text or cdata.
-   */
-  def captureText(): Unit = {
-    if (capture && buffer.nonEmpty) {
-      val text: String = buffer.toString
-      val newNode: Node = if (inCDATA) createPCData(text) else createText(text)
-      hStack =  newNode :: hStack
+    hStack ::= null
+    var m: MetaData = Null
+    var scpe: NamespaceBinding =
+      if (scopeStack.isEmpty) TopScope
+      else scopeStack.head
+
+    for (i <- (0 until attributes.getLength).reverse) {
+      val qname: String = attributes getQName i
+      val value: String = attributes getValue i
+      val (pre: Option[String], key: String) = Utility.splitName(qname)
+      def nullIfEmpty(s: String): String = if (s == "") null else s
+
+      if (pre.contains("xmlns") || (pre.isEmpty && qname == "xmlns")) {
+        val arg: String = if (pre.isEmpty) null else key
+        scpe = NamespaceBinding(arg, nullIfEmpty(value), scpe)
+      } else
+        m = Attribute(pre, key, Text(value), m)
     }
 
-    buffer.clear()
-    inCDATA = false
+    // Add namespace bindings for the prefix mappings declared by this element
+    // (if there are any, the parser is namespace-aware, and no namespace bindings were delivered as attributes).
+    // All `startPrefixMapping()` events will occur immediately before the corresponding `startElement()` event.
+    for ((prefix: String, uri: String) <- prefixMappings)
+      scpe = NamespaceBinding(if (prefix.isEmpty) null else prefix, uri, scpe)
+
+    // Once the `prefixMappings` are processed into `scpe`, the list is emptied out
+    // so that already-declared namespaces are not re-declared on the nested elements.
+    prefixMappings = List.empty
+
+    scopeStack ::= scpe
+    attribStack ::=  m
   }
 
   /**
@@ -262,18 +293,35 @@ abstract class FactoryAdapter extends DefaultHandler2 with factory.XMLLoader[Nod
 
     // create element
     rootElem = createNode(pre.orNull, localName, metaData, scp, v)
-    hStack = rootElem :: hStack
+    hStack ::= rootElem
     curTag = tagStack.head
     tagStack = tagStack.tail
     capture = curTag != null && nodeContainsText(curTag) // root level
   }
 
-  override def endDocument(): Unit =  {
-    // capture the epilogue at the end of the document
-    epilogue = hStack.init.reverse
-    hStack = hStack.last :: Nil
+  /**
+   * Capture characters, possibly normalizing whitespace.
+   *
+   * @param ch
+   * @param offset
+   * @param length
+   */
+  override def characters(ch: Array[Char], offset: Int, length: Int): Unit = {
+    if (!capture) ()
+    // compliant: report every character
+    else if (!normalizeWhitespace) buffer.appendAll(ch, offset, length)
+    // normalizing whitespace is not compliant, but useful
+    else {
+      var it: Iterator[Char] = ch.slice(offset, offset + length).iterator
+      while (it.hasNext) {
+        val c: Char = it.next()
+        val isSpace: Boolean = c.isWhitespace
+        buffer append (if (isSpace) ' ' else c)
+        if (isSpace)
+          it = it dropWhile (_.isWhitespace)
+      }
+    }
   }
-
   /**
    * Processing instruction.
    */
@@ -281,6 +329,19 @@ abstract class FactoryAdapter extends DefaultHandler2 with factory.XMLLoader[Nod
     captureText()
     hStack = hStack.reverse_:::(createProcInstr(target, data).toList)
   }
+
+  /**
+   * Start of a CDATA section.
+   */
+  override def startCDATA(): Unit = {
+    captureText()
+    inCDATA = true
+  }
+
+  /**
+   * End of a CDATA section.
+   */
+  override def endCDATA(): Unit = captureText()
 
   /**
    * Comment.


### PR DESCRIPTION
- moved private def parse() from `XMLLoader` to `FactoryAdapter`;
- `FactoryAdapter.parse` returns `Document`;
- added yet another flavor of the `XMLLoader.load*` methods returning `Document`: `load*Document`;
- expressed all the other `load` methods in terms of the `load*Document`;