### PR TITLE
Change infix method calls `o m a` to `o.m(a)`.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val xml = crossProject(JSPlatform, JVMPlatform, NativePlatform)
           file(jarPath)
             -> url("http://docs.oracle.com/javase/8/docs/api")
         )
-      } getOrElse {
+      }.getOrElse {
         // If everything fails, jam in Java 11 modules.
         Map(
           file("/modules/java.base")

--- a/jvm/src/test/scala-2.x/scala/xml/CompilerErrors.scala
+++ b/jvm/src/test/scala-2.x/scala/xml/CompilerErrors.scala
@@ -197,12 +197,12 @@ class CompilerTesting {
 
   def expectXmlError(msg: String, code: String): Unit = {
     val errors: List[String] = xmlErrorMessages(msg, code)
-    assert(errors exists (_ contains msg), errors mkString "\n")
+    assert(errors.exists(_.contains(msg)), errors.mkString("\n"))
   }
 
   def expectXmlErrors(msgCount: Int, msg: String, code: String): Unit = {
     val errors: List[String] = xmlErrorMessages(msg, code)
-    val errorCount: Int = errors.count(_ contains msg)
-    assert(errorCount == msgCount, s"$errorCount occurrences of \'$msg\' found -- expected $msgCount in:\n${errors mkString "\n"}")
+    val errorCount: Int = errors.count(_.contains(msg))
+    assert(errorCount == msgCount, s"$errorCount occurrences of \'$msg\' found -- expected $msgCount in:\n${errors.mkString("\n")}")
   }
 }

--- a/jvm/src/test/scala/scala/xml/ReuseNodesTest.scala
+++ b/jvm/src/test/scala/scala/xml/ReuseNodesTest.scala
@@ -19,7 +19,7 @@ object ReuseNodesTest {
  
   class OriginalTranformr(rules: RewriteRule*) extends RuleTransformer(rules:_*) {
     override def transform(ns: Seq[Node]): Seq[Node] = {
-      val xs: Seq[Seq[Node]] = ns.toStream map transform
+      val xs: Seq[Seq[Node]] = ns.toStream.map(transform)
       val (xs1: Seq[(Seq[Node], Node)], xs2: Seq[(Seq[Node], Node)]) = xs.zip(ns).span { case (x, n) => unchanged(n, x) }
        
       if (xs2.isEmpty) ns
@@ -30,7 +30,7 @@ object ReuseNodesTest {
 
   class ModifiedTranformr(rules: RewriteRule*) extends RuleTransformer(rules:_*) {
     override def transform(ns: Seq[Node]): Seq[Node] = {
-      val changed: Seq[Node] = ns flatMap transform
+      val changed: Seq[Node] = ns.flatMap(transform)
       
       if (changed.length != ns.length || changed.zip(ns).exists(p => p._1 != p._2)) changed
       else ns
@@ -93,7 +93,7 @@ class ReuseNodesTest {
         recursiveAssert(original.child,transformed.child)
       case _ =>
         assertSame(original, transformed)
-        // No need to check for children, node being immuatable
+        // No need to check for children, node being immutable
         // children can't be different if parents are referentially equal
     }
   }

--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -1,6 +1,5 @@
 package scala.xml
 
-import language.postfixOps
 import org.junit.{Test => UnitTest}
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import java.io.StringWriter
@@ -38,8 +37,8 @@ class XMLTestJVM {
 
     assertEquals(c, parsedxml11)
     assertEquals(parsedxml1, parsedxml11)
-    assertTrue(List(parsedxml1) sameElements List(parsedxml11))
-    assertTrue(Array(parsedxml1).toList sameElements List(parsedxml11))
+    assertTrue(List(parsedxml1).sameElements(List(parsedxml11)))
+    assertTrue(Array(parsedxml1).toList.sameElements(List(parsedxml11)))
 
     val x2: String = "<book><author>Peter Buneman</author><author>Dan Suciu</author><title>Data on ze web</title></book>"
     val x2p: Elem = XML.loadString(x2)
@@ -52,44 +51,44 @@ class XMLTestJVM {
 
   @UnitTest
   def xpath(): Unit = {
-    assertTrue(parsedxml1 \ "_" sameElements List(Elem(null, "world", e, sc)))
+    assertTrue((parsedxml1 \ "_").sameElements(List(Elem(null, "world", e, sc))))
 
-    assertTrue(parsedxml1 \ "world" sameElements List(Elem(null, "world", e, sc)))
+    assertTrue((parsedxml1 \ "world").sameElements(List(Elem(null, "world", e, sc))))
 
     assertTrue(
-      (parsedxml2 \ "_") sameElements List(
+      (parsedxml2 \ "_").sameElements(List(
         Elem(null, "book", e, sc,
           Elem(null, "author", e, sc, Text("Peter Buneman")),
           Elem(null, "author", e, sc, Text("Dan Suciu")),
           Elem(null, "title", e, sc, Text("Data on ze web"))),
         Elem(null, "book", e, sc,
           Elem(null, "author", e, sc, Text("John Mitchell")),
-          Elem(null, "title", e, sc, Text("Foundations of Programming Languages")))))
+          Elem(null, "title", e, sc, Text("Foundations of Programming Languages"))))))
     assertTrue((parsedxml2 \ "author").isEmpty)
 
     assertTrue(
-      (parsedxml2 \ "book") sameElements List(
+      (parsedxml2 \ "book").sameElements(List(
         Elem(null, "book", e, sc,
           Elem(null, "author", e, sc, Text("Peter Buneman")),
           Elem(null, "author", e, sc, Text("Dan Suciu")),
           Elem(null, "title", e, sc, Text("Data on ze web"))),
         Elem(null, "book", e, sc,
           Elem(null, "author", e, sc, Text("John Mitchell")),
-          Elem(null, "title", e, sc, Text("Foundations of Programming Languages")))))
+          Elem(null, "title", e, sc, Text("Foundations of Programming Languages"))))))
 
     assertTrue(
-      (parsedxml2 \ "_" \ "_") sameElements List(
+      (parsedxml2 \ "_" \ "_").sameElements(List(
         Elem(null, "author", e, sc, Text("Peter Buneman")),
         Elem(null, "author", e, sc, Text("Dan Suciu")),
         Elem(null, "title", e, sc, Text("Data on ze web")),
         Elem(null, "author", e, sc, Text("John Mitchell")),
-        Elem(null, "title", e, sc, Text("Foundations of Programming Languages"))))
+        Elem(null, "title", e, sc, Text("Foundations of Programming Languages")))))
 
     assertTrue(
-      (parsedxml2 \ "_" \ "author") sameElements List(
+      (parsedxml2 \ "_" \ "author").sameElements(List(
         Elem(null, "author", e, sc, Text("Peter Buneman")),
         Elem(null, "author", e, sc, Text("Dan Suciu")),
-        Elem(null, "author", e, sc, Text("John Mitchell"))))
+        Elem(null, "author", e, sc, Text("John Mitchell")))))
 
     assertTrue((parsedxml2 \ "_" \ "_" \ "author").isEmpty)
   }
@@ -97,21 +96,21 @@ class XMLTestJVM {
   @UnitTest
   def xpathDESCENDANTS(): Unit = {
     assertTrue(
-      (parsedxml2 \\ "author") sameElements List(
+      (parsedxml2 \\ "author").sameElements(List(
         Elem(null, "author", e, sc, Text("Peter Buneman")),
         Elem(null, "author", e, sc, Text("Dan Suciu")),
-        Elem(null, "author", e, sc, Text("John Mitchell"))))
+        Elem(null, "author", e, sc, Text("John Mitchell")))))
 
     assertTrue(
-      (parsedxml2 \\ "title") sameElements List(
+      (parsedxml2 \\ "title").sameElements(List(
         Elem(null, "title", e, sc, Text("Data on ze web")),
-        Elem(null, "title", e, sc, Text("Foundations of Programming Languages"))))
+        Elem(null, "title", e, sc, Text("Foundations of Programming Languages")))))
 
     assertEquals("<book><author>Peter Buneman</author><author>Dan Suciu</author><title>Data on ze web</title></book>",
       (parsedxml2 \\ "book") { (n: Node) => (n \ "title") xml_== "Data on ze web" }.toString)
 
     assertTrue(
-      (NodeSeq.fromSeq(List(parsedxml2)) \\ "_") sameElements List(
+      (NodeSeq.fromSeq(List(parsedxml2)) \\ "_").sameElements(List(
         Elem(null, "bib", e, sc,
           Elem(null, "book", e, sc,
             Elem(null, "author", e, sc, Text("Peter Buneman")),
@@ -131,7 +130,7 @@ class XMLTestJVM {
           Elem(null, "author", e, sc, Text("John Mitchell")),
           Elem(null, "title", e, sc, Text("Foundations of Programming Languages"))),
         Elem(null, "author", e, sc, Text("John Mitchell")),
-        Elem(null, "title", e, sc, Text("Foundations of Programming Languages"))))
+        Elem(null, "title", e, sc, Text("Foundations of Programming Languages")))))
   }
 
   @UnitTest
@@ -196,7 +195,7 @@ class XMLTestJVM {
       // println("x = " + x)
       // println("y = " + y)
       // println("x equals y: " + (x equals y) + ", y equals x: " + (y equals x))
-      assertTrue((x equals y) && (y equals x))
+      assertTrue(x.equals(y) && y.equals(x))
       // println()
     }
   }
@@ -659,7 +658,7 @@ class XMLTestJVM {
     val parent: org.xml.sax.XMLReader = xercesInternal.newSAXParser.getXMLReader
     val filter: org.xml.sax.XMLFilter = new org.xml.sax.helpers.XMLFilterImpl(parent) {
       override def characters(ch: Array[Char], start: Int, length: Int): Unit = {
-        for (i <- 0 until length) if (ch(start+i) == 'a') ch(start+i) = 'b'
+        for (i <- 0.until(length)) if (ch(start+i) == 'a') ch(start+i) = 'b'
         super.characters(ch, start, length)
       }
     }

--- a/shared/src/main/scala/scala/xml/Comment.scala
+++ b/shared/src/main/scala/scala/xml/Comment.scala
@@ -39,5 +39,5 @@ case class Comment(commentText: String) extends SpecialNode {
    * Appends &quot;<!-- text -->&quot; to this string buffer.
    */
   override def buildString(sb: StringBuilder): StringBuilder =
-    sb append "<!--" append commentText append "-->"
+    sb.append("<!--").append(commentText).append("-->")
 }

--- a/shared/src/main/scala/scala/xml/Elem.scala
+++ b/shared/src/main/scala/scala/xml/Elem.scala
@@ -106,5 +106,5 @@ class Elem(
   /**
    * Returns concatenation of `text(n)` for each child `n`.
    */
-  override def text: String = (child map (_.text)).mkString
+  override def text: String = child.map(_.text).mkString
 }

--- a/shared/src/main/scala/scala/xml/Equality.scala
+++ b/shared/src/main/scala/scala/xml/Equality.scala
@@ -63,7 +63,7 @@ object Equality {
   }
   def compareBlithely(x1: AnyRef, x2: AnyRef): Boolean = {
     if (x1 == null || x2 == null)
-      return x1 eq x2
+      return x1.eq(x2)
 
     x2 match {
       case s: String => compareBlithely(x1, s)
@@ -108,9 +108,9 @@ trait Equality extends scala.Equals {
    */
   private def doComparison(other: Any, blithe: Boolean): Boolean = {
     val strictlyEqual: Boolean = other match {
-      case x: AnyRef if this eq x => true
-      case x: Equality            => (x canEqual this) && (this strict_== x)
-      case _                      => false
+      case x: AnyRef if this.eq(x) => true
+      case x: Equality             => (x canEqual this) && (this strict_== x)
+      case _                       => false
     }
 
     strictlyEqual || (blithe && compareBlithely(this, asRef(other)))

--- a/shared/src/main/scala/scala/xml/Group.scala
+++ b/shared/src/main/scala/scala/xml/Group.scala
@@ -29,7 +29,7 @@ final case class Group(nodes: Seq[Node]) extends Node {
   }
 
   override def strict_==(other: Equality): Boolean = other match {
-    case Group(xs) => nodes sameElements xs
+    case Group(xs) => nodes.sameElements(xs)
     case _         => false
   }
 
@@ -39,7 +39,7 @@ final case class Group(nodes: Seq[Node]) extends Node {
    * Since Group is very much a hack it throws an exception if you
    *  try to do anything with it.
    */
-  private def fail(msg: String): Nothing = throw new UnsupportedOperationException("class Group does not support method '%s'" format msg)
+  private def fail(msg: String): Nothing = throw new UnsupportedOperationException("class Group does not support method '%s'".format(msg))
 
   override def label: Nothing = fail("label")
   override def attributes: Nothing = fail("attributes")

--- a/shared/src/main/scala/scala/xml/MetaData.scala
+++ b/shared/src/main/scala/scala/xml/MetaData.scala
@@ -29,8 +29,8 @@ object MetaData {
    */
   @tailrec
   def concatenate(attribs: MetaData, new_tail: MetaData): MetaData =
-    if (attribs eq Null) new_tail
-    else concatenate(attribs.next, attribs copy new_tail)
+    if (attribs.eq(Null)) new_tail
+    else concatenate(attribs.next, attribs.copy(new_tail))
 
   /**
    * returns normalized MetaData, with all duplicates removed and namespace prefixes resolved to
@@ -38,16 +38,16 @@ object MetaData {
    */
   def normalize(attribs: MetaData, scope: NamespaceBinding): MetaData = {
     def iterate(md: MetaData, normalized_attribs: MetaData, set: Set[String]): MetaData = {
-      if (md eq Null) {
+      if (md.eq(Null)) {
         normalized_attribs
-      } else if (md.value eq null) {
+      } else if (md.value.eq(null)) {
         iterate(md.next, normalized_attribs, set)
       } else {
         val key: String = getUniversalKey(md, scope)
         if (set(key)) {
           iterate(md.next, normalized_attribs, set)
         } else {
-          md copy iterate(md.next, normalized_attribs, set + key)
+          md.copy(iterate(md.next, normalized_attribs, set + key))
         }
       }
     }
@@ -154,8 +154,8 @@ abstract class MetaData
 
   /** filters this sequence of meta data */
   override def filter(f: MetaData => Boolean): MetaData =
-    if (f(this)) copy(next filter f)
-    else next filter f
+    if (f(this)) copy(next.filter(f))
+    else next.filter(f)
 
   def reverse: MetaData =
     foldLeft(Null: MetaData) { (x, xs) =>
@@ -181,7 +181,7 @@ abstract class MetaData
    * Returns a Map containing the attributes stored as key/value pairs.
    */
   def asAttrMap: Map[String, String] =
-    (iterator map (x => (x.prefixedKey, x.value.text))).toMap
+    iterator.map(x => (x.prefixedKey, x.value.text)).toMap
 
   /** returns Null or the next MetaData item */
   def next: MetaData
@@ -217,9 +217,9 @@ abstract class MetaData
   override def toString: String = sbToString(buildString)
 
   def buildString(sb: StringBuilder): StringBuilder = {
-    sb append ' '
+    sb.append(' ')
     toString1(sb)
-    next buildString sb
+    next.buildString(sb)
   }
 
   /**

--- a/shared/src/main/scala/scala/xml/NamespaceBinding.scala
+++ b/shared/src/main/scala/scala/xml/NamespaceBinding.scala
@@ -14,7 +14,6 @@ package scala
 package xml
 
 import scala.collection.Seq
-import Utility.sbToString
 
 /**
  * The class `NamespaceBinding` represents namespace bindings
@@ -30,7 +29,7 @@ case class NamespaceBinding(prefix: String, uri: String, parent: NamespaceBindin
     throw new IllegalArgumentException("zero length prefix not allowed")
 
   def getURI(_prefix: String): String =
-    if (prefix == _prefix) uri else parent getURI _prefix
+    if (prefix == _prefix) uri else parent.getURI(_prefix)
 
   /**
    * Returns some prefix that is mapped to the URI.
@@ -40,13 +39,13 @@ case class NamespaceBinding(prefix: String, uri: String, parent: NamespaceBindin
    * if no prefix is mapped to the URI.
    */
   def getPrefix(_uri: String): String =
-    if (_uri == uri) prefix else parent getPrefix _uri
+    if (_uri == uri) prefix else parent.getPrefix(_uri)
 
-  override def toString: String = sbToString(buildString(_, TopScope))
+  override def toString: String = Utility.sbToString(buildString(_, TopScope))
 
   private def shadowRedefined(stop: NamespaceBinding): NamespaceBinding = {
     def prefixList(x: NamespaceBinding): List[String] =
-      if ((x == null) || (x eq stop)) Nil
+      if ((x == null) || x.eq(stop)) Nil
       else x.prefix :: prefixList(x.parent)
     def fromPrefixList(l: List[String]): NamespaceBinding = l match {
       case Nil     => stop
@@ -70,7 +69,7 @@ case class NamespaceBinding(prefix: String, uri: String, parent: NamespaceBindin
 
   override def basisForHashCode: Seq[Any] = List(prefix, uri, parent)
 
-  def buildString(stop: NamespaceBinding): String = sbToString(buildString(_, stop))
+  def buildString(stop: NamespaceBinding): String = Utility.sbToString(buildString(_, stop))
 
   def buildString(sb: StringBuilder, stop: NamespaceBinding): Unit = {
     shadowRedefined(stop).doBuildString(sb, stop)
@@ -83,6 +82,6 @@ case class NamespaceBinding(prefix: String, uri: String, parent: NamespaceBindin
       if (prefix != null) ":" + prefix else "",
       if (uri != null) uri else ""
     )
-    parent.doBuildString(sb append s, stop) // copy(ignore)
+    parent.doBuildString(sb.append(s), stop) // copy(ignore)
   }
 }

--- a/shared/src/main/scala/scala/xml/Node.scala
+++ b/shared/src/main/scala/scala/xml/Node.scala
@@ -81,7 +81,7 @@ abstract class Node extends NodeSeq {
    * @return    the namespace if `scope != null` and prefix was
    *            found, else `null`
    */
-  def getNamespace(pre: String): String = if (scope eq null) null else scope.getURI(pre)
+  def getNamespace(pre: String): String = if (scope.eq(null)) null else scope.getURI(pre)
 
   /**
    * Convenience method, looks up an unprefixed attribute in attributes of this node.
@@ -124,7 +124,7 @@ abstract class Node extends NodeSeq {
   /**
    * Children which do not stringify to "" (needed for equality)
    */
-  def nonEmptyChildren: Seq[Node] = child filterNot (_.toString == "")
+  def nonEmptyChildren: Seq[Node] = child.filterNot(_.toString == "")
 
   /**
    * Descendant axis (all descendants of this node, not including node itself)
@@ -155,7 +155,7 @@ abstract class Node extends NodeSeq {
         (label == x.label) &&
         (attributes == x.attributes) &&
         // (scope == x.scope)               // note - original code didn't compare scopes so I left it as is.
-        (nonEmptyChildren sameElements x.nonEmptyChildren)
+        nonEmptyChildren.sameElements(x.nonEmptyChildren)
     case _ =>
       false
   }
@@ -185,10 +185,10 @@ abstract class Node extends NodeSeq {
    */
   def nameToString(sb: StringBuilder): StringBuilder = {
     if (null != prefix) {
-      sb append prefix
-      sb append ':'
+      sb.append(prefix)
+      sb.append(':')
     }
-    sb append label
+    sb.append(label)
   }
 
   /**

--- a/shared/src/main/scala/scala/xml/NodeBuffer.scala
+++ b/shared/src/main/scala/scala/xml/NodeBuffer.scala
@@ -38,7 +38,7 @@ class NodeBuffer extends scala.collection.mutable.ArrayBuffer[Node] with ScalaVe
   def &+(o: Any): NodeBuffer = {
     o match {
       case null | _: Unit | Text("") => // ignore
-      case it: Iterator[_]           => it foreach &+
+      case it: Iterator[_]           => it.foreach(&+)
       case n: Node                   => super.+=(n)
       case ns: Iterable[_]           => this &+ ns.iterator
       case ns: Array[_]              => this &+ ns.iterator

--- a/shared/src/main/scala/scala/xml/PCData.scala
+++ b/shared/src/main/scala/scala/xml/PCData.scala
@@ -30,7 +30,7 @@ class PCData(data: String) extends Atom[String](data) {
    *  @return the input string buffer with the formatted CDATA section
    */
   override def buildString(sb: StringBuilder): StringBuilder =
-    sb append "<![CDATA[%s]]>".format(data.replaceAll("]]>", "]]]]><![CDATA[>"))
+    sb.append("<![CDATA[%s]]>".format(data.replaceAll("]]>", "]]]]><![CDATA[>")))
 }
 
 /**

--- a/shared/src/main/scala/scala/xml/PrefixedAttribute.scala
+++ b/shared/src/main/scala/scala/xml/PrefixedAttribute.scala
@@ -29,11 +29,11 @@ class PrefixedAttribute(
   override val value: Seq[Node],
   val next1: MetaData)
   extends Attribute {
-  override val next: MetaData = if (value ne null) next1 else next1.remove(key)
+  override val next: MetaData = if (value.ne(null)) next1 else next1.remove(key)
 
   /** same as this(pre, key, Text(value), next), or no attribute if value is null */
   def this(pre: String, key: String, value: String, next: MetaData) =
-    this(pre, key, if (value ne null) Text(value) else null: NodeSeq, next)
+    this(pre, key, if (value.ne(null)) Text(value) else null: NodeSeq, next)
 
   /** same as this(pre, key, value.get, next), or no attribute if value is None */
   def this(pre: String, key: String, value: Option[Seq[Node]], next: MetaData) =

--- a/shared/src/main/scala/scala/xml/PrettyPrinter.scala
+++ b/shared/src/main/scala/scala/xml/PrettyPrinter.scala
@@ -59,7 +59,7 @@ class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean) {
     val tmp: Int = width - cur
     if (s.length <= tmp)
       return List(Box(ind, s))
-    var i: Int = s indexOf ' '
+    var i: Int = s.indexOf(' ')
     if (i > tmp || i == -1) throw new BrokenException() // cannot break
 
     var last: List[Int] = Nil
@@ -87,7 +87,7 @@ class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean) {
     if (cur + s.length > width) { // fits in this line
       items ::= Box(ind, s)
       cur += s.length
-    } else try cut(s, ind) foreach (items ::= _) // break it up
+    } else try cut(s, ind).foreach(items ::= _) // break it up
     catch { case _: BrokenException => makePara(ind, s) } // give up, para
 
   // dont respect indent in para, but afterwards
@@ -104,10 +104,10 @@ class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean) {
 
   protected def leafTag(n: Node): String = {
     def mkLeaf(sb: StringBuilder): Unit = {
-      sb append '<'
-      n nameToString sb
-      n.attributes buildString sb
-      sb append "/>"
+      sb.append('<')
+      n.nameToString(sb)
+      n.attributes.buildString(sb)
+      sb.append("/>")
     }
     sbToString(mkLeaf)
   }
@@ -115,21 +115,21 @@ class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean) {
   protected def startTag(n: Node, pscope: NamespaceBinding): (String, Int) = {
     var i: Int = 0
     def mkStart(sb: StringBuilder): Unit = {
-      sb append '<'
-      n nameToString sb
+      sb.append('<')
+      n.nameToString(sb)
       i = sb.length + 1
-      n.attributes buildString sb
+      n.attributes.buildString(sb)
       n.scope.buildString(sb, pscope)
-      sb append '>'
+      sb.append('>')
     }
     (sbToString(mkStart), i)
   }
 
   protected def endTag(n: Node): String = {
     def mkEnd(sb: StringBuilder): Unit = {
-      sb append "</"
-      n nameToString sb
-      sb append '>'
+      sb.append("</")
+      n.nameToString(sb)
+      sb.append('>')
     }
     sbToString(mkEnd)
   }
@@ -139,7 +139,7 @@ class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean) {
       case _: Atom[_] | _: Comment | _: EntityRef | _: ProcInstr => true
       case _ => false
     }
-    n.child forall isLeaf
+    n.child.forall(isLeaf)
   }
 
   protected def fits(test: String): Boolean =
@@ -236,20 +236,20 @@ class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean) {
         lastwasbreak = true
         cur = 0
       //        while (cur < last) {
-      //          sb append ' '
+      //          sb.append(' ')
       //          cur += 1
       //        }
 
       case Box(i, s) =>
         lastwasbreak = false
         while (cur < i) {
-          sb append ' '
+          sb.append(' ')
           cur += 1
         }
         sb.append(s)
       case Para(s) =>
         lastwasbreak = false
-        sb append s
+        sb.append(s)
     }
   }
 
@@ -284,5 +284,5 @@ class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean) {
    *  @param sb     the string buffer to which to append to
    */
   def formatNodes(nodes: Seq[Node], pscope: NamespaceBinding, sb: StringBuilder): Unit =
-    nodes foreach (n => sb append format(n, pscope))
+    nodes.foreach(n => sb.append(format(n, pscope)))
 }

--- a/shared/src/main/scala/scala/xml/ProcInstr.scala
+++ b/shared/src/main/scala/scala/xml/ProcInstr.scala
@@ -23,7 +23,7 @@ package xml
 case class ProcInstr(target: String, proctext: String) extends SpecialNode {
   if (!Utility.isName(target))
     throw new IllegalArgumentException(target + " must be an XML Name")
-  if (proctext contains "?>")
+  if (proctext.contains("?>"))
     throw new IllegalArgumentException(proctext + " may not contain \"?>\"")
   if (target.toLowerCase == "xml")
     throw new IllegalArgumentException(target + " is reserved")
@@ -39,5 +39,5 @@ case class ProcInstr(target: String, proctext: String) extends SpecialNode {
    *  to this stringbuffer.
    */
   override def buildString(sb: StringBuilder): StringBuilder =
-    sb append "<?%s%s?>".format(target, if (proctext == "") "" else " " + proctext)
+    sb.append("<?%s%s?>".format(target, if (proctext == "") "" else " " + proctext))
 }

--- a/shared/src/main/scala/scala/xml/TextBuffer.scala
+++ b/shared/src/main/scala/scala/xml/TextBuffer.scala
@@ -17,7 +17,7 @@ import scala.collection.Seq
 import Utility.isSpace
 
 object TextBuffer {
-  def fromString(str: String): TextBuffer = new TextBuffer() append str
+  def fromString(str: String): TextBuffer = new TextBuffer().append(str)
 }
 
 /**
@@ -33,9 +33,9 @@ class TextBuffer {
    * Appends this string to the text buffer, trimming whitespaces as needed.
    */
   def append(cs: Seq[Char]): this.type = {
-    cs foreach { c =>
-      if (!isSpace(c)) sb append c
-      else if (sb.isEmpty || !isSpace(sb.last)) sb append ' '
+    cs.foreach { c =>
+      if (!isSpace(c)) sb.append(c)
+      else if (sb.isEmpty || !isSpace(sb.last)) sb.append(' ')
     }
     this
   }

--- a/shared/src/main/scala/scala/xml/Unparsed.scala
+++ b/shared/src/main/scala/scala/xml/Unparsed.scala
@@ -27,7 +27,7 @@ class Unparsed(data: String) extends Atom[String](data) {
    *  specification.
    */
   override def buildString(sb: StringBuilder): StringBuilder =
-    sb append data
+    sb.append(data)
 }
 
 /**

--- a/shared/src/main/scala/scala/xml/UnprefixedAttribute.scala
+++ b/shared/src/main/scala/scala/xml/UnprefixedAttribute.scala
@@ -26,11 +26,11 @@ class UnprefixedAttribute(
   next1: MetaData)
   extends Attribute {
   final override val pre: scala.Null = null
-  override val next: MetaData = if (value ne null) next1 else next1.remove(key)
+  override val next: MetaData = if (value.ne(null)) next1 else next1.remove(key)
 
   /** same as this(key, Text(value), next), or no attribute if value is null */
   def this(key: String, value: String, next: MetaData) =
-    this(key, if (value ne null) Text(value) else null: NodeSeq, next)
+    this(key, if (value.ne(null)) Text(value) else null: NodeSeq, next)
 
   /** same as this(key, value.get, next), or no attribute if value is None */
   def this(key: String, value: Option[Seq[Node]], next: MetaData) =

--- a/shared/src/main/scala/scala/xml/XML.scala
+++ b/shared/src/main/scala/scala/xml/XML.scala
@@ -126,7 +126,7 @@ object XML extends XMLLoader[Elem] {
   ): Unit = {
     /* TODO: optimize by giving writer parameter to toXML*/
     if (xmlDecl) w.write("<?xml version='1.0' encoding='" + enc + "'?>\n")
-    if (doctype ne null) w.write(doctype.toString + "\n")
+    if (doctype.ne(null)) w.write(doctype.toString + "\n")
     w.write(Utility.serialize(node, minimizeTags = minimizeTags).toString)
   }
 }

--- a/shared/src/main/scala/scala/xml/Xhtml.scala
+++ b/shared/src/main/scala/scala/xml/Xhtml.scala
@@ -49,40 +49,40 @@ object Xhtml {
     stripComments: Boolean = false,
     decodeEntities: Boolean = false,
     preserveWhitespace: Boolean = false,
-    minimizeTags: Boolean = true): Unit =
-    {
-      def decode(er: EntityRef): StringBuilder = XhtmlEntities.entMap.get(er.entityName) match {
-        case Some(chr) if chr.toInt >= 128 => sb.append(chr)
-        case _                             => er.buildString(sb)
-      }
-      def shortForm: Boolean =
-        minimizeTags &&
-          (x.child == null || x.child.isEmpty) &&
-          (minimizableElements contains x.label)
-
-      x match {
-        case c: Comment                      => if (!stripComments) c buildString sb
-        case er: EntityRef if decodeEntities => decode(er)
-        case x: SpecialNode                  => x buildString sb
-        case g: Group =>
-          g.nodes foreach { toXhtml(_, x.scope, sb, stripComments, decodeEntities, preserveWhitespace, minimizeTags) }
-
-        case _ =>
-          sb.append('<')
-          x.nameToString(sb)
-          if (x.attributes ne null) x.attributes.buildString(sb)
-          x.scope.buildString(sb, pscope)
-
-          if (shortForm) sb.append(" />")
-          else {
-            sb.append('>')
-            sequenceToXML(x.child, x.scope, sb, stripComments, decodeEntities, preserveWhitespace, minimizeTags)
-            sb.append("</")
-            x.nameToString(sb)
-            sb.append('>')
-          }
-      }
+    minimizeTags: Boolean = true
+  ): Unit = {
+    def decode(er: EntityRef): StringBuilder = XhtmlEntities.entMap.get(er.entityName) match {
+      case Some(chr) if chr.toInt >= 128 => sb.append(chr)
+      case _                             => er.buildString(sb)
     }
+    def shortForm: Boolean =
+      minimizeTags &&
+        (x.child == null || x.child.isEmpty) &&
+        minimizableElements.contains(x.label)
+
+    x match {
+      case c: Comment                      => if (!stripComments) c.buildString(sb)
+      case er: EntityRef if decodeEntities => decode(er)
+      case x: SpecialNode                  => x.buildString(sb)
+      case g: Group =>
+        g.nodes.foreach { toXhtml(_, x.scope, sb, stripComments, decodeEntities, preserveWhitespace, minimizeTags) }
+
+      case _ =>
+        sb.append('<')
+        x.nameToString(sb)
+        if (x.attributes.ne(null)) x.attributes.buildString(sb)
+        x.scope.buildString(sb, pscope)
+
+        if (shortForm) sb.append(" />")
+        else {
+          sb.append('>')
+          sequenceToXML(x.child, x.scope, sb, stripComments, decodeEntities, preserveWhitespace, minimizeTags)
+          sb.append("</")
+          x.nameToString(sb)
+          sb.append('>')
+        }
+    }
+  }
 
   /**
    * Amounts to calling toXhtml(node, ...) with the given parameters on each node.
@@ -94,16 +94,16 @@ object Xhtml {
     stripComments: Boolean = false,
     decodeEntities: Boolean = false,
     preserveWhitespace: Boolean = false,
-    minimizeTags: Boolean = true): Unit =
-    {
-      if (children.isEmpty)
-        return
+    minimizeTags: Boolean = true
+  ): Unit = {
+    if (children.isEmpty)
+      return
 
-      val doSpaces: Boolean = children forall isAtomAndNotText // interleave spaces
-      for (c <- children.take(children.length - 1)) {
-        toXhtml(c, pscope, sb, stripComments, decodeEntities, preserveWhitespace, minimizeTags)
-        if (doSpaces) sb append ' '
-      }
-      toXhtml(children.last, pscope, sb, stripComments, decodeEntities, preserveWhitespace, minimizeTags)
+    val doSpaces: Boolean = children.forall(isAtomAndNotText) // interleave spaces
+    for (c <- children.take(children.length - 1)) {
+      toXhtml(c, pscope, sb, stripComments, decodeEntities, preserveWhitespace, minimizeTags)
+      if (doSpaces) sb.append(' ')
     }
+    toXhtml(children.last, pscope, sb, stripComments, decodeEntities, preserveWhitespace, minimizeTags)
+  }
 }

--- a/shared/src/main/scala/scala/xml/dtd/ContentModel.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ContentModel.scala
@@ -38,7 +38,7 @@ object ContentModel extends WordExp {
   }
 
   case class ElemName(name: String) extends Label {
-    override def toString: String = """ElemName("%s")""" format name
+    override def toString: String = """ElemName("%s")""".format(name)
   }
 
   def isMixed(cm: ContentModel): Boolean = cond(cm) { case _: MIXED => true }
@@ -48,8 +48,8 @@ object ContentModel extends WordExp {
     def traverse(r: RegExp): Set[String] = r match { // !!! check for match translation problem
       case Letter(ElemName(name)) => Set(name)
       case Star(x@_)              => traverse(x) // bug if x@_*
-      case Sequ(xs@_*)            => Set(xs flatMap traverse: _*)
-      case Alt(xs@_*)             => Set(xs flatMap traverse: _*)
+      case Sequ(xs@_*)            => Set(xs.flatMap(traverse): _*)
+      case Alt(xs@_*)             => Set(xs.flatMap(traverse): _*)
     }
 
     traverse(r)
@@ -61,16 +61,16 @@ object ContentModel extends WordExp {
   private def buildString(rs: Seq[RegExp], sb: StringBuilder, sep: Char): Unit = {
     buildString(rs.head, sb)
     for (z <- rs.tail) {
-      sb append sep
+      sb.append(sep)
       buildString(z, sb)
     }
   }
 
   def buildString(c: ContentModel, sb: StringBuilder): StringBuilder = c match {
-    case ANY                    => sb append "ANY"
-    case EMPTY                  => sb append "EMPTY"
-    case PCDATA                 => sb append "(#PCDATA)"
-    case ELEMENTS(_) | MIXED(_) => c buildString sb
+    case ANY                    => sb.append("ANY")
+    case EMPTY                  => sb.append("EMPTY")
+    case PCDATA                 => sb.append("(#PCDATA)")
+    case ELEMENTS(_) | MIXED(_) => c.buildString(sb)
   }
 
   def buildString(r: RegExp, sb: StringBuilder): StringBuilder =
@@ -118,11 +118,11 @@ case class MIXED(override val r: RegExp) extends DFAContentModel {
   import ContentModel.Alt
 
   override def buildString(sb: StringBuilder): StringBuilder = {
-    val newAlt: Alt = r match { case Alt(rs@_*) => Alt(rs drop 1: _*) }
+    val newAlt: Alt = r match { case Alt(rs@_*) => Alt(rs.drop(1): _*) }
 
-    sb append "(#PCDATA|"
+    sb.append("(#PCDATA|")
     ContentModel.buildString(newAlt: RegExp, sb)
-    sb append ")*"
+    sb.append(")*")
   }
 }
 

--- a/shared/src/main/scala/scala/xml/dtd/Decl.scala
+++ b/shared/src/main/scala/scala/xml/dtd/Decl.scala
@@ -40,17 +40,17 @@ sealed abstract class MarkupDecl extends Decl {
 case class ElemDecl(name: String, contentModel: ContentModel)
   extends MarkupDecl {
   override def buildString(sb: StringBuilder): StringBuilder = {
-    sb append "<!ELEMENT " append name append ' '
+    sb.append("<!ELEMENT ").append(name).append(' ')
 
     ContentModel.buildString(contentModel, sb)
-    sb append '>'
+    sb.append('>')
   }
 }
 
 case class AttListDecl(name: String, attrs: List[AttrDecl])
   extends MarkupDecl {
   override def buildString(sb: StringBuilder): StringBuilder = {
-    sb append "<!ATTLIST " append name append '\n' append attrs.mkString("", "\n", ">")
+    sb.append("<!ATTLIST ").append(name).append('\n').append(attrs.mkString("", "\n", ">"))
   }
 }
 
@@ -63,8 +63,8 @@ case class AttrDecl(name: String, tpe: String, default: DefaultDecl) {
   override def toString: String = sbToString(buildString)
 
   def buildString(sb: StringBuilder): StringBuilder = {
-    sb append "  " append name append ' ' append tpe append ' '
-    default buildString sb
+    sb.append("  ").append(name).append(' ').append(tpe).append(' ')
+    default.buildString(sb)
   }
 
 }
@@ -75,31 +75,31 @@ sealed abstract class EntityDecl extends MarkupDecl
 /** a parsed general entity declaration */
 case class ParsedEntityDecl(name: String, entdef: EntityDef) extends EntityDecl {
   override def buildString(sb: StringBuilder): StringBuilder = {
-    sb append "<!ENTITY " append name append ' '
-    entdef buildString sb append '>'
+    sb.append("<!ENTITY ").append(name).append(' ')
+    entdef.buildString(sb).append('>')
   }
 }
 
 /** a parameter entity declaration */
 case class ParameterEntityDecl(name: String, entdef: EntityDef) extends EntityDecl {
   override def buildString(sb: StringBuilder): StringBuilder = {
-    sb append "<!ENTITY % " append name append ' '
-    entdef buildString sb append '>'
+    sb.append("<!ENTITY % ").append(name).append(' ')
+    entdef.buildString(sb).append('>')
   }
 }
 
 /** an unparsed entity declaration */
 case class UnparsedEntityDecl(name: String, extID: ExternalID, notation: String) extends EntityDecl {
   override def buildString(sb: StringBuilder): StringBuilder = {
-    sb append "<!ENTITY " append name append ' '
-    extID buildString sb append " NDATA " append notation append '>'
+    sb.append("<!ENTITY ").append(name).append(' ')
+    extID.buildString(sb).append(" NDATA ").append(notation).append('>')
   }
 }
 /** a notation declaration */
 case class NotationDecl(name: String, extID: ExternalID) extends MarkupDecl {
   override def buildString(sb: StringBuilder): StringBuilder = {
-    sb append "<!NOTATION " append name append ' '
-    extID buildString sb
+    sb.append("<!NOTATION ").append(name).append(' ')
+    extID.buildString(sb)
   }
 }
 
@@ -110,7 +110,7 @@ sealed abstract class EntityDef {
 case class IntDef(value: String) extends EntityDef {
   private def validateValue(): Unit = {
     var tmp: String = value
-    var ix: Int = tmp indexOf '%'
+    var ix: Int = tmp.indexOf('%')
     while (ix != -1) {
       val iz: Int = tmp.indexOf(';', ix)
       if (iz == -1 && iz == ix + 1)
@@ -122,7 +122,7 @@ case class IntDef(value: String) extends EntityDef {
           throw new IllegalArgumentException("internal entity def: \"" + n + "\" must be an XML Name")
 
         tmp = tmp.substring(iz + 1, tmp.length)
-        ix = tmp indexOf '%'
+        ix = tmp.indexOf('%')
       }
     }
   }
@@ -135,7 +135,7 @@ case class IntDef(value: String) extends EntityDef {
 
 case class ExtDef(extID: ExternalID) extends EntityDef {
   override def buildString(sb: StringBuilder): StringBuilder =
-    extID buildString sb
+    extID.buildString(sb)
 }
 
 /** a parsed entity reference */
@@ -144,7 +144,7 @@ case class PEReference(ent: String) extends MarkupDecl {
     throw new IllegalArgumentException("ent must be an XML Name")
 
   override def buildString(sb: StringBuilder): StringBuilder =
-    sb append '%' append ent append ';'
+    sb.append('%').append(ent).append(';')
 }
 
 // default declarations for attributes
@@ -156,18 +156,18 @@ sealed abstract class DefaultDecl {
 
 case object REQUIRED extends DefaultDecl {
   override def toString: String = "#REQUIRED"
-  override def buildString(sb: StringBuilder): StringBuilder = sb append "#REQUIRED"
+  override def buildString(sb: StringBuilder): StringBuilder = sb.append("#REQUIRED")
 }
 
 case object IMPLIED extends DefaultDecl {
   override def toString: String = "#IMPLIED"
-  override def buildString(sb: StringBuilder): StringBuilder = sb append "#IMPLIED"
+  override def buildString(sb: StringBuilder): StringBuilder = sb.append("#IMPLIED")
 }
 
 case class DEFAULT(fixed: Boolean, attValue: String) extends DefaultDecl {
   override def toString: String = sbToString(buildString)
   override def buildString(sb: StringBuilder): StringBuilder = {
-    if (fixed) sb append "#FIXED "
+    if (fixed) sb.append("#FIXED ")
     Utility.appendEscapedQuoted(attValue, sb)
   }
 }

--- a/shared/src/main/scala/scala/xml/dtd/ExternalID.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ExternalID.scala
@@ -21,7 +21,7 @@ package dtd
  */
 sealed abstract class ExternalID extends parsing.TokenTests {
   def quoted(s: String): String = {
-    val c: Char = if (s contains '"') '\'' else '"'
+    val c: Char = if (s.contains('"')) '\'' else '"'
     c.toString + s + c
   }
 

--- a/shared/src/main/scala/scala/xml/dtd/ValidationException.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ValidationException.scala
@@ -36,7 +36,7 @@ object MakeValidationException {
   def fromMissingAttribute(allKeys: Set[String]): ValidationException = {
     val sb: StringBuilder = new StringBuilder("missing value for REQUIRED attribute")
     if (allKeys.size > 1) sb.append('s')
-    allKeys foreach (k => sb append "'%s'".format(k))
+    allKeys.foreach(k => sb.append("'%s'".format(k)))
     ValidationException(sb.toString)
   }
 

--- a/shared/src/main/scala/scala/xml/dtd/impl/Base.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/Base.scala
@@ -38,7 +38,7 @@ private[dtd] abstract class Base {
   }
 
   class Alt private (val rs: _regexpT*) extends RegExp {
-    final override val isNullable: Boolean = rs exists (_.isNullable)
+    final override val isNullable: Boolean = rs.exists(_.isNullable)
   }
 
   object Sequ {
@@ -48,7 +48,7 @@ private[dtd] abstract class Base {
   }
 
   class Sequ private (val rs: _regexpT*) extends RegExp {
-    final override val isNullable: Boolean = rs forall (_.isNullable)
+    final override val isNullable: Boolean = rs.forall(_.isNullable)
   }
 
   case class Star(r: _regexpT) extends RegExp {

--- a/shared/src/main/scala/scala/xml/dtd/impl/BaseBerrySethi.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/BaseBerrySethi.scala
@@ -42,12 +42,12 @@ private[dtd] abstract class BaseBerrySethi {
   final val emptySet: Set[Int] = Set()
 
   private def doComp(r: RegExp, compFunction: RegExp => Set[Int]): Set[Int] = r match {
-    case x: Alt  => (x.rs map compFirst).foldLeft(emptySet)(_ ++ _)
+    case x: Alt  => x.rs.map(compFirst).foldLeft(emptySet)(_ ++ _)
     case Eps     => emptySet
     case x: Meta => compFunction(x.r)
     case x: Sequ =>
-      val (l1: Seq[lang._regexpT], l2: Seq[lang._regexpT]) = x.rs span (_.isNullable)
-      ((l1 ++ (l2 take 1)) map compFunction).foldLeft(emptySet)(_ ++ _)
+      val (l1: Seq[lang._regexpT], l2: Seq[lang._regexpT]) = x.rs.span(_.isNullable)
+      (l1 ++ l2.take(1)).map(compFunction).foldLeft(emptySet)(_ ++ _)
     case Star(t) => compFunction(t)
     case _       => throw new IllegalArgumentException("unexpected pattern " + r.getClass)
   }
@@ -98,8 +98,8 @@ private[dtd] abstract class BaseBerrySethi {
    */
   protected def traverse(r: RegExp): Unit = r match {
     // (is tree automaton stuff, more than Berry-Sethi)
-    case x: Alt  => x.rs foreach traverse
-    case x: Sequ => x.rs foreach traverse
+    case x: Alt  => x.rs.foreach(traverse)
+    case x: Sequ => x.rs.foreach(traverse)
     case x: Meta => traverse(x.r)
     case Star(t) => traverse(t)
     case _       => throw new IllegalArgumentException("unexp pattern " + r.getClass)

--- a/shared/src/main/scala/scala/xml/dtd/impl/DetWordAutom.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/DetWordAutom.scala
@@ -42,10 +42,10 @@ private[dtd] abstract class DetWordAutom[T <: AnyRef] {
     sb.append(map.toString)
     sb.append(" delta=\n")
 
-    for (i <- 0 until nstates) {
-      sb append "%d->%s\n".format(i, delta(i))
+    for (i <- 0.until(nstates)) {
+      sb.append("%d->%s\n".format(i, delta(i)))
       if (i < default.length)
-        sb append "_>%s\n".format(default(i))
+        sb.append("_>%s\n".format(default(i)))
     }
     sb.toString
   }

--- a/shared/src/main/scala/scala/xml/dtd/impl/NondetWordAutom.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/NondetWordAutom.scala
@@ -39,10 +39,10 @@ private[dtd] abstract class NondetWordAutom[T <: AnyRef] {
   final def finalTag(state: Int): Int = finals(state)
 
   /** @return true if the set of states contains at least one final state */
-  final def containsFinal(Q: immutable.BitSet): Boolean = Q exists isFinal
+  final def containsFinal(Q: immutable.BitSet): Boolean = Q.exists(isFinal)
 
   /** @return true if there are no accepting states */
-  final def isEmpty: Boolean = (0 until nstates) forall (x => !isFinal(x))
+  final def isEmpty: Boolean = 0.until(nstates).forall(x => !isFinal(x))
 
   /** @return a immutable.BitSet with the next states for given state and label */
   def next(q: Int, a: T): immutable.BitSet = delta(q).getOrElse(a, default(q))
@@ -54,11 +54,11 @@ private[dtd] abstract class NondetWordAutom[T <: AnyRef] {
   private def next(Q: immutable.BitSet, f: Int => immutable.BitSet): immutable.BitSet =
     Q.toSet.map(f).foldLeft(immutable.BitSet.empty)(_ ++ _)
 
-  private def finalStates: immutable.Seq[Int] = 0 until nstates filter isFinal
+  private def finalStates: immutable.Seq[Int] = 0.until(nstates).filter(isFinal)
   override def toString: String = {
 
-    val finalString: String = Map(finalStates map (j => j -> finals(j)): _*).toString
-    val deltaString: String = (0 until nstates)
+    val finalString: String = Map(finalStates.map(j => j -> finals(j)): _*).toString
+    val deltaString: String = 0.until(nstates)
       .map(i => "   %d->%s\n    _>%s\n".format(i, delta(i), default(i))).mkString
 
     "[NondetWordAutom  nstates=%d  finals=%s  delta=\n%s".format(nstates, finalString, deltaString)

--- a/shared/src/main/scala/scala/xml/dtd/impl/SubsetConstruction.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/SubsetConstruction.scala
@@ -20,7 +20,7 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
   import nfa.labels
 
   def selectTag(Q: immutable.BitSet, finals: Array[Int]): Int =
-    (Q map finals filter (_ > 0)).min
+    Q.map(finals).filter(_ > 0).min
 
   def determinize: DetWordAutom[T] = {
     // for assigning numbers to bitsets
@@ -42,7 +42,7 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
     rest = q0 :: sink :: rest
 
     def addFinal(q: immutable.BitSet): Unit = {
-      if (nfa containsFinal q)
+      if (nfa.containsFinal(q))
         finals(q) = selectTag(q, nfa.finals)
     }
     def add(Q: immutable.BitSet): Unit = {
@@ -67,7 +67,7 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
       val Pdelta: mutable.HashMap[T, immutable.BitSet] = new mutable.HashMap[T, immutable.BitSet]
       delta.update(P, Pdelta)
 
-      labels foreach { label =>
+      labels.foreach { label =>
         val Q: immutable.BitSet = nfa.next(P, label)
         Pdelta.update(label, Q)
         add(Q)
@@ -102,7 +102,7 @@ private[dtd] class SubsetConstruction[T <: AnyRef](val nfa: NondetWordAutom[T]) 
       defaultR(q) = qDef
     }
 
-    finals foreach { case (k, v) => finalsR(indexMap(k)) = v }
+    finals.foreach { case (k, v) => finalsR(indexMap(k)) = v }
 
     new DetWordAutom[T] {
       override val nstates: Int = nstatesR

--- a/shared/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
+++ b/shared/src/main/scala/scala/xml/dtd/impl/WordBerrySethi.scala
@@ -109,7 +109,7 @@ private[dtd] abstract class WordBerrySethi extends BaseBerrySethi {
     this.pos = 0
 
     // determine "Sethi-length" of the regexp
-    subexpr foreach traverse
+    subexpr.foreach(traverse)
 
     this.initials = Set(0)
   }
@@ -119,14 +119,14 @@ private[dtd] abstract class WordBerrySethi extends BaseBerrySethi {
     deltaq = new Array[mutable.HashMap[_labelT, List[Int]]](pos) // delta
     defaultq = new Array[List[Int]](pos) // default transitions
 
-    for (j <- 0 until pos) {
+    for (j <- 0.until(pos)) {
       deltaq(j) = mutable.HashMap[_labelT, List[Int]]()
       defaultq(j) = Nil
     }
   }
 
   protected def collectTransitions(): Unit = // make transitions
-    for (j <- 0 until pos; fol = follow(j); k <- fol) {
+    for (j <- 0.until(pos); fol = follow(j); k <- fol) {
       if (pos == k) finals = finals.updated(j, finalTag)
       else makeTransition(j, k, labelAt(k))
     }
@@ -149,14 +149,14 @@ private[dtd] abstract class WordBerrySethi extends BaseBerrySethi {
           finals = finals.updated(0, finalTag)
 
         val delta1: immutable.Map[Int, mutable.HashMap[lang._labelT, List[Int]]] = deltaq.zipWithIndex.map(_.swap).toMap
-        val finalsArr: Array[Int] = (0 until pos map (k => finals.getOrElse(k, 0))).toArray // 0 == not final
+        val finalsArr: Array[Int] = 0.until(pos).map(k => finals.getOrElse(k, 0)).toArray // 0 == not final
 
         val deltaArr: Array[mutable.Map[_labelT, immutable.BitSet]] =
-          (0 until pos map { x =>
-            mutable.HashMap(delta1(x).toSeq map { case (k, v) => k -> immutable.BitSet(v: _*) }: _*)
-          }).toArray
+          0.until(pos).map { x =>
+            mutable.HashMap(delta1(x).toSeq.map { case (k, v) => k -> immutable.BitSet(v: _*) }: _*)
+          }.toArray
 
-        val defaultArr: Array[immutable.BitSet] = (0 until pos map (k => immutable.BitSet(defaultq(k): _*))).toArray
+        val defaultArr: Array[immutable.BitSet] = 0.until(pos).map(k => immutable.BitSet(defaultq(k): _*)).toArray
 
         new NondetWordAutom[_labelT] {
           override val nstates: Int = pos

--- a/shared/src/main/scala/scala/xml/factory/NodeFactory.scala
+++ b/shared/src/main/scala/scala/xml/factory/NodeFactory.scala
@@ -32,7 +32,7 @@ trait NodeFactory[A <: Node] {
   }
 
   def eqElements(ch1: Seq[Node], ch2: Seq[Node]): Boolean =
-    ch1.view.zipAll(ch2.view, null, null) forall { case (x, y) => x eq y }
+    ch1.view.zipAll(ch2.view, null, null).forall { case (x, y) => x.eq(y) }
 
   def nodeEquals(n: Node, pre: String, name: String, attrSeq: MetaData, scope: NamespaceBinding, children: Seq[Node]): Boolean =
     n.prefix == pre &&

--- a/shared/src/main/scala/scala/xml/include/sax/XIncludeFilter.scala
+++ b/shared/src/main/scala/scala/xml/include/sax/XIncludeFilter.scala
@@ -143,13 +143,13 @@ class XIncludeFilter extends XMLFilterImpl {
           throw new SAXException("Missing href attribute")
         }
 
-        var parse: String = atts getValue "parse"
+        var parse: String = atts.getValue("parse")
         if (parse == null) parse = "xml"
 
-        if (parse equals "text") {
-          val encoding: String = atts getValue "encoding"
+        if (parse.equals("text")) {
+          val encoding: String = atts.getValue("encoding")
           includeTextDocument(href, encoding)
-        } else if (parse equals "xml") {
+        } else if (parse.equals("xml")) {
           includeXMLDocument(href)
         } // Need to check this also in DOM and JDOM????
         else {
@@ -346,7 +346,7 @@ class XIncludeFilter extends XMLFilterImpl {
       // save old level and base
       val previousLevel: Int = level
       this.level = 0
-      if (bases contains source)
+      if (bases.contains(source))
         throw new SAXException(
           "Circular XInclude Reference",
           new CircularIncludeException("Circular XInclude Reference to " + source + getLocation)

--- a/shared/src/main/scala/scala/xml/parsing/ExternalSources.scala
+++ b/shared/src/main/scala/scala/xml/parsing/ExternalSources.scala
@@ -26,12 +26,12 @@ trait ExternalSources {
   self: ExternalSources with MarkupParser with MarkupHandler =>
 
   def externalSource(systemId: String): Source = {
-    if (systemId startsWith "http:")
-      return Source fromURL new URL(systemId)
+    if (systemId.startsWith("http:"))
+      return Source.fromURL(new URL(systemId))
 
     val fileStr: String = input.descr match {
-      case x if x startsWith "file:" => x drop 5
-      case x                         => x take ((x lastIndexOf separator) + 1)
+      case x if x.startsWith("file:") => x.drop(5)
+      case x                          => x.take(x.lastIndexOf(separator) + 1)
     }
 
     Source.fromFile(fileStr + systemId)

--- a/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
+++ b/shared/src/main/scala/scala/xml/parsing/FactoryAdapter.scala
@@ -211,7 +211,7 @@ abstract class FactoryAdapter extends DefaultHandler2 with factory.XMLLoader[Nod
   }
 
   override def startPrefixMapping(prefix: String, uri: String): Unit =
-    prefixMappings ::= (prefix, uri)
+    prefixMappings ::= ((prefix, uri))
 
   override def endPrefixMapping(prefix: String): Unit = ()
 
@@ -242,9 +242,9 @@ abstract class FactoryAdapter extends DefaultHandler2 with factory.XMLLoader[Nod
       if (scopeStack.isEmpty) TopScope
       else scopeStack.head
 
-    for (i <- (0 until attributes.getLength).reverse) {
-      val qname: String = attributes getQName i
-      val value: String = attributes getValue i
+    for (i <- 0.until(attributes.getLength).reverse) {
+      val qname: String = attributes.getQName(i)
+      val value: String = attributes.getValue(i)
       val (pre: Option[String], key: String) = Utility.splitName(qname)
       def nullIfEmpty(s: String): String = if (s == "") null else s
 
@@ -316,9 +316,9 @@ abstract class FactoryAdapter extends DefaultHandler2 with factory.XMLLoader[Nod
       while (it.hasNext) {
         val c: Char = it.next()
         val isSpace: Boolean = c.isWhitespace
-        buffer append (if (isSpace) ' ' else c)
+        buffer.append(if (isSpace) ' ' else c)
         if (isSpace)
-          it = it dropWhile (_.isWhitespace)
+          it = it.dropWhile(_.isWhitespace)
       }
     }
   }

--- a/shared/src/main/scala/scala/xml/parsing/MarkupHandler.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupHandler.scala
@@ -40,9 +40,9 @@ abstract class MarkupHandler {
   def replacementText(entityName: String): Source =
     Source.fromString(ent.get(entityName) match {
       case Some(ParsedEntityDecl(_, IntDef(value)))    => value
-      case Some(ParameterEntityDecl(_, IntDef(value))) => " %s " format value
-      case Some(_)                                     => "<!-- %s; -->" format entityName
-      case None                                        => "<!-- unknown entity %s; -->" format entityName
+      case Some(ParameterEntityDecl(_, IntDef(value))) => " %s ".format(value)
+      case Some(_)                                     => "<!-- %s; -->".format(entityName)
+      case None                                        => "<!-- unknown entity %s; -->".format(entityName)
     })
 
   def endDTD(n: String): Unit = ()

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParser.scala
@@ -202,7 +202,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
 
     if (m.length - n != 0) {
       val s: String = if (isProlog) "SDDecl? " else ""
-      reportSyntaxError("VersionInfo EncodingDecl? %sor '?>' expected!" format s)
+      reportSyntaxError("VersionInfo EncodingDecl? %sor '?>' expected!".format(s))
     }
 
     (info_ver, info_enc, info_stdl)
@@ -283,7 +283,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
   }
 
   /** append Unicode character to name buffer*/
-  protected def putChar(c: Char): StringBuilder = cbuf append c
+  protected def putChar(c: Char): StringBuilder = cbuf.append(c)
 
   /**
    * As the current code requires you to call nextch once manually
@@ -480,7 +480,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
               val n: String = xName
               xToken(';')
 
-              if (unescape contains n) {
+              if (unescape.contains(n)) {
                 handle.entityRef(tmppos, n)
                 ts &+ unescape(n)
               } else push(n)
@@ -523,7 +523,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
    */
   def parseDTD(): Unit = { // dirty but fast
     var extID: ExternalID = null
-    if (this.dtd ne null)
+    if (this.dtd.ne(null))
       reportSyntaxError("unexpected character (DOCTYPE already defined")
     xToken("DOCTYPE")
     xSpace()
@@ -562,7 +562,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests {
       /*override val */ decls = handle.decls.reverse
     }
     //this.dtd.initializeEntities();
-    if (doc ne null)
+    if (doc.ne(null))
       doc.dtd = this.dtd
 
     handle.endDTD(n)

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
@@ -68,7 +68,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
       // well-formedness constraint
       if (ch == '<') reportSyntaxError("'<' not allowed in attrib value")
       else if (ch == SU) truncatedError("")
-      else buf append ch_returning_nextch
+      else buf.append(ch_returning_nextch)
     }
     ch_returning_nextch
     // @todo: normalize attribute value
@@ -85,7 +85,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
     val buf: StringBuilder = new StringBuilder
     while (it.hasNext) it.next() match {
       case `end` => return buf.toString
-      case ch    => buf append ch
+      case ch    => buf.append(ch)
     }
     scala.sys.error("Expected '%s'".format(end))
   }
@@ -115,16 +115,16 @@ private[scala] trait MarkupParserCommon extends TokenTests {
     if (ch == SU)
       truncatedError("")
     else if (!isNameStart(ch))
-      return errorAndResult("name expected, but char '%s' cannot start a name" format ch, "")
+      return errorAndResult("name expected, but char '%s' cannot start a name".format(ch), "")
 
     val buf: StringBuilder = new StringBuilder
 
-    while ({ buf append ch_returning_nextch
+    while ({ buf.append(ch_returning_nextch)
     ; isNameChar(ch)}) ()
 
     if (buf.last == ':') {
       reportSyntaxError("name cannot end in ':'")
-      buf.toString dropRight 1
+      buf.toString.dropRight(1)
     } else buf.toString
   }
 
@@ -146,10 +146,9 @@ private[scala] trait MarkupParserCommon extends TokenTests {
     val buf: StringBuilder = new StringBuilder
     val it: BufferedIterator[Char] = attval.iterator.buffered
 
-    while (it.hasNext) buf append (it.next() match {
+    while (it.hasNext) buf.append(it.next() match {
       case ' ' | '\t' | '\n' | '\r' => " "
-      case '&' if it.head == '#'    =>
-        it.next(); xCharRef(it)
+      case '&' if it.head == '#'    => it.next(); xCharRef(it)
       case '&'                      => attr_unescape(takeUntilChar(it, ';'))
       case c                        => c
     })
@@ -208,7 +207,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
     if (ch == that) nextch()
     else xHandleError(that, "'%s' expected instead of '%s'".format(that, ch))
   }
-  def xToken(that: Seq[Char]): Unit = { that foreach xToken }
+  def xToken(that: Seq[Char]): Unit = that.foreach(xToken)
 
   /** scan [S] '=' [S]*/
   def xEQ(): Unit = { xSpaceOpt(); xToken('='); xSpaceOpt() }
@@ -251,7 +250,7 @@ private[scala] trait MarkupParserCommon extends TokenTests {
         else if (ch == SU || eof)
           truncatedError(s"died parsing until $until") // throws TruncatedXMLControl in compiler
 
-        sb append ch
+        sb.append(ch)
         nextch()
       }
       unreachable
@@ -264,9 +263,9 @@ private[scala] trait MarkupParserCommon extends TokenTests {
    *  and leave input unchanged.
    */
   private def peek(lookingFor: String): Boolean =
-    (lookahead() take lookingFor.length sameElements lookingFor.iterator) && {
+    lookahead().take(lookingFor.length).sameElements(lookingFor.iterator) && {
       // drop the chars from the real reader (all lookahead + orig)
-      (0 to lookingFor.length) foreach (_ => nextch())
+      0.to(lookingFor.length).foreach(_ => nextch())
       true
     }
 }

--- a/shared/src/main/scala/scala/xml/parsing/TokenTests.scala
+++ b/shared/src/main/scala/scala/xml/parsing/TokenTests.scala
@@ -35,7 +35,7 @@ trait TokenTests {
    *  (#x20 | #x9 | #xD | #xA)+
    *  }}}
    */
-  final def isSpace(cs: Seq[Char]): Boolean = cs.nonEmpty && (cs forall isSpace)
+  final def isSpace(cs: Seq[Char]): Boolean = cs.nonEmpty && cs.forall(isSpace)
 
   /** These are 99% sure to be redundant but refactoring on the safe side. */
   def isAlpha(c: Char): Boolean = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
@@ -56,7 +56,7 @@ trait TokenTests {
       case COMBINING_SPACING_MARK |
         ENCLOSING_MARK | NON_SPACING_MARK |
         MODIFIER_LETTER | DECIMAL_DIGIT_NUMBER => true
-      case _ => ".-:·" contains ch
+      case _ => ".-:·".contains(ch)
     })
   }
 
@@ -88,11 +88,11 @@ trait TokenTests {
    *  See [5] of XML 1.0 specification.
    */
   def isName(s: String): Boolean =
-    s.nonEmpty && isNameStart(s.head) && (s.tail forall isNameChar)
+    s.nonEmpty && isNameStart(s.head) && s.tail.forall(isNameChar)
 
   def isPubIDChar(ch: Char): Boolean =
     isAlphaDigit(ch) || (isSpace(ch) && ch != '\u0009') ||
-      ("""-\()+,./:=?;!*#@$_%""" contains ch)
+      """-\()+,./:=?;!*#@$_%""".contains(ch)
 
   /**
    * Returns `true` if the encoding name is a valid IANA encoding.
@@ -103,12 +103,12 @@ trait TokenTests {
    * @param ianaEncoding The IANA encoding name.
    */
   def isValidIANAEncoding(ianaEncoding: Seq[Char]): Boolean = {
-    def charOK(c: Char): Boolean = isAlphaDigit(c) || ("._-" contains c)
+    def charOK(c: Char): Boolean = isAlphaDigit(c) || "._-".contains(c)
 
     ianaEncoding.nonEmpty && isAlpha(ianaEncoding.head) &&
-      (ianaEncoding.tail forall charOK)
+      ianaEncoding.tail.forall(charOK)
   }
 
-  def checkSysID(s: String): Boolean = List('"', '\'') exists (c => !(s contains c))
-  def checkPubID(s: String): Boolean = s forall isPubIDChar
+  def checkSysID(s: String): Boolean = List('"', '\'').exists(c => !s.contains(c))
+  def checkPubID(s: String): Boolean = s.forall(isPubIDChar)
 }

--- a/shared/src/main/scala/scala/xml/transform/BasicTransformer.scala
+++ b/shared/src/main/scala/scala/xml/transform/BasicTransformer.scala
@@ -37,7 +37,7 @@ abstract class BasicTransformer extends (Node => Node) {
    *  otherwise a new sequence of concatenated results.
    */
   def transform(ns: Seq[Node]): Seq[Node] = {
-    val changed: Seq[Node] = ns flatMap transform
+    val changed: Seq[Node] = ns.flatMap(transform)
     if (changed.length != ns.length || changed.zip(ns).exists(p => p._1 != p._2)) changed
     else ns
 }
@@ -49,7 +49,7 @@ abstract class BasicTransformer extends (Node => Node) {
         val ch: Seq[Node] = n.child
         val nch: Seq[Node] = transform(ch)
 
-        if (ch eq nch) n
+        if (ch.eq(nch)) n
         else Elem(n.prefix, n.label, n.attributes, n.scope, nch.isEmpty, nch: _*)
     }
     else n

--- a/shared/src/test/scala-2.x/scala/xml/XMLTest2x.scala
+++ b/shared/src/test/scala-2.x/scala/xml/XMLTest2x.scala
@@ -1,7 +1,5 @@
 package scala.xml
 
-import language.postfixOps
-
 import org.junit.{Test => UnitTest}
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
@@ -30,5 +28,4 @@ class XMLTest2x {
     assertTrue(f)
     assertTrue(g)
   }
-
 }

--- a/shared/src/test/scala/scala/xml/AttributeTest.scala
+++ b/shared/src/test/scala/scala/xml/AttributeTest.scala
@@ -19,9 +19,9 @@ class AttributeTest {
     val z: UnprefixedAttribute = new UnprefixedAttribute("foo", null:NodeSeq, x)
     assertEquals(None, z.get("foo"))
 
-    var appended: MetaData = x append x append x append x
+    var appended: MetaData = x.append(x).append(x).append(x)
     var len: Int = 0
-    while (appended ne Null) {
+    while (appended.ne(Null)) {
       appended = appended.next
       len = len + 1
     }

--- a/shared/src/test/scala/scala/xml/PatternMatchingTest.scala
+++ b/shared/src/test/scala/scala/xml/PatternMatchingTest.scala
@@ -57,7 +57,7 @@ class PatternMatchingTest {
 
   object SafeNodeSeq {
     def unapplySeq(any: Any): Option[Seq[Node]] = any match {
-      case s: Seq[_] => Some(s flatMap {
+      case s: Seq[_] => Some(s.flatMap {
         case n: Node => n
         case _ => NodeSeq.Empty
       })

--- a/shared/src/test/scala/scala/xml/ShouldCompile.scala
+++ b/shared/src/test/scala/scala/xml/ShouldCompile.scala
@@ -26,8 +26,8 @@ class t2281B {
     var outstr: StringBuffer = new StringBuffer
     var prevspace: Boolean = false
     val ctext: String = text.replaceAll("\n+", "\n")
-    ctext foreach { c =>
-      outstr append c
+    ctext.foreach { c =>
+      outstr.append(c)
       if (c == '.' || c == '!' || c == '?' || c == '\n' || c == ':' || c == ';' || (prevspace && c == '-')) {
         outarr += outstr.toString
         outstr = new StringBuffer

--- a/shared/src/test/scala/scala/xml/XMLSyntaxTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLSyntaxTest.scala
@@ -15,14 +15,14 @@ class XMLSyntaxTest {
   @Test
   def test1(): Unit = {
     val xNull: Elem = <hello>{null}</hello> // these used to be Atom(unit), changed to empty children
-    assertTrue(xNull.child sameElements Nil)
+    assertTrue(xNull.child.sameElements(Nil))
 
     val x0: Elem = <hello>{}</hello> // these used to be Atom(unit), changed to empty children
     val x00: Elem = <hello>{ }</hello> //  dto.
     val xa: Elem = <hello>{ "world" }</hello>
 
-    assertTrue(x0.child sameElements Nil)
-    assertTrue(x00.child sameElements Nil)
+    assertTrue(x0.child.sameElements(Nil))
+    assertTrue(x00.child.sameElements(Nil))
     assertEquals("world", handle[String](xa))
 
     val xb: Elem = <hello>{ 1.5 }</hello>

--- a/shared/src/test/scala/scala/xml/XMLTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLTest.scala
@@ -1,7 +1,5 @@
 package scala.xml
 
-import language.postfixOps
-
 import org.junit.{Test => UnitTest}
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
@@ -31,8 +29,8 @@ class XMLTest {
     }
 
     val pelems_2: NodeSeq = NodeSeq.fromSeq(List(Text("38!"), Text("58!")))
-    assertTrue(pelems_1 sameElements pelems_2)
-    assertTrue(Text("8") sameElements (p \\ "@bazValue"))
+    assertTrue(pelems_1.sameElements(pelems_2))
+    assertTrue(Text("8").sameElements(p \\ "@bazValue"))
   }
 
   @UnitTest


### PR DESCRIPTION
With infix method invocations falling out of fashion - and eventually, out of validity - maybe it is time to move away from them?