### PR TITLE
NodeBuffer append is this.type

### DIFF
--- a/shared/src/main/scala/scala/xml/NodeBuffer.scala
+++ b/shared/src/main/scala/scala/xml/NodeBuffer.scala
@@ -36,7 +36,7 @@ class NodeBuffer extends scala.collection.mutable.ArrayBuffer[Node] with ScalaVe
    * @param o converts to an xml node and adds to this node buffer
    * @return  this nodebuffer
    */
-  def &+(o: Any): NodeBuffer = {
+  def &+(o: Any): this.type = {
     o match {
       case null | _: Unit | Text("") => // ignore
       case it: Iterator[?]           => it.foreach(&+)


### PR DESCRIPTION
Fixes https://github.com/scala/scala-xml/issues/650

The signature should be like https://github.com/scala/scala/blob/v2.13.15/src/library/scala/collection/mutable/StringBuilder.scala#L142 so that linting knows it does not return a new value.

The generated code has the form
```
    private[this] val xml: scala.xml.Elem = new scala.xml.Elem(null, "xml", scala.xml.Null, scala.xml.TopScope, false, ({
      val $buf: scala.xml.NodeBuffer = new scala.xml.NodeBuffer();
      $buf.&+(new scala.xml.Elem(null, "elem", scala.xml.Null, scala.xml.TopScope, false));
      $buf
    }: _*));
```