### PR TITLE
use new wildcard syntax

### DIFF
--- a/jvm/src/test/scala/scala/xml/XMLTest.scala
+++ b/jvm/src/test/scala/scala/xml/XMLTest.scala
@@ -393,7 +393,7 @@ class XMLTestJVM {
 
   @UnitTest
   def t5115(): Unit = {
-    def assertHonorsIterableContract(i: Iterable[_]): Unit = assertEquals(i.size.toLong, i.iterator.size.toLong)
+    def assertHonorsIterableContract(i: Iterable[?]): Unit = assertEquals(i.size.toLong, i.iterator.size.toLong)
 
     assertHonorsIterableContract(<a/>.attributes)
     assertHonorsIterableContract(<a x=""/>.attributes)

--- a/shared/src/main/scala/scala/xml/Atom.scala
+++ b/shared/src/main/scala/scala/xml/Atom.scala
@@ -29,12 +29,12 @@ class Atom[+A](val data: A) extends SpecialNode with Serializable {
   override protected def basisForHashCode: Seq[Any] = Seq(data)
 
   override def strict_==(other: Equality): Boolean = other match {
-    case x: Atom[_] => data == x.data
+    case x: Atom[?] => data == x.data
     case _          => false
   }
 
   override def canEqual(other: Any): Boolean = other match {
-    case _: Atom[_] => true
+    case _: Atom[?] => true
     case _          => false
   }
 

--- a/shared/src/main/scala/scala/xml/Equality.scala
+++ b/shared/src/main/scala/scala/xml/Equality.scala
@@ -53,7 +53,7 @@ object Equality {
    * Note - these functions assume strict equality has already failed.
    */
   def compareBlithely(x1: AnyRef, x2: String): Boolean = x1 match {
-    case x: Atom[_] => x.data == x2
+    case x: Atom[?] => x.data == x2
     case x: NodeSeq => x.text == x2
     case _          => false
   }

--- a/shared/src/main/scala/scala/xml/Node.scala
+++ b/shared/src/main/scala/scala/xml/Node.scala
@@ -56,7 +56,7 @@ abstract class Node extends NodeSeq {
   /**
    * used internally. Atom/Molecule = -1 PI = -2 Comment = -3 EntityRef = -5
    */
-  def isAtom: Boolean = this.isInstanceOf[Atom[_]]
+  def isAtom: Boolean = this.isInstanceOf[Atom[?]]
 
   /** The logic formerly found in typeTag$, as best I could infer it. */
   def doCollectNamespaces: Boolean = true // if (tag >= 0) DO collect namespaces

--- a/shared/src/main/scala/scala/xml/NodeBuffer.scala
+++ b/shared/src/main/scala/scala/xml/NodeBuffer.scala
@@ -39,10 +39,10 @@ class NodeBuffer extends scala.collection.mutable.ArrayBuffer[Node] with ScalaVe
   def &+(o: Any): NodeBuffer = {
     o match {
       case null | _: Unit | Text("") => // ignore
-      case it: Iterator[_]           => it.foreach(&+)
+      case it: Iterator[?]           => it.foreach(&+)
       case n: Node                   => super.+=(n)
-      case ns: Iterable[_]           => this &+ ns.iterator
-      case ns: Array[_]              => this &+ ns.iterator
+      case ns: Iterable[?]           => this &+ ns.iterator
+      case ns: Array[?]              => this &+ ns.iterator
       case d                         => super.+=(new Atom(d))
     }
     this

--- a/shared/src/main/scala/scala/xml/PrettyPrinter.scala
+++ b/shared/src/main/scala/scala/xml/PrettyPrinter.scala
@@ -136,7 +136,7 @@ class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean) {
 
   protected def childrenAreLeaves(n: Node): Boolean = {
     def isLeaf(l: Node): Boolean = l match {
-      case _: Atom[_] | _: Comment | _: EntityRef | _: ProcInstr => true
+      case _: Atom[?] | _: Comment | _: EntityRef | _: ProcInstr => true
       case _ => false
     }
     n.child.forall(isLeaf)
@@ -152,7 +152,7 @@ class PrettyPrinter(width: Int, step: Int, minimizeEmpty: Boolean) {
 
     case Text(s) if s.trim.isEmpty =>
 
-    case _: Atom[_] | _: Comment | _: EntityRef | _: ProcInstr =>
+    case _: Atom[?] | _: Comment | _: EntityRef | _: ProcInstr =>
       makeBox(ind, node.toString.trim)
     case Group(xs) =>
       traverse(xs.iterator, pscope, ind)

--- a/shared/src/test/scala/scala/xml/PatternMatchingTest.scala
+++ b/shared/src/test/scala/scala/xml/PatternMatchingTest.scala
@@ -57,7 +57,7 @@ class PatternMatchingTest {
 
   object SafeNodeSeq {
     def unapplySeq(any: Any): Option[Seq[Node]] = any match {
-      case s: Seq[_] => Some(s.flatMap {
+      case s: Seq[?] => Some(s.flatMap {
         case n: Node => n
         case _ => NodeSeq.Empty
       })

--- a/shared/src/test/scala/scala/xml/XMLTest.scala
+++ b/shared/src/test/scala/scala/xml/XMLTest.scala
@@ -408,7 +408,7 @@ Ours is the portal of hope, come as you are."
 
   @UnitTest
   def t5115(): Unit = {
-    def assertHonorsIterableContract(i: Iterable[_]): Unit = assertEquals(i.size.toLong, i.iterator.size.toLong)
+    def assertHonorsIterableContract(i: Iterable[?]): Unit = assertEquals(i.size.toLong, i.iterator.size.toLong)
 
     assertHonorsIterableContract(<a/>.attributes)
     assertHonorsIterableContract(<a x=""/>.attributes)


### PR DESCRIPTION
- Scala 3 report warnings since 3.4 https://github.com/lampepfl/dotty/pull/18813
- Scala 2.12 and 2.13 support new syntax without `-Xsource:3` option https://github.com/scala/scala/pull/10005