### PR TITLE
Added all missing type annotations.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,56 +92,56 @@ workflows:
   build:
     jobs:
       - scala_job:
-          name: 2.12.18
+          name: 2.12.x
           java_version: jdk8
           scala_version: 2.12.18
       - scala_job:
-          name: 2.13.11
+          name: 2.13.x
           java_version: jdk8
           scala_version: 2.13.11
       - scala_job:
-          name: 3.3.0
+          name: 3.x
           java_version: jdk8
           scala_version: 3.3.0
       - scala_job:
-          name: jdk11_2.12
+          name: jdk11_2.12.x
           java_version: jdk11
           scala_version: 2.12.18
       - scala_job:
-          name: jdk11_2.13
+          name: jdk11_2.13.x
           java_version: jdk11
           scala_version: 2.13.11
       - scala_job:
-          name: jdk11_3.1
+          name: jdk11_3.x
           java_version: jdk11
           scala_version: 3.3.0
       - scala_job:
-          name: jdk17_2.12
+          name: jdk17_2.12.x
           java_version: jdk17
           scala_version: 2.12.18
       - scala_job:
-          name: jdk17_2.13
+          name: jdk17_2.13.x
           java_version: jdk17
           scala_version: 2.13.11
       - scala_job:
-          name: jdk17_3.3
+          name: jdk17_3.x
           java_version: jdk17
           scala_version: 3.3.0
       - scalajs_job:
-          name: sjs1.0_2.12
+          name: sjs1.0_2.12.x
           scala_version: 2.12.18
       - scalajs_job:
-          name: sjs1.0_2.13
+          name: sjs1.0_2.13.x
           scala_version: 2.13.11
       - scalajs_job:
-          name: sjs1.0_3.3
+          name: sjs1.0_3.x
           scala_version: 3.3.0
       - scalanative_job:
-          name: native0.4_2.12
+          name: native0.4_2.12.x
           scala_version: 2.12.18
       - scalanative_job:
-          name: native0.4_2.13
+          name: native0.4_2.13.x
           scala_version: 2.13.11
       - scalanative_job:
-          name: native0.4_3
+          name: native0.4_3.x
           scala_version: 3.3.0

--- a/shared/src/main/scala-2.12/scala/xml/ScalaVersionSpecific.scala
+++ b/shared/src/main/scala-2.12/scala/xml/ScalaVersionSpecific.scala
@@ -22,6 +22,7 @@ private[xml] object ScalaVersionSpecific {
     override def apply(from: Coll): mutable.Builder[Node, NodeSeq] = NodeSeq.newBuilder
     override def apply(): mutable.Builder[Node, NodeSeq] = NodeSeq.newBuilder
   }
+  type SeqNodeUnapplySeq = scala.collection.Seq[Node]
 }
 
 private[xml] trait ScalaVersionSpecificNodeSeq extends SeqLike[Node, NodeSeq] { self: NodeSeq =>

--- a/shared/src/main/scala-2.13+/scala/xml/ScalaVersionSpecific.scala
+++ b/shared/src/main/scala-2.13+/scala/xml/ScalaVersionSpecific.scala
@@ -24,6 +24,7 @@ private[xml] object ScalaVersionSpecific {
     def newBuilder(from: Coll): Builder[Node, NodeSeq] = NodeSeq.newBuilder
     def fromSpecific(from: Coll)(it: IterableOnce[Node]): NodeSeq = (NodeSeq.newBuilder ++= from).result()
   }
+  type SeqNodeUnapplySeq = scala.collection.immutable.Seq[Node]
 }
 
 private[xml] trait ScalaVersionSpecificNodeSeq

--- a/shared/src/main/scala-2/scala/xml/ScalaVersionSpecificReturnTypes.scala
+++ b/shared/src/main/scala-2/scala/xml/ScalaVersionSpecificReturnTypes.scala
@@ -1,0 +1,36 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.xml
+
+/*
+ Unlike other Scala-version-specific things, this class is not filling any gaps in capabilities
+ between different versions of Scala; instead, it mostly documents the types that different versions of the
+ Scala compiler inferred in the unfortunate absence of the explicit type annotations.
+ What should have been specified explicitly is given in the comments;
+ next time we break binary compatibility the types should be changed in the code and this class removed.
+ */
+private[xml] object ScalaVersionSpecificReturnTypes { // should be
+  type ExternalIDAttribute = MetaData                 // Null.type
+  type NoExternalIDId = scala.Null
+  type NodeNoAttributes = MetaData                    // Null.type
+  type NullFilter = MetaData                          // Null.type
+  type NullGetNamespace = scala.Null
+  type NullNext = scala.Null
+  type NullKey = scala.Null
+  type NullValue = scala.Null
+  type NullApply1 = scala.collection.Seq[Node]        // scala.Null
+  type NullApply3 = scala.Null
+  type NullRemove = Null.type
+  type SpecialNodeChild = Nil.type
+  type GroupChild = Nothing
+}

--- a/shared/src/main/scala-3/scala/xml/ScalaVersionSpecificReturnTypes.scala
+++ b/shared/src/main/scala-3/scala/xml/ScalaVersionSpecificReturnTypes.scala
@@ -1,0 +1,36 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.xml
+
+/*
+ Unlike other Scala-version-specific things, this class is not filling any gaps in capabilities
+ between different versions of Scala; instead, it mostly documents the types that different versions of the
+ Scala compiler inferred in the unfortunate absence of the explicit type annotations.
+ What should have been specified explicitly is given in the comments;
+ next time we break binary compatibility the types should be changed in the code and this class removed.
+ */
+private[xml] object ScalaVersionSpecificReturnTypes { // should be
+  type ExternalIDAttribute = MetaData                 // Null.type
+  type NoExternalIDId = String                        // scala.Null
+  type NodeNoAttributes = MetaData                    // Null.type
+  type NullFilter = MetaData                          // Null.type
+  type NullGetNamespace = String                      // scala.Null
+  type NullNext = MetaData                            // scala.Null
+  type NullKey = String                               // scala.Null
+  type NullValue = scala.collection.Seq[Node]         // scala.Null
+  type NullApply1 = scala.collection.Seq[Node]        // scala.Null
+  type NullApply3 = scala.collection.Seq[Node]        // scala.Null
+  type NullRemove = MetaData                          // Null.type
+  type SpecialNodeChild = scala.collection.Seq[Node]  // Nil.type
+  type GroupChild = scala.collection.Seq[Node]        // Nothing
+}

--- a/shared/src/main/scala/scala/xml/Attribute.scala
+++ b/shared/src/main/scala/scala/xml/Attribute.scala
@@ -22,7 +22,7 @@ import scala.collection.Seq
  *  @author  Burak Emir
  */
 object Attribute {
-  def unapply(x: Attribute) /* TODO type annotation */ = x match {
+  def unapply(x: Attribute): Option[(String, Seq[Node], MetaData)] = x match {
     case PrefixedAttribute(_, key, value, next) => Some((key, value, next))
     case UnprefixedAttribute(key, value, next)  => Some((key, value, next))
     case _                                      => None

--- a/shared/src/main/scala/scala/xml/Comment.scala
+++ b/shared/src/main/scala/scala/xml/Comment.scala
@@ -21,6 +21,7 @@ package xml
  *        and the final character may not be `-` to prevent a closing span of `-->`
  *        which is invalid. [[https://www.w3.org/TR/xml11//#IDA5CES]]
  */
+// Note: used by the Scala compiler.
 case class Comment(commentText: String) extends SpecialNode {
 
   override def label: String = "#REM"

--- a/shared/src/main/scala/scala/xml/Elem.scala
+++ b/shared/src/main/scala/scala/xml/Elem.scala
@@ -21,15 +21,17 @@ import scala.collection.Seq
  *  any `Node` instance (that is not a `SpecialNode` or a `Group`) using the
  *  syntax `case Elem(prefix, label, attribs, scope, child @ _*) => ...`
  */
+// Note: used by the Scala compiler.
 object Elem {
 
   def apply(prefix: String, label: String, attributes: MetaData, scope: NamespaceBinding, minimizeEmpty: Boolean, child: Node*): Elem =
     new Elem(prefix, label, attributes, scope, minimizeEmpty, child: _*)
 
-  def unapplySeq(n: Node) /* TODO type annotation */ = n match {
-    case _: SpecialNode | _: Group => None
-    case _                         => Some((n.prefix, n.label, n.attributes, n.scope, n.child.toSeq))
-  }
+  def unapplySeq(n: Node): Option[(String, String, MetaData, NamespaceBinding, ScalaVersionSpecific.SeqNodeUnapplySeq)] =
+    n match {
+      case _: SpecialNode | _: Group => None
+      case _                         => Some((n.prefix, n.label, n.attributes, n.scope, n.child.toSeq))
+    }
 }
 
 /**
@@ -51,6 +53,7 @@ object Elem {
  *                       empty; `false` if it should be written out in long form.
  *  @param child         the children of this node
  */
+// Note: used by the Scala compiler.
 class Elem(
   override val prefix: String,
   override val label: String,

--- a/shared/src/main/scala/scala/xml/EntityRef.scala
+++ b/shared/src/main/scala/scala/xml/EntityRef.scala
@@ -19,6 +19,7 @@ package xml
  * @author  Burak Emir
  * @param   entityName the name of the entity reference, for example `amp`.
  */
+// Note: used by the Scala compiler.
 case class EntityRef(entityName: String) extends SpecialNode {
   final override def doCollectNamespaces: Boolean = false
   final override def doTransform: Boolean = false

--- a/shared/src/main/scala/scala/xml/Group.scala
+++ b/shared/src/main/scala/scala/xml/Group.scala
@@ -20,6 +20,7 @@ import scala.collection.Seq
  *
  *  @author  Burak Emir
  */
+// Note: used by the Scala compiler.
 final case class Group(nodes: Seq[Node]) extends Node {
   override def theSeq: Seq[Node] = nodes
 
@@ -44,6 +45,6 @@ final case class Group(nodes: Seq[Node]) extends Node {
   override def label: Nothing = fail("label")
   override def attributes: Nothing = fail("attributes")
   override def namespace: Nothing = fail("namespace")
-  override def child /* TODO type annotation */ = fail("child")
+  override def child: ScalaVersionSpecificReturnTypes.GroupChild = fail("child")
   def buildString(sb: StringBuilder): Nothing = fail("toString(StringBuilder)")
 }

--- a/shared/src/main/scala/scala/xml/MetaData.scala
+++ b/shared/src/main/scala/scala/xml/MetaData.scala
@@ -80,6 +80,7 @@ object MetaData {
  *  Namespace URIs are obtained by using the namespace scope of the element
  *  owning this attribute (see `getNamespace`).
  */
+// Note: used by the Scala compiler.
 abstract class MetaData
   extends AbstractIterable[MetaData]
   with Iterable[MetaData]

--- a/shared/src/main/scala/scala/xml/NamespaceBinding.scala
+++ b/shared/src/main/scala/scala/xml/NamespaceBinding.scala
@@ -23,6 +23,7 @@ import scala.collection.Seq
  *
  *  @author  Burak Emir
  */
+// Note: used by the Scala compiler.
 @SerialVersionUID(0 - 2518644165573446725L)
 case class NamespaceBinding(prefix: String, uri: String, parent: NamespaceBinding) extends AnyRef with Equality {
   if (prefix == "")

--- a/shared/src/main/scala/scala/xml/Node.scala
+++ b/shared/src/main/scala/scala/xml/Node.scala
@@ -23,12 +23,13 @@ import scala.collection.Seq
  */
 object Node {
   /** the constant empty attribute sequence */
-  final def NoAttributes: MetaData = Null
+  final def NoAttributes: ScalaVersionSpecificReturnTypes.NodeNoAttributes = Null
 
   /** the empty namespace */
   val EmptyNamespace: String = ""
 
-  def unapplySeq(n: Node) /* TODO type annotation */ = Some((n.label, n.attributes, n.child.toSeq))
+  def unapplySeq(n: Node): Some[(String, MetaData, ScalaVersionSpecific.SeqNodeUnapplySeq)] =
+    Some((n.label, n.attributes, n.child.toSeq))
 }
 
 /**

--- a/shared/src/main/scala/scala/xml/NodeBuffer.scala
+++ b/shared/src/main/scala/scala/xml/NodeBuffer.scala
@@ -23,6 +23,7 @@ package xml
  *
  * @author  Burak Emir
  */
+// Note: used by the Scala compiler.
 class NodeBuffer extends scala.collection.mutable.ArrayBuffer[Node] with ScalaVersionSpecificNodeBuffer {
   /**
    * Append given object to this buffer, returns reference on this

--- a/shared/src/main/scala/scala/xml/Null.scala
+++ b/shared/src/main/scala/scala/xml/Null.scala
@@ -23,19 +23,20 @@ import scala.collection.Seq
  *
  *  @author  Burak Emir
  */
+// Note: used by the Scala compiler.
 case object Null extends MetaData {
   override def iterator: Iterator[Nothing] = Iterator.empty
   override def size: Int = 0
   override def append(m: MetaData, scope: NamespaceBinding = TopScope): MetaData = m
-  override def filter(f: MetaData => Boolean): MetaData = this
+  override def filter(f: MetaData => Boolean): ScalaVersionSpecificReturnTypes.NullFilter = this
 
   override def copy(next: MetaData): MetaData = next
-  override def getNamespace(owner: Node) /* TODO type annotation */ = null
+  override def getNamespace(owner: Node): ScalaVersionSpecificReturnTypes.NullGetNamespace = null
 
   override def hasNext: Boolean = false
-  override def next /* TODO type annotation */ = null
-  override def key /* TODO type annotation */ = null
-  override def value /* TODO type annotation */ = null
+  override def next: ScalaVersionSpecificReturnTypes.NullNext = null
+  override def key: ScalaVersionSpecificReturnTypes.NullKey = null
+  override def value: ScalaVersionSpecificReturnTypes.NullValue = null
   override def isPrefixed: Boolean = false
 
   override def length: Int = 0
@@ -47,8 +48,8 @@ case object Null extends MetaData {
   }
   override protected def basisForHashCode: Seq[Any] = Nil
 
-  override def apply(namespace: String, scope: NamespaceBinding, key: String) /* TODO type annotation */ = null
-  override def apply(key: String) /* TODO type annotation */ =
+  override def apply(namespace: String, scope: NamespaceBinding, key: String): ScalaVersionSpecificReturnTypes.NullApply3 = null
+  override def apply(key: String): ScalaVersionSpecificReturnTypes.NullApply1 =
     if (Utility.isNameStart(key.head)) null
     else throw new IllegalArgumentException("not a valid attribute name '" + key + "', so can never match !")
 
@@ -61,6 +62,6 @@ case object Null extends MetaData {
 
   override def wellformed(scope: NamespaceBinding): Boolean = true
 
-  override def remove(key: String) /* TODO type annotation */ = this
-  override def remove(namespace: String, scope: NamespaceBinding, key: String) /* TODO type annotation */ = this
+  override def remove(key: String): ScalaVersionSpecificReturnTypes.NullRemove = this
+  override def remove(namespace: String, scope: NamespaceBinding, key: String): ScalaVersionSpecificReturnTypes.NullRemove = this
 }

--- a/shared/src/main/scala/scala/xml/PCData.scala
+++ b/shared/src/main/scala/scala/xml/PCData.scala
@@ -20,6 +20,7 @@ package xml
  *
  *  @author  Burak Emir
  */
+// Note: used by the Scala compiler (before Scala 3).
 class PCData(data: String) extends Atom[String](data) {
 
   /**
@@ -39,6 +40,7 @@ class PCData(data: String) extends Atom[String](data) {
  *
  *  @author  Burak Emir
  */
+// Note: used by the Scala compiler (before Scala 3).
 object PCData {
   def apply(data: String): PCData = new PCData(data)
   def unapply(other: Any): Option[String] = other match {

--- a/shared/src/main/scala/scala/xml/PrefixedAttribute.scala
+++ b/shared/src/main/scala/scala/xml/PrefixedAttribute.scala
@@ -23,6 +23,7 @@ import scala.collection.Seq
  *  @param value the attribute value
  *  @param next1
  */
+// Note: used by the Scala compiler.
 class PrefixedAttribute(
   override val pre: String,
   override val key: String,
@@ -64,5 +65,5 @@ class PrefixedAttribute(
 }
 
 object PrefixedAttribute {
-  def unapply(x: PrefixedAttribute) /* TODO type annotation */ = Some((x.pre, x.key, x.value, x.next))
+  def unapply(x: PrefixedAttribute): Some[(String, String, Seq[Node], MetaData)] = Some((x.pre, x.key, x.value, x.next))
 }

--- a/shared/src/main/scala/scala/xml/ProcInstr.scala
+++ b/shared/src/main/scala/scala/xml/ProcInstr.scala
@@ -20,6 +20,7 @@ package xml
  * @param  target     target name of this PI
  * @param  proctext   text contained in this node, may not contain "?>"
  */
+// Note: used by the Scala compiler.
 case class ProcInstr(target: String, proctext: String) extends SpecialNode {
   if (!Utility.isName(target))
     throw new IllegalArgumentException(target + " must be an XML Name")

--- a/shared/src/main/scala/scala/xml/QNode.scala
+++ b/shared/src/main/scala/scala/xml/QNode.scala
@@ -20,5 +20,6 @@ package xml
  *  @author  Burak Emir
  */
 object QNode {
-  def unapplySeq(n: Node) /* TODO type annotation */ = Some((n.scope.getURI(n.prefix), n.label, n.attributes, n.child.toSeq))
+  def unapplySeq(n: Node): Some[(String, String, MetaData, ScalaVersionSpecific.SeqNodeUnapplySeq)] =
+    Some((n.scope.getURI(n.prefix), n.label, n.attributes, n.child.toSeq))
 }

--- a/shared/src/main/scala/scala/xml/SpecialNode.scala
+++ b/shared/src/main/scala/scala/xml/SpecialNode.scala
@@ -28,7 +28,7 @@ abstract class SpecialNode extends Node {
   final override def namespace: scala.Null = null
 
   /** always empty */
-  final override def child /* TODO type annotation */ = Nil
+  final override def child: ScalaVersionSpecificReturnTypes.SpecialNodeChild = Nil
 
   /** Append string representation to the given string buffer argument. */
   def buildString(sb: StringBuilder): StringBuilder

--- a/shared/src/main/scala/scala/xml/Text.scala
+++ b/shared/src/main/scala/scala/xml/Text.scala
@@ -20,6 +20,7 @@ package xml
  *  @author Burak Emir
  *  @param data the text contained in this node, may not be null.
  */
+// Note: used by the Scala compiler.
 class Text(data: String) extends Atom[String](data) {
 
   /**
@@ -36,6 +37,7 @@ class Text(data: String) extends Atom[String](data) {
  *
  *  @author  Burak Emir
  */
+// Note: used by the Scala compiler.
 object Text {
   def apply(data: String): Text = new Text(data)
   def unapply(other: Any): Option[String] = other match {

--- a/shared/src/main/scala/scala/xml/Unparsed.scala
+++ b/shared/src/main/scala/scala/xml/Unparsed.scala
@@ -20,6 +20,7 @@ package xml
  *  @author Burak Emir
  *  @param data content in this node, may not be null.
  */
+// Note: used by the Scala compiler.
 class Unparsed(data: String) extends Atom[String](data) {
 
   /**

--- a/shared/src/main/scala/scala/xml/UnprefixedAttribute.scala
+++ b/shared/src/main/scala/scala/xml/UnprefixedAttribute.scala
@@ -20,6 +20,7 @@ import scala.collection.Seq
  *
  *  @author Burak Emir
  */
+// Note: used by the Scala compiler.
 class UnprefixedAttribute(
   override val key: String,
   override val value: Seq[Node],
@@ -62,5 +63,5 @@ class UnprefixedAttribute(
     next(namespace, scope, key)
 }
 object UnprefixedAttribute {
-  def unapply(x: UnprefixedAttribute) /* TODO type annotation */ = Some((x.key, x.value, x.next))
+  def unapply(x: UnprefixedAttribute): Some[(String, Seq[Node], MetaData)] = Some((x.key, x.value, x.next))
 }

--- a/shared/src/main/scala/scala/xml/dtd/ExternalID.scala
+++ b/shared/src/main/scala/scala/xml/dtd/ExternalID.scala
@@ -73,7 +73,7 @@ case class PublicID(override val publicId: String, override val systemId: String
   def label: String = "#PI"
 
   /** always empty */
-  def attribute: MetaData = Node.NoAttributes
+  def attribute: ScalaVersionSpecificReturnTypes.ExternalIDAttribute = Node.NoAttributes
 
   /** always empty */
   def child: Nil.type = Nil
@@ -85,8 +85,8 @@ case class PublicID(override val publicId: String, override val systemId: String
  *  @author Michael Bayne
  */
 object NoExternalID extends ExternalID {
-  override val publicId /* TODO type annotation */ = null
-  override val systemId /* TODO type annotation */ = null
+  override val publicId: ScalaVersionSpecificReturnTypes.NoExternalIDId = null
+  override val systemId: ScalaVersionSpecificReturnTypes.NoExternalIDId = null
 
   override def toString: String = ""
 }

--- a/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
+++ b/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala
@@ -22,6 +22,7 @@ import Utility.SU
  *  between the library level XML parser and the compiler's.
  *  All members should be accessed through those.
  */
+// Note: this is no longer true; Scala compiler uses its own copy since at least 2013.
 private[scala] trait MarkupParserCommon extends TokenTests {
   protected def unreachable: Nothing = truncatedError("Cannot be reached.")
 


### PR DESCRIPTION
- introduced `ScalaVersionSpecificReturnTypes`;
- split MIMA exclusions by Scala version;
- removed exclusions that are no longer needed;
- made Circle CI task names not mention the exact Scala version;
- provisioned for Scala 2.13-specific code;
- Scala 2.13- is only Scala 2.12 now that Scala 11 is no longer supported :)
- marked classes used by the compiler.