### PR TITLE
Switch to new CircleCI OpenJDK images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,15 @@ version: 2.1
 executors:
   scala_jdk8_executor:
     docker:
-      - image: circleci/openjdk:8-jdk-node
+      - image: cimg/openjdk:8.0-node
     resource_class: small
   scala_jdk11_executor:
     docker:
-      - image: circleci/openjdk:11-jdk
+      - image: cimg/openjdk:11.0-node
     resource_class: small
   scala_jdk17_executor:
     docker:
-      - image: circleci/openjdk:17-buster
+      - image: cimg/openjdk:17.0-node
     resource_class: small
 
 commands:


### PR DESCRIPTION
The `cimg/openjdk` images are designed to supercede the legacy `circleci/openjdk` images, see https://circleci.com/developer/images/image/cimg/openjdk.